### PR TITLE
Examples: Fixed linter errors.

### DIFF
--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/main.c
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/main.c
@@ -40,14 +40,13 @@
  */
 
 /***** Includes *****/
-#include "mxc_delay.h"
-#include "mxc_device.h"
-#include "mxc_sys.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-
-#include "sema_reva.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "mxc_sys.h"
+#include "sema.h"
 
 /***** Definitions *****/
 #define DUAL_CORE_SYNC (1)
@@ -65,7 +64,6 @@ typedef struct {
 #else
     uint8_t payload[MAILBOX_PAYLOAD_LEN];
 #endif
-
 } mxcSemaBox_t;
 
 /***** Globals *****/

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/main.c
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/main.c
@@ -39,16 +39,15 @@
  */
 
 /***** Includes *****/
-#include "board.h"
-#include "led.h"
-#include "mxc_delay.h"
-#include "mxc_device.h"
-#include "pb.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-
-#include "sema_reva.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "board.h"
+#include "led.h"
+#include "pb.h"
+#include "sema.h"
 
 /***** Definitions *****/
 #define DUAL_CORE_SYNC (1)
@@ -66,7 +65,6 @@ typedef struct {
 #else
     uint8_t payload[MAILBOX_PAYLOAD_LEN];
 #endif
-
 } mxcSemaBox_t;
 
 /***** Globals *****/

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/descriptors.h
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/descriptors.h
@@ -31,8 +31,8 @@
  *
  ******************************************************************************/
 
-#ifndef EXAMPLES_MAX32665_USB_COMPOSITEDEVICE_MSC_CDC_DESCRIPTORS_H_
-#define EXAMPLES_MAX32665_USB_COMPOSITEDEVICE_MSC_CDC_DESCRIPTORS_H_
+#ifndef EXAMPLES_MAX78002_USB_COMPOSITEDEVICE_MSC_CDC_DESCRIPTORS_H_
+#define EXAMPLES_MAX78002_USB_COMPOSITEDEVICE_MSC_CDC_DESCRIPTORS_H_
 
 #include <stdint.h>
 #include "usb.h"
@@ -453,4 +453,4 @@ __attribute__((aligned(4))) uint8_t msc_func_desc[] = {
     'g',  0,   'e', 0,   ' ', 0,   'D', 0,   'e', 0,   'v', 0,   'i', 0,   'c', 0,   'e', 0,
 };
 
-#endif // EXAMPLES_MAX32665_USB_COMPOSITEDEVICE_MSC_CDC_DESCRIPTORS_H_
+#endif // EXAMPLES_MAX78002_USB_COMPOSITEDEVICE_MSC_CDC_DESCRIPTORS_H_

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/mscmem.h
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/mscmem.h
@@ -37,8 +37,8 @@
  *          See the msc_mem_t structure in msc.h for function details.
  */
 
-#ifndef EXAMPLES_MAX32665_USB_COMPOSITEDEVICE_MSC_CDC_MSCMEM_H_
-#define EXAMPLES_MAX32665_USB_COMPOSITEDEVICE_MSC_CDC_MSCMEM_H_
+#ifndef EXAMPLES_MAX78002_USB_COMPOSITEDEVICE_MSC_CDC_MSCMEM_H_
+#define EXAMPLES_MAX78002_USB_COMPOSITEDEVICE_MSC_CDC_MSCMEM_H_
 
 #include <stdint.h>
 
@@ -94,4 +94,4 @@ int mscmem_Write(uint32_t lba, uint8_t *buffer);
  */
 int mscmem_Ready(void);
 
-#endif // EXAMPLES_MAX32665_USB_COMPOSITEDEVICE_MSC_CDC_MSCMEM_H_
+#endif // EXAMPLES_MAX78002_USB_COMPOSITEDEVICE_MSC_CDC_MSCMEM_H_

--- a/Examples/MAX78002/USB_MassStorage/descriptors.h
+++ b/Examples/MAX78002/USB_MassStorage/descriptors.h
@@ -31,8 +31,8 @@
  *
  ******************************************************************************/
 
-#ifndef EXAMPLES_MAX32665_USB_MASSSTORAGE_DESCRIPTORS_H_
-#define EXAMPLES_MAX32665_USB_MASSSTORAGE_DESCRIPTORS_H_
+#ifndef EXAMPLES_MAX78002_USB_MASSSTORAGE_DESCRIPTORS_H_
+#define EXAMPLES_MAX78002_USB_MASSSTORAGE_DESCRIPTORS_H_
 
 #include <stdint.h>
 #include "usb.h"
@@ -190,4 +190,4 @@ uint8_t serial_id_desc[] = { 26, /* bLength */
                              '0',  0, '0', 0, '0', 0, '0', 0, '0', 0, '0', 0,
                              '0',  0, '0', 0, '0', 0, '0', 0, '0', 0, '1', 0 };
 
-#endif // EXAMPLES_MAX32665_USB_MASSSTORAGE_DESCRIPTORS_H_
+#endif // EXAMPLES_MAX78002_USB_MASSSTORAGE_DESCRIPTORS_H_

--- a/Examples/MAX78002/USB_MassStorage/mscmem.h
+++ b/Examples/MAX78002/USB_MassStorage/mscmem.h
@@ -36,8 +36,9 @@
  * ownership rights.
  *
  ******************************************************************************/
-#ifndef EXAMPLES_MAX32665_USB_MASSSTORAGE_MSCMEM_H_
-#define EXAMPLES_MAX32665_USB_MASSSTORAGE_MSCMEM_H_
+
+#ifndef EXAMPLES_MAX78002_USB_MASSSTORAGE_MSCMEM_H_
+#define EXAMPLES_MAX78002_USB_MASSSTORAGE_MSCMEM_H_
 
 /* **** Include Files **** */
 #include <stdint.h>
@@ -94,4 +95,4 @@ int mscmem_Write(uint32_t lba, uint8_t *buffer);
  */
 int mscmem_Ready(void);
 
-#endif // EXAMPLES_MAX32665_USB_MASSSTORAGE_MSCMEM_H_
+#endif // EXAMPLES_MAX78002_USB_MASSSTORAGE_MSCMEM_H_

--- a/Examples/MAX78002/USB_MassStorage_ThroughPut/descriptors.h
+++ b/Examples/MAX78002/USB_MassStorage_ThroughPut/descriptors.h
@@ -31,8 +31,8 @@
  *
  ******************************************************************************/
 
-#ifndef EXAMPLES_MAX32665_USB_MASSSTORAGE_DESCRIPTORS_H_
-#define EXAMPLES_MAX32665_USB_MASSSTORAGE_DESCRIPTORS_H_
+#ifndef EXAMPLES_MAX78002_USB_MASSSTORAGE_THROUGHPUT_DESCRIPTORS_H_
+#define EXAMPLES_MAX78002_USB_MASSSTORAGE_THROUGHPUT_DESCRIPTORS_H_
 
 #include <stdint.h>
 #include "usb.h"
@@ -190,4 +190,4 @@ uint8_t serial_id_desc[] = { 26, /* bLength */
                              '0',  0, '0', 0, '0', 0, '0', 0, '0', 0, '0', 0,
                              '0',  0, '0', 0, '0', 0, '0', 0, '0', 0, '1', 0 };
 
-#endif // EXAMPLES_MAX32665_USB_MASSSTORAGE_DESCRIPTORS_H_
+#endif // EXAMPLES_MAX78002_USB_MASSSTORAGE_THROUGHPUT_DESCRIPTORS_H_

--- a/Examples/MAX78002/USB_MassStorage_ThroughPut/mscmem.h
+++ b/Examples/MAX78002/USB_MassStorage_ThroughPut/mscmem.h
@@ -36,8 +36,9 @@
  * ownership rights.
  *
  ******************************************************************************/
-#ifndef EXAMPLES_MAX32665_USB_MASSSTORAGE_MSCMEM_H_
-#define EXAMPLES_MAX32665_USB_MASSSTORAGE_MSCMEM_H_
+
+#ifndef EXAMPLES_MAX78002_USB_MASSSTORAGE_THROUGHPUT_MSCMEM_H_
+#define EXAMPLES_MAX78002_USB_MASSSTORAGE_THROUGHPUT_MSCMEM_H_
 
 /* **** Include Files **** */
 #include <stdint.h>
@@ -94,4 +95,4 @@ int mscmem_Write(uint32_t lba, uint8_t *buffer);
  */
 int mscmem_Ready(void);
 
-#endif // EXAMPLES_MAX32665_USB_MASSSTORAGE_MSCMEM_H_
+#endif // EXAMPLES_MAX78002_USB_MASSSTORAGE_THROUGHPUT_MSCMEM_H_


### PR DESCRIPTION
Fixed the linter errors in the newest examples that weren't checked in the first major pass-through.