### PR TITLE
Bug fix: TRNG RevB AES key generation polling wrong status bit

### DIFF
--- a/Libraries/PeriphDrivers/Source/TRNG/trng_revb.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_revb.c
@@ -153,10 +153,11 @@ void MXC_TRNG_RevB_RandomAsync(mxc_trng_revb_regs_t *trng, uint8_t *data, uint32
 
 void MXC_TRNG_RevB_GenerateKey(mxc_trng_revb_regs_t *trng)
 {
-    /*Generate AES Key */
+	// Generate AES Key
     trng->ctrl |= MXC_F_TRNG_REVB_CTRL_AESKG_USR;
 
-    while (trng->ctrl & MXC_F_TRNG_REVB_CTRL_AESKG_USR) {}
+    // Wait for key transfer to complete
+    while (trng->status & MXC_F_TRNG_REVB_STATUS_AESKGD) {};
 }
 
 int MXC_TRNG_RevB_HealthTest(mxc_trng_revb_regs_t *trng)

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_revb.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_revb.c
@@ -153,7 +153,7 @@ void MXC_TRNG_RevB_RandomAsync(mxc_trng_revb_regs_t *trng, uint8_t *data, uint32
 
 void MXC_TRNG_RevB_GenerateKey(mxc_trng_revb_regs_t *trng)
 {
-	// Generate AES Key
+    // Generate AES Key
     trng->ctrl |= MXC_F_TRNG_REVB_CTRL_AESKG_USR;
 
     // Wait for key transfer to complete


### PR DESCRIPTION
TRNG RevB was waiting for the AESKG_USR bit to clear to determine when the generated AES key had finished transferring into the AESKEY registers, however the AESKG_USR bit clears after the key has finished generating not when it has finished transferring. Since the new key wasn't done transferring into the AESKEY registers by the end of the function, an encryption operation performed immediately after would only be using a partial key. This would cause data mismatches for subsequent decryption operations since by the time they were performed the key had been fully transferred into the AESKEY registers. The fix is to instead poll the AESKGD bit in the status register since it is cleared by hardware once the transfer has finished.