### PR TITLE
Hotfix: Use header_MAX32572.c

### DIFF
--- a/Examples/MAX32572/ADC/Makefile
+++ b/Examples/MAX32572/ADC/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/AES/Makefile
+++ b/Examples/MAX32572/AES/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/Barcode_Decoder/Makefile
+++ b/Examples/MAX32572/Barcode_Decoder/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += src/ov2640.c
 SRCS += src/ov7670.c
 SRCS += src/camera.c

--- a/Examples/MAX32572/CRC/Makefile
+++ b/Examples/MAX32572/CRC/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/CameraIF/Makefile
+++ b/Examples/MAX32572/CameraIF/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += src/ov2640.c
 SRCS += src/ov7670.c
 SRCS += src/camera.c

--- a/Examples/MAX32572/DES/Makefile
+++ b/Examples/MAX32572/DES/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/DMA/Makefile
+++ b/Examples/MAX32572/DMA/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/Flash/Makefile
+++ b/Examples/MAX32572/Flash/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32572/FreeRTOSDemo/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += FreeRTOS_CLI.c
 SRCS += CLI-commands.c
 SRCS += freertos_tickless.c

--- a/Examples/MAX32572/GPIO/Makefile
+++ b/Examples/MAX32572/GPIO/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/HTMR/Makefile
+++ b/Examples/MAX32572/HTMR/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += resources/all_imgs.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/Hash/Makefile
+++ b/Examples/MAX32572/Hash/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/Hello_World/Makefile
+++ b/Examples/MAX32572/Hello_World/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += resources/all_imgs.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/I2C/Makefile
+++ b/Examples/MAX32572/I2C/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/ICC/Makefile
+++ b/Examples/MAX32572/ICC/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/LP/Makefile
+++ b/Examples/MAX32572/LP/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/MAX32572_Demo_BareMetal/Makefile
+++ b/Examples/MAX32572/MAX32572_Demo_BareMetal/Makefile
@@ -86,7 +86,7 @@ endif
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += src/keypad.c
 SRCS += src/utils.c
 SRCS += resources/all_imgs.c

--- a/Examples/MAX32572/MAX32572_Demo_FreeRTOS/Makefile
+++ b/Examples/MAX32572/MAX32572_Demo_FreeRTOS/Makefile
@@ -86,7 +86,7 @@ endif
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += resources/all_imgs.c
 SRCS += src/wrapper_tft.c
 SRCS += src/utils.c

--- a/Examples/MAX32572/MSR/Makefile
+++ b/Examples/MAX32572/MSR/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += msr_sdma.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/OTP_Dump/Makefile
+++ b/Examples/MAX32572/OTP_Dump/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/OWM/Makefile
+++ b/Examples/MAX32572/OWM/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/Pulse_Train/Makefile
+++ b/Examples/MAX32572/Pulse_Train/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/RTC/Makefile
+++ b/Examples/MAX32572/RTC/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/SDHC_FAT/Makefile
+++ b/Examples/MAX32572/SDHC_FAT/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/SDHC_Raw/Makefile
+++ b/Examples/MAX32572/SDHC_Raw/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/SKB/Makefile
+++ b/Examples/MAX32572/SKB/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/SMON/Makefile
+++ b/Examples/MAX32572/SMON/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/SPI/Makefile
+++ b/Examples/MAX32572/SPI/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/SPIXF/Makefile
+++ b/Examples/MAX32572/SPIXF/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += ramfunc.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/SPIXR/Makefile
+++ b/Examples/MAX32572/SPIXR/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/SPI_Usecase/Makefile
+++ b/Examples/MAX32572/SPI_Usecase/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += spi_master
 SRCS += spi_slave
 

--- a/Examples/MAX32572/SRCC/Makefile
+++ b/Examples/MAX32572/SRCC/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/Security_Monitor/Makefile
+++ b/Examples/MAX32572/Security_Monitor/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += keypad.c
 SRCS += security_monitor.c
 SRCS += utils.c

--- a/Examples/MAX32572/Semaphore/Makefile
+++ b/Examples/MAX32572/Semaphore/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += resources/all_imgs.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/TFT_Demo/Makefile
+++ b/Examples/MAX32572/TFT_Demo/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += src/state_keypad.c
 SRCS += src/state_home.c
 SRCS += src/state.c

--- a/Examples/MAX32572/TMR/Makefile
+++ b/Examples/MAX32572/TMR/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/TRNG/Makefile
+++ b/Examples/MAX32572/TRNG/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/UART/Makefile
+++ b/Examples/MAX32572/UART/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/USB_CDCACM/Makefile
+++ b/Examples/MAX32572/USB_CDCACM/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX32572/USB_CompositeDevice_MSC_CDC/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += mscmem.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX32572/USB_CompositeDevice_MSC_HID/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += mscmem.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX32572/USB_HIDKeyboard/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/USB_MassStorage/Makefile
+++ b/Examples/MAX32572/USB_MassStorage/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += mscmem.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/Watchdog/Makefile
+++ b/Examples/MAX32572/Watchdog/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/WearLeveling/Makefile
+++ b/Examples/MAX32572/WearLeveling/Makefile
@@ -79,7 +79,7 @@ export CMSIS_ROOT
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
 SRCS += flash.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 
 # Where to find source files for this test
 VPATH=.

--- a/Examples/MAX32572/lwIP_Ping/Makefile
+++ b/Examples/MAX32572/lwIP_Ping/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += ping.c
 
 # Where to find source files for this test

--- a/Examples/MAX32572/lwIP_TCP/Makefile
+++ b/Examples/MAX32572/lwIP_TCP/Makefile
@@ -78,7 +78,7 @@ export CMSIS_ROOT
 
 # Source files for this test (add path to VPATH below)
 SRCS  = main.c
-SRCS += sla_header.c
+SRCS += header_MAX32572.c
 SRCS += tcpecho_raw.c
 
 # Where to find source files for this test


### PR DESCRIPTION
This PR fixes a missed build error from https://github.com/Analog-Devices-MSDK/msdk/pull/180

The MAX32572 projects still need a significant amount of work and a migration to the new Makefile system, but this at least gets Hello_World building again.