### PR TITLE
Fix i2c repated start issue

### DIFF
--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -805,10 +805,11 @@ int MXC_I2C_RevA_MasterTransaction(mxc_i2c_reva_req_t *req)
         i2c->mstctrl |= MXC_F_I2C_REVA_MSTCTRL_RESTART;
     } else {
         i2c->mstctrl |= MXC_F_I2C_REVA_MSTCTRL_STOP;
+        
+        while (!(i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_STOP)) {}
+        // Wait for Transaction to finish
     }
 
-    while (!(i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_STOP)) {}
-    // Wait for Transaction to finish
     while (!(i2c->intfl0 & MXC_F_I2C_REVA_INTFL0_DONE)) {}
     // Wait for Transaction to finish
 


### PR DESCRIPTION
Do not wait stop signal for repeated start case.

The change has been tested on [MAX32670EVKit](https://www.maximintegrated.com/en/products/microcontrollers/MAX32670EVKIT.html) (I2C Master) - [MAX31825EvKit](https://www.maximintegrated.com/en/products/sensors/MAX31825EVKIT.html) (I2C Slave)

Signed-off-by: Sadik.Ozer <sadik.ozer@analog.com>