### PR TITLE
Use Relative URL for Submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,33 +1,30 @@
 [submodule "Libraries/MAXUSB"]
 	path = Libraries/MAXUSB
-	url = git@github.com:Analog-Devices-MSDK/Libraries-maxusb.git
+	url = ../Libraries-maxusb.git
 [submodule "Libraries/SDHC"]
 	path = Libraries/SDHC
-	url = git@github.com:Analog-Devices-MSDK/Libraries-sdhc.git
+	url = ../Libraries-sdhc.git
 [submodule "Libraries/FreeRTOS"]
 	path = Libraries/FreeRTOS
-	url = git@github.com:Analog-Devices-MSDK/Libraries-freeRTOS.git
+	url = ../Libraries-freeRTOS.git
 [submodule "Libraries/lwIP"]
 	path = Libraries/lwIP
-	url = git@github.com:Analog-Devices-MSDK/Libraries-lwIP.git
+	url = ../Libraries-lwIP.git
 [submodule "Libraries/FCL"]
 	path = Libraries/FCL
-	url = git@github.com:Analog-Devices-MSDK/Libraries-fcl.git
+	url = ../Libraries-fcl.git
 [submodule "Libraries/Cordio"]
 	path = Libraries/Cordio
-	url = git@github.com:Analog-Devices-MSDK/Libraries-cordio.git
+	url = ../Libraries-cordio.git
 [submodule "Libraries/littlefs"]
 	path = Libraries/littlefs
-	url = git@github.com:Analog-Devices-MSDK/Libraries-littlefs.git
+	url = ../Libraries-littlefs.git
 [submodule "Libraries/MiscDrivers"]
 	path = Libraries/MiscDrivers
-	url = git@github.com:Analog-Devices-MSDK/Libraries-miscDrivers.git
+	url = ../Libraries-miscDrivers.git
 [submodule "Libraries/LC3"]
 	path = Libraries/LC3
-	url = git@github.com:Analog-Devices-MSDK/Libraries-lc3.git
+	url = ../Libraries-lc3.git
 [submodule "Libraries/FreeRTOS-Plus"]
 	path = Libraries/FreeRTOS-Plus
-	url = git@github.com:Analog-Devices-MSDK/Libraries-freeRTOS_plus.git
-[submodule "Examples/MAX32570"]
-	path = Examples/MAX32570
-	url = git@github.com:Analog-Devices-MSDK/Examples-MAX32570.git
+	url = ../Libraries-freeRTOS_plus.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ For beginners, [learngitbranching.js.org](https://learngitbranching.js.org/) is 
 
 The MSDK follows the [GitHub contribution guidelines](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).  
 
-External contributions from outside the [Analog Devices organization](https://github.com/Analog-Devices-MSDK) should be made via a Pull Request opened from a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).  **It should be noted that all of the MSDK's submodule's should be individually forked to your personal Github account as well**.
+External contributions from outside the [Analog Devices organization](https://github.com/Analog-Devices-MSDK) should be made via a Pull Request opened from a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).  **It should be noted that all of the MSDK's submodules should be individually forked to your personal Github account as well**.
 
 Internal contributions should also originate from a fork where possible.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,11 @@ For beginners, [learngitbranching.js.org](https://learngitbranching.js.org/) is 
 
 The MSDK follows the [GitHub contribution guidelines](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).  
 
-External contributions from outside the [Analog Devices organization](https://github.com/Analog-Devices-MSDK) should be made via a Pull Request opened from a fork.  Internal contributions should also preferrably use a fork where possible.
+External contributions from outside the [Analog Devices organization](https://github.com/Analog-Devices-MSDK) should be made via a Pull Request opened from a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).  **It should be noted that all of the MSDK's submodule's should be individually forked to your personal Github account as well**.
 
-If a direct branch on the mainline MSDK repo is made, the following branch naming conventions should be used when possible:
+Internal contributions should also originate from a fork where possible.
+
+If a direct branch on the mainline MSDK repo is made, use the following branch naming conventions:
 
 * Bugfix/ticket: `fix/branchname`
     * For Jira tickets, it's recommended to use `fix/ticketnumber` so that the branch gets automatically tracked.  Ex: `fix/MSDK-670`


### PR DESCRIPTION
Using relative URLs should allow both HTTPS and SSH cloning to work.