### PR TITLE
MSDK-952: Fix TFT TS issue

### DIFF
--- a/Examples/MAX78000/TFT_Demo/example_config.h
+++ b/Examples/MAX78000/TFT_Demo/example_config.h
@@ -34,6 +34,8 @@
 #ifndef EXAMPLES_MAX78000_TFT_DEMO_EXAMPLE_CONFIG_H_
 #define EXAMPLES_MAX78000_TFT_DEMO_EXAMPLE_CONFIG_H_
 
+#include "board.h"
+
 #ifdef BOARD_EVKIT_V1
 #include "tft_ssd2119.h"
 #include "bitmap.h"

--- a/Examples/MAX78000/TFT_Demo/include/state.h
+++ b/Examples/MAX78000/TFT_Demo/include/state.h
@@ -34,6 +34,10 @@
 #ifndef EXAMPLES_MAX78000_TFT_DEMO_INCLUDE_STATE_H_
 #define EXAMPLES_MAX78000_TFT_DEMO_INCLUDE_STATE_H_
 
+/*****************************     Includes    *********************************/
+#include "example_config.h"
+
+/*****************************     Typedef     *********************************/
 typedef int (*Init_func)(void);
 typedef int (*Keypad_process)(int key);
 typedef void (*Time_Tick)(void);


### PR DESCRIPTION
TFT Demo TS issue fixed, 
Tested on MAX78000 EvKit RevC.

If there is some other TFT example which TS does not work it most probably can be fix by this type change.

Signed-off-by: Sadik.Ozer <sadik.ozer@analog.com>