### PR TITLE
preserves logging of failed tests

### DIFF
--- a/.github/workflows/ci-tests/Examples_tests/local_testLauncher.sh
+++ b/.github/workflows/ci-tests/Examples_tests/local_testLauncher.sh
@@ -69,7 +69,7 @@ function flash_with_openocd() {
 }
 # This function accepts a CMSIS device ID as a parameter
 function erase_with_openocd() {
-    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$TARGET_2_CFG -s $OPENOCD_TCL_PATH/ -c "cmsis_dap_serial  $1" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt; flash erase_address 0x10004000 0x40000; reset exit" &
+    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$TARGET_2_CFG -s $OPENOCD_TCL_PATH/ -c "cmsis_dap_serial  $1" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt;max32xxx mass_erase 0; reset exit" &
     openocd_dapLink_pid=$!
     # wait for openocd to finish
     wait $openocd_dapLink_pid

--- a/.github/workflows/ci-tests/Examples_tests/resources/Serial.robot
+++ b/.github/workflows/ci-tests/Examples_tests/resources/Serial.robot
@@ -39,10 +39,10 @@ Send
     Write Data    ${data}    NONE    NONE    ${port}
 
 
-Expect And Timeout   
+Expect And Timeout Simple
     [Arguments]    ${data}    ${timeout}    ${port}
     [Timeout]    ${timeout}
-    ${read} =     Read Until    ${data}    NONE    NONE    ${port}
+    ${read} =     Read Until   ${data}    NONE    NONE    ${port} 
     Log Serial Traffic    ${read}
     
 Expect And Timeout No Verbose  
@@ -50,7 +50,21 @@ Expect And Timeout No Verbose
     [Timeout]    ${timeout}
     ${read} =     Read Until    ${data}    NONE    NONE    ${port}
    
-   
+Expect And Timeout
+    [Arguments]    ${data}    ${timeout}    ${port}    
+    [Timeout]    ${timeout}
+    ${EMPTY}=    Set Variable    ""
+    Log To Console    \n
+    WHILE    True    limit=200000
+        ${source}=    Read Until   NONE    NONE    NONE    ${port}
+        Log To Console    ${source}
+        ${contains}=    Run Keyword And Return Status    Should Contain    ${source}    ${data}
+        IF    ${contains}
+            Pass Execution    ------------------------------------------------------------------------------
+        END
+    END
+    Fail    "Test Failed"
+
 Log Serial Traffic
     [Arguments]    ${data}
     Log To Console    \n
@@ -63,4 +77,6 @@ Flush Serial Port
 
 Clear Port Input Buffer
     [Arguments]    ${port}
-    Reset Input Buffer    ${port}
+    ${source}=    Read All Data   NONE    ${port}
+    
+    

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_FreeRTOS.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_FreeRTOS.robot
@@ -15,28 +15,28 @@ Stop Advertising Test
     # inital sleep to allow device time to boot up after programming
     sleep    5
     Serial.Send    btn 2 s\n    ${SERIAL_PORT_1}    
-    Serial.Expect And Timeout    >>> Advertising stopped <<<    10s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    >>> Advertising stopped <<<    10    ${SERIAL_PORT_1}
 
 
 Start Advertising Test  
     [Timeout]     30s
     Serial.send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Advertising started <<<    10s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    >>> Advertising started <<<    10    ${SERIAL_PORT_1}
 
 
 Button M Press Test  
     [Timeout]     30s
     Serial.send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Medium Button 1 Press    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Medium Button 1 Press    5    ${SERIAL_PORT_1}
     
 
 Button L Press Test  
     [Timeout]     30s
     Serial.send    btn 1 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Clear resolving list status 0x00    5S    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Clear resolving list status 0x00    5    ${SERIAL_PORT_1}
    
 
 Button X Press Test  
     [Timeout]     30s
     Serial.send    btn 1 x\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Stack Version: Packetcraft Host    5S    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Stack Version: Packetcraft Host    5    ${SERIAL_PORT_1}

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_FreeRTOS_cs.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_FreeRTOS_cs.robot
@@ -15,7 +15,7 @@ Write Characteristic Test
     # inital sleep to allow device time to boot up after programming
     sleep    5
     Serial.send    btn 2 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout   hello back    2s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout   hello back    2    ${SERIAL_PORT_1}
 
 
 # Phy Switching Test 

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_dat_cs.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_dat_cs.robot
@@ -14,40 +14,35 @@ ${VERBOSE}    1
 *** test cases ***
 
 Secured Connection Test
-    [Timeout]     30s
+    [Timeout]     60s
     # inital sleep to allow device time to boot up after programming
     sleep    5
-    Serial.send    pin 1 1234\n    ${SERIAL_PORT_1}
-    sleep    2
     Serial.send   pin 1 1234\n    ${SERIAL_PORT_2}
-
-    Serial.Expect And Timeout    >>> Pairing completed successfully <<<    15s    ${SERIAL_PORT_1}
+    sleep    2
+    Serial.send    pin 1 1234\n    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    >>> Pairing completed successfully <<<    25    ${SERIAL_PORT_1}
 
 Write Characteristic Test
     [Timeout]     30s
-    sleep    5
     Serial.send    btn 2 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    hello back    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    hello back    5    ${SERIAL_PORT_1}    
 
 Write Secure Characteristic Test
     [Timeout]     30s
-    sleep    5
     Serial.send    btn 2 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Notification from secure data service    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Notification from secure data service    5    ${SERIAL_PORT_1}    
 
 
 Phy Switching Test 
     [Timeout]     30s
-    sleep     2
     Serial.send    btn 2 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    DM_PHY_UPDATE_IND - RX: 2, TX: 2    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    DM_PHY_UPDATE_IND - RX: 2, TX: 2    5    ${SERIAL_PORT_1}    
 
 
 Speed Test  
     [Timeout]     120s
-    sleep    5s
     Serial.send    btn 2 x\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout No Verbose     bits transferred in    120s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout     bits transferred in    120    ${SERIAL_PORT_1}
 
 
 

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_datc.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_datc.robot
@@ -15,19 +15,19 @@ Stop Scanning Test
     # inital sleep to allow device time to boot up after programming
     Sleep     5s
     Serial.Send    btn 1 s\n    ${SERIAL_PORT_1}   
-    Serial.Expect And Timeout    >>> Scanning stopped <<<    10s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    >>> Scanning stopped <<<    10    ${SERIAL_PORT_1}
 
 Button Press Test
     [Timeout]    30s
     Serial.Send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Medium Button 1 Press    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Medium Button 1 Press    5    ${SERIAL_PORT_1}
 
 No button Action Test
     [Timeout]    30s
     Serial.Send    btn 2 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    No action assigned    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    No action assigned    5    ${SERIAL_PORT_1}
 
 Clearing Bond Info Test
     [Timeout]    30s
     Serial.Send    btn 1 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Clear bonding info    10s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Clear bonding info    10    ${SERIAL_PORT_1}

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_dats.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_dats.robot
@@ -15,31 +15,31 @@ Stop Advertising Test
     # inital sleep to allow device time to boot up after programming
     sleep    5
     Serial.Send     btn 2 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Advertising stopped <<<    10s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    >>> Advertising stopped <<<    10    ${SERIAL_PORT_1}
 
 
 Start Advertising Test  
     [Timeout]     30s
     Serial.send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Advertising started <<<    10s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    >>> Advertising started <<<    10    ${SERIAL_PORT_1}
 
 
 Button M Press Test  
     [Timeout]     30s
     Serial.send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Medium Button 1 Press    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Medium Button 1 Press    5    ${SERIAL_PORT_1}
     
 
 Button L Press Test  
     [Timeout]     30s
     Serial.send    btn 1 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Clear resolving list status 0x00    5S    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Clear resolving list status 0x00    5    ${SERIAL_PORT_1}
    
 
 Button X Press Test  
     [Timeout]     30s
     Serial.send    btn 1 x\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Stack Version: Packetcraft Host    5S    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Stack Version: Packetcraft Host    5    ${SERIAL_PORT_1}
    
 
 

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_fit.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_fit.robot
@@ -15,7 +15,7 @@ Button Press Tests
     # inital sleep to allow device time to boot up after programming
     Sleep     5s
     Serial.Send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Short Button 1 Press    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Short Button 1 Press    5    ${SERIAL_PORT_1}
 
     Serial.Send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Medium Button 1 Press    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    Medium Button 1 Press    5    ${SERIAL_PORT_1}

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_mcs.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_mcs.robot
@@ -15,10 +15,10 @@ Button Press Tests
     # inital sleep to allow device time to boot up after programming
     Sleep     5s
     Serial.Send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    mcsAppBtnCback; 2    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    mcsAppBtnCback; 2    5    ${SERIAL_PORT_1}
 
     Serial.Send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    mcsAppBtnCback; 3    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    mcsAppBtnCback; 3    5    ${SERIAL_PORT_1}
     
     Serial.Send    btn 1 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    mcsAppBtnCback; 4    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    mcsAppBtnCback; 4    5    ${SERIAL_PORT_1}

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_ota_cs.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_ota_cs.robot
@@ -17,38 +17,35 @@ Original Firmware Test
     Sleep     5s
     # inital sleep to allow device time to boot up after programming
     Serial.send    btn 2 m\n    ${SERIAL_PORT_2}
-    Serial.Expect And Timeout    FW_VERSION: 1    5s    ${SERIAL_PORT_2}
+    Serial.Expect And Timeout    FW_VERSION: 1   5    ${SERIAL_PORT_2}
 
 File Discovery Test
     [Timeout]    30s
-     Serial.send    btn 2 s\n    ${SERIAL_PORT_1}
-     Serial.Expect And Timeout    >>> File discovery complete <<<    5s    ${SERIAL_PORT_1}
+    Serial.send    btn 2 s\n    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    >>> File discovery complete <<<    5    ${SERIAL_PORT_1}
 
 File Transfer Test
     [Timeout]    30s
-     Serial.Send    btn 2 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout No Verbose    >>> File transfer complete    20s    ${SERIAL_PORT_1}
+    Serial.Send    btn 2 m\n    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout    >>> File transfer complete    20    ${SERIAL_PORT_1}
 
 File Verification Test
     [Timeout]    30S
     Serial.Send    btn 2 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Verify complete status: 0 <<<    2s    ${SERIAL_PORT_1}
-
+    Serial.Expect And Timeout    >>> Verify complete status: 0 <<<    2    ${SERIAL_PORT_1}
+   
 Peer Device Reset Test
     [Timeout]    30s
     Serial.Send    btn 2 x\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Scanning started <<<    5s    ${SERIAL_PORT_1}
-
+    Serial.Expect And Timeout    >>> Scanning started <<<    5    ${SERIAL_PORT_1}
 
 Firmware Reconnect Succesful Test
     [Timeout]    60s
-    Serial.Expect And Timeout    AppDiscComplete connId:1 status:0x08    30s    ${SERIAL_PORT_1}
-
-
+    Serial.Expect And Timeout    AppDiscComplete connId:1 status:0x08    30    ${SERIAL_PORT_1}
+    
 Firmware Update Verification Test
     [Timeout]    30s
-    Sleep     5
-    Serial.Flush Serial Port    ${SERIAL_PORT_2}
-    Sleep     1
     Serial.send    btn 2 m\n    ${SERIAL_PORT_2}
+    
+
 

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_otac.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_otac.robot
@@ -15,14 +15,14 @@ Stop Scanning Test
     # inital sleep to allow device time to boot up after programming
     Sleep    5s
     Serial.Send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout     >>> Scanning stopped <<<    5s    ${SERIAL_PORT_1}
+    Serial.Expect And Timeout     >>> Scanning stopped <<<    5    ${SERIAL_PORT_1}
 
 Connection ID Test
     [Timeout]    30s
     Serial.Send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect and timeout    ConnID for Button Press:    5s    ${SERIAL_PORT_1}
+    Serial.Expect and timeout    ConnID for Button Press:    5    ${SERIAL_PORT_1}
 
 Clear Resolving List Test
     [Timeout]    30s
     Serial.Send    btn 1 l\n    ${SERIAL_PORT_1}
-    serial.Expect And Timeout    Clear resolving list status 0x00    5s    ${SERIAL_PORT_1}
+    serial.Expect And Timeout    Clear resolving list status 0x00    5    ${SERIAL_PORT_1}

--- a/Examples/MAX32655/BLE_otas/test.txt
+++ b/Examples/MAX32655/BLE_otas/test.txt
@@ -1,0 +1,1 @@
+testing

--- a/Examples/MAX32655/BLE_otas/test.txt
+++ b/Examples/MAX32655/BLE_otas/test.txt
@@ -1,1 +1,0 @@
-testing


### PR DESCRIPTION
Fixes issue with failed test discarding the logging information, which is not very helpful in debugging why a test failed.