### PR TITLE
Added workaround for SRAM trim issue

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
@@ -91,7 +91,8 @@ __weak void SystemCoreClockUpdate(void)
  */
 __weak int PreInit(void)
 {
-    /* Do nothing */
+    /* Workaround: Write to SCON register on power up to fix trim issue for SRAM */
+    MXC_GCR->scon = (MXC_GCR->scon & ~(MXC_F_GCR_SCON_OVR)) | (MXC_S_GCR_SCON_OVR_1V1);
     return 0;
 }
 


### PR DESCRIPTION
ME10 has SRAM trim issue and requires setting gcr.scon[17:16]=2'b10 - for 1.1V +/- 10% on every power up which overwrites the wrong trims to the correct SRAM trims.

The ME14 also has the same issue and already has this implementation.
