### PR TITLE
Add Touch Screen Support for AI87 EVKIT + NewHaven TFT

### DIFF
--- a/Examples/MAX78002/TFT_Demo/main.c
+++ b/Examples/MAX78002/TFT_Demo/main.c
@@ -118,15 +118,10 @@ void TFT_test(void)
 
 void print_xy(unsigned int x, unsigned int y)
 {
-    char buf[9];
-    static int last_x = 0;
-    static int last_y = 0;
+    char buf[16];
 
-    TFT_Print("        ", last_x, last_y, font_5, 8);
-    TFT_Print(buf, x, y, font_5, snprintf(buf, sizeof(buf), "(%u,%u)", x, y));
-
-    last_x = x;
-    last_y = y;
+    MXC_TFT_ClearScreen();
+    TFT_Print(buf, x, y, font_1, snprintf(buf, sizeof(buf), "(%u,%u)", x, y));
 }
 
 int32_t rescale(int32_t x, int32_t min, int32_t max, int32_t a, int32_t b)
@@ -163,6 +158,7 @@ int main(void)
     unsigned int touch_x, touch_y;
     MXC_TS_Init();
     MXC_TS_Start();
+    TFT_Print("Touch the screen!", 0, 120, font_5, 17);
 #endif
 
     for (;;) {

--- a/Examples/MAX78002/TFT_Demo/main.c
+++ b/Examples/MAX78002/TFT_Demo/main.c
@@ -158,7 +158,7 @@ int main(void)
     MXC_TFT_Init(NULL, NULL);
     MXC_TFT_SetRotation(ROTATE_270);
     TFT_test();
-    
+
     /* Initialize TouchScreen*/
     unsigned int touch_x, touch_y;
     MXC_TS_Init();

--- a/Examples/MAX78002/TFT_Demo/main.c
+++ b/Examples/MAX78002/TFT_Demo/main.c
@@ -158,19 +158,14 @@ int main(void)
     MXC_TFT_Init(NULL, NULL);
     MXC_TFT_SetRotation(ROTATE_270);
     TFT_test();
-#endif
-
+    
     /* Initialize TouchScreen*/
     unsigned int touch_x, touch_y;
     MXC_TS_Init();
     MXC_TS_Start();
+#endif
 
     for (;;) {
-        if (MXC_TS_GetTSEvent()) {
-            MXC_TS_ClearTSEvent();
-            MXC_TS_GetXY(&touch_x, &touch_y);
-            print_xy(touch_x, touch_y);
-        }
 #ifdef TFT_ADAFRUIT
         if (ts_event) {
             MXC_TS_GetTouch(&x, &y);
@@ -179,6 +174,12 @@ int main(void)
             xx = rescale(x, TS_X_MIN, TS_X_MAX, 0, DISPLAY_HEIGHT);
             yy = rescale(y, TS_Y_MIN, TS_Y_MAX, 0, DISPLAY_WIDTH);
             printf("%d,%d\n", xx, yy);
+        }
+#else
+        if (MXC_TS_GetTSEvent()) {
+            MXC_TS_ClearTSEvent();
+            MXC_TS_GetXY(&touch_x, &touch_y);
+            print_xy(touch_x, touch_y);
         }
 #endif
     }

--- a/Libraries/Boards/MAX32655/EvKit_V1/Include/board.h
+++ b/Libraries/Boards/MAX32655/EvKit_V1/Include/board.h
@@ -80,6 +80,9 @@ extern "C" {
 #define EXT_FLASH_BAUD 5000000
 #endif
 
+#define TS_SPI MXC_SPI1
+#define TS_SPI_FREQ 200000
+
 /**
  *  A reference to LED1 (RED LED in the RGB LED) of the board.
  *  Can be used with the LED_On, LED_Off, and LED_Toggle functions.

--- a/Libraries/Boards/MAX32655/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32655/EvKit_V1/Source/board.c
@@ -305,7 +305,7 @@ void TS_SPI_Transmit(uint8_t datain, uint16_t *dataout)
     request.rxData = NULL;
     request.txLen = 1;
     request.rxLen = 0;
-    request.ssIdx = 2;
+    request.ssIdx = 1;
 
     MXC_SPI_SetFrequency(TS_SPI, TS_SPI_FREQ);
     MXC_SPI_SetDataSize(TS_SPI, 8);

--- a/Libraries/Boards/MAX32655/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32655/EvKit_V1/Source/board.c
@@ -277,6 +277,58 @@ static int ext_flash_clock(unsigned int len, unsigned int deassert)
     free(write);
     return res;
 }
+
+void TS_SPI_Init(void) {
+    mxc_spi_pins_t ts_pins = {
+        // CLK, MISO, MOSI enabled, SS IDx = 1
+        .clock = true, .ss0 = false, .ss1 = true,   .ss2 = false,
+        .miso = true,  .mosi = true, .sdio2 = false, .sdio3 = false,
+    };
+
+    MXC_SPI_Init(TS_SPI, true, false, 1, 0, TS_SPI_FREQ, ts_pins);
+    MXC_GPIO_SetVSSEL(MXC_GPIO0, MXC_GPIO_VSSEL_VDDIOH,
+                      MXC_GPIO_PIN_21 | MXC_GPIO_PIN_22 | MXC_GPIO_PIN_23 | MXC_GPIO_PIN_26);
+    MXC_SPI_SetDataSize(TS_SPI, 8);
+    MXC_SPI_SetWidth(TS_SPI, SPI_WIDTH_STANDARD);
+}
+
+void TS_SPI_Transmit(uint8_t datain, uint16_t *dataout)
+{
+    int i;
+    uint8_t rx[2] = { 0, 0 };
+    mxc_spi_req_t request;
+
+    request.spi = TS_SPI;
+    request.ssDeassert = 0;
+    request.txData = (uint8_t *)(&datain);
+    request.rxData = NULL;
+    request.txLen = 1;
+    request.rxLen = 0;
+    request.ssIdx = 2;
+
+    MXC_SPI_SetFrequency(TS_SPI, TS_SPI_FREQ);
+    MXC_SPI_SetDataSize(TS_SPI, 8);
+
+    MXC_SPI_MasterTransaction(&request);
+
+    // Wait to clear TS busy signal
+    for (i = 0; i < 100; i++) {
+        __asm volatile("nop\n");
+    }
+
+    request.ssDeassert = 1;
+    request.txData = NULL;
+    request.rxData = (uint8_t *)(rx);
+    request.txLen = 0;
+    request.rxLen = 2;
+
+    MXC_SPI_MasterTransaction(&request);
+
+    if (dataout != NULL) {
+        *dataout = (rx[1] | (rx[0] << 8)) >> 4;
+    }
+}
+
 #endif /* __riscv */
 
 /******************************************************************************/

--- a/Libraries/Boards/MAX32655/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32655/EvKit_V1/Source/board.c
@@ -278,10 +278,11 @@ static int ext_flash_clock(unsigned int len, unsigned int deassert)
     return res;
 }
 
-void TS_SPI_Init(void) {
+void TS_SPI_Init(void)
+{
     mxc_spi_pins_t ts_pins = {
         // CLK, MISO, MOSI enabled, SS IDx = 1
-        .clock = true, .ss0 = false, .ss1 = true,   .ss2 = false,
+        .clock = true, .ss0 = false, .ss1 = true,    .ss2 = false,
         .miso = true,  .mosi = true, .sdio2 = false, .sdio3 = false,
     };
 

--- a/Libraries/Boards/MAX78000/EvKit_V1/Include/board.h
+++ b/Libraries/Boards/MAX78000/EvKit_V1/Include/board.h
@@ -63,6 +63,7 @@ extern "C" {
 #define LED_OFF 1 /// Inactive state of LEDs
 #define LED_ON 0 /// Active state of LEDs
 
+#ifndef __riscv // RISC-V does not have access to SPI0
 #define TFT_SPI MXC_SPI0 // SPI port to use for TFT display
 #define TFT_SPI_PORT MXC_GPIO0 /**< GPIO port for SPI peripheral pins. */
 #define TFT_SPI_PINS                                   \
@@ -74,6 +75,7 @@ extern "C" {
 
 #define TS_SPI MXC_SPI0
 #define TS_SPI_FREQ 1000000
+#endif // __riscv
 
 /**
  *  A reference to LED1 of the board.

--- a/Libraries/Boards/MAX78000/EvKit_V1/Include/board.h
+++ b/Libraries/Boards/MAX78000/EvKit_V1/Include/board.h
@@ -72,6 +72,9 @@ extern "C" {
 #define TFT_DC_PORT MXC_GPIO0 /**< GPIO port for Data/Command signal. */
 #define TFT_DC_PIN MXC_GPIO_PIN_8 /**< GPIO pin for Data/Command signal. */
 
+#define TS_SPI MXC_SPI0
+#define TS_SPI_FREQ 1000000
+
 /**
  *  A reference to LED1 of the board.
  *  Can be used with the LED_On, LED_Off, and LED_Toggle functions.

--- a/Libraries/Boards/MAX78000/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78000/EvKit_V1/Source/board.c
@@ -105,7 +105,8 @@ void TS_SPI_Init(void)
     MXC_SPI_Init(TS_SPI, master, quadMode, numSlaves, ssPol, TS_SPI_FREQ, ts_pins);
 
     // Set SPI pins to VDDIOH (3.3V) to be compatible with TFT display
-    MXC_GPIO_SetVSSEL(MXC_GPIO0, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7 | MXC_GPIO_PIN_10);
+    MXC_GPIO_SetVSSEL(MXC_GPIO0, MXC_GPIO_VSSEL_VDDIOH,
+                      MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7 | MXC_GPIO_PIN_10);
     MXC_SPI_SetDataSize(TS_SPI, 8);
     MXC_SPI_SetWidth(TS_SPI, SPI_WIDTH_STANDARD);
 }

--- a/Libraries/Boards/MAX78000/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78000/EvKit_V1/Source/board.c
@@ -88,6 +88,7 @@ void mxc_assert(const char *expr, const char *file, int line)
     while (1) {}
 }
 
+#ifndef __riscv
 void TS_SPI_Init(void)
 {
     int master = 1;
@@ -145,6 +146,7 @@ void TS_SPI_Transmit(uint8_t datain, uint16_t *dataout)
         *dataout = (rx[1] | (rx[0] << 8)) >> 4;
     }
 }
+#endif // __riscv
 
 /******************************************************************************/
 int Board_Init(void)

--- a/Libraries/Boards/MAX78002/EvKit_V1/Include/board.h
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Include/board.h
@@ -88,9 +88,10 @@ extern "C" {
  */
 #define LED2 1
 
-#ifdef TFT_NEWHAVEN
 #define TFT_SPI MXC_SPI0 // SPI port to use for TFT display
+#ifdef TFT_NEWHAVEN
 #define TFT_SPI_FREQ 20000000 /**< SPI clock frequency in Hertz. */
+#endif
 #define TFT_DC_PORT MXC_GPIO2 /**< GPIO port for Data/Command signal. */
 #define TFT_DC_PIN MXC_GPIO_PIN_2 /**< GPIO pin for Data/Command signal. */
 #define TFT_SS_PORT MXC_GPIO0 /**< GPIO port for select signal. */
@@ -106,7 +107,6 @@ extern "C" {
 void TFT_SPI_Init(void);
 void TFT_SPI_Write(uint8_t data, bool cmd);
 void TFT_SPI_Transmit(void *src, int count);
-#endif
 
 /**
  * \brief   Initialize the BSP and board interfaces.

--- a/Libraries/Boards/MAX78002/EvKit_V1/Include/board.h
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Include/board.h
@@ -48,6 +48,7 @@
 #endif
 #ifdef TFT_NEWHAVEN
 #include "tft_st7789v.h"
+#include "tsc2046.h"
 #endif
 
 #ifdef __cplusplus
@@ -94,6 +95,13 @@ extern "C" {
 #define TFT_DC_PIN MXC_GPIO_PIN_2 /**< GPIO pin for Data/Command signal. */
 #define TFT_SS_PORT MXC_GPIO0 /**< GPIO port for select signal. */
 #define TFT_SS_PIN MXC_GPIO_PIN_3 /**< GPIO pin for select signal. */
+
+#define TS_SPI MXC_SPI0
+#define TS_SPI_FREQ 1000000
+#define TS_IRQ_PORT MXC_GPIO0
+#define TS_IRQ_PIN MXC_GPIO_PIN_19
+#define TS_SS_PORT MXC_GPIO1
+#define TS_SS_PIN MXC_GPIO_PIN_1
 
 void TFT_SPI_Init(void);
 void TFT_SPI_Write(uint8_t data, bool cmd);

--- a/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
@@ -68,10 +68,10 @@ const mxc_gpio_cfg_t tft_ss_pin = { TFT_SS_PORT, TFT_SS_PIN, MXC_GPIO_FUNC_OUT, 
                                     MXC_GPIO_VSSEL_VDDIOH };
 // TS IRQ pin
 mxc_gpio_cfg_t ts_irq_pin = { TS_IRQ_PORT, TS_IRQ_PIN, MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_NONE,
-                                    MXC_GPIO_VSSEL_VDDIOH };
+                              MXC_GPIO_VSSEL_VDDIOH };
 // TS SS pin
 const mxc_gpio_cfg_t ts_ss_pin = { TS_SS_PORT, TS_SS_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_NONE,
-                                    MXC_GPIO_VSSEL_VDDIOH };
+                                   MXC_GPIO_VSSEL_VDDIOH };
 
 /***** File Scope Variables *****/
 // const uart_cfg_t uart_cfg = {
@@ -218,7 +218,8 @@ void TS_SPI_Init(void)
     MXC_SPI_Init(TS_SPI, master, quadMode, numSlaves, ssPol, TS_SPI_FREQ, ts_pins);
 
     // Set SPI pins to VDDIOH (3.3V) to be compatible with TFT display
-    MXC_GPIO_SetVSSEL(MXC_GPIO0, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7);
+    MXC_GPIO_SetVSSEL(MXC_GPIO0, MXC_GPIO_VSSEL_VDDIOH,
+                      MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7);
     MXC_SPI_SetDataSize(TS_SPI, 8);
     MXC_SPI_SetWidth(TS_SPI, SPI_WIDTH_STANDARD);
 
@@ -311,7 +312,7 @@ int Board_Init(void)
 #ifdef TFT_NEWHAVEN
     // Set falling edge triggered interrupt for TouchScreen
     // MXC_TS_PreInit is not used because we need to take more direct
-    // control of SPI routines and initialization 
+    // control of SPI routines and initialization
     ts_irq_pin.port->intmode |= ts_irq_pin.mask;
     ts_irq_pin.port->intpol &= ~(ts_irq_pin.mask);
     MXC_TS_AssignInterruptPin(ts_irq_pin);

--- a/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
@@ -66,6 +66,12 @@ const mxc_gpio_cfg_t tft_dc_pin = { TFT_DC_PORT, TFT_DC_PIN, MXC_GPIO_FUNC_OUT, 
 // TFT Slave Select pin
 const mxc_gpio_cfg_t tft_ss_pin = { TFT_SS_PORT, TFT_SS_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_NONE,
                                     MXC_GPIO_VSSEL_VDDIOH };
+// TS IRQ pin
+mxc_gpio_cfg_t ts_irq_pin = { TS_IRQ_PORT, TS_IRQ_PIN, MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_NONE,
+                                    MXC_GPIO_VSSEL_VDDIOH };
+// TS SS pin
+const mxc_gpio_cfg_t ts_ss_pin = { TS_SS_PORT, TS_SS_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_NONE,
+                                    MXC_GPIO_VSSEL_VDDIOH };
 
 /***** File Scope Variables *****/
 // const uart_cfg_t uart_cfg = {
@@ -120,11 +126,22 @@ void TFT_SPI_Init(void)
     // Initialize SPI GPIOs
     MXC_GPIO_Config(&tft_dc_pin); // Data/Command select
     MXC_GPIO_Config(&tft_ss_pin); // Slave Select
-    MXC_GPIO_OutSet(TFT_SS_PORT, TFT_SS_PIN);
+    MXC_GPIO_OutSet(tft_ss_pin.port, tft_ss_pin.mask);
+
+    // If the touchscreen controller pin is unitialized, it will default
+    // to logic level 0 (active slave select) and intercept TFT traffic.
+    // Therefore it must be initialized and set to logic level 1 here.
+    MXC_GPIO_Config(&ts_ss_pin);
+    MXC_GPIO_OutSet(ts_ss_pin.port, ts_ss_pin.mask);
 }
 
 void TFT_SPI_Write(uint8_t data, bool cmd)
 {
+    // TFT and TS share the same SPI bus, and TS will set a lower SPI freq
+    // So explicity set the TFT speed again before transmitting
+    MXC_SPI_SetFrequency(TFT_SPI, TFT_SPI_FREQ);
+
+    // Software controlled Slave Select
     MXC_GPIO_OutClr(TFT_SS_PORT, TFT_SS_PIN);
 
     if (cmd)
@@ -153,6 +170,11 @@ void TFT_SPI_Transmit(void *src, int count)
 {
     uint8_t *buf = (uint8_t *)src;
 
+    // TFT and TS share the same SPI bus, and TS will set a lower SPI freq
+    // So explicity set the TFT speed again before transmitting
+    MXC_SPI_SetFrequency(TFT_SPI, TFT_SPI_FREQ);
+
+    // Software controlled Slave Select
     MXC_GPIO_OutClr(TFT_SS_PORT, TFT_SS_PIN);
 
     MXC_GPIO_OutSet(TFT_DC_PORT, TFT_DC_PIN);
@@ -178,6 +200,80 @@ void TFT_SPI_Transmit(void *src, int count)
     TFT_SPI->intfl = TFT_SPI->intfl;
 
     MXC_GPIO_OutSet(TFT_SS_PORT, TFT_SS_PIN);
+}
+
+void TS_SPI_Init(void)
+{
+    int master = 1;
+    int quadMode = 0;
+    int numSlaves = 0;
+    int ssPol = 0;
+
+    mxc_spi_pins_t ts_pins = {
+        // CLK, MISO, MOSI enabled, software controlled SS
+        .clock = true, .ss0 = false, .ss1 = false,   .ss2 = false,
+        .miso = true,  .mosi = true, .sdio2 = false, .sdio3 = false,
+    };
+
+    MXC_SPI_Init(TS_SPI, master, quadMode, numSlaves, ssPol, TS_SPI_FREQ, ts_pins);
+
+    // Set SPI pins to VDDIOH (3.3V) to be compatible with TFT display
+    MXC_GPIO_SetVSSEL(MXC_GPIO0, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7);
+    MXC_SPI_SetDataSize(TS_SPI, 8);
+    MXC_SPI_SetWidth(TS_SPI, SPI_WIDTH_STANDARD);
+
+    // Configure Slave Select and IRQ GPIOs
+    MXC_GPIO_Config(&ts_irq_pin);
+    MXC_GPIO_Config(&ts_ss_pin);
+    MXC_GPIO_OutSet(ts_ss_pin.port, ts_ss_pin.mask);
+}
+
+void TS_SPI_Transmit(uint8_t datain, uint16_t *dataout)
+{
+    int i;
+    uint8_t rx[2] = { 0, 0 };
+    mxc_spi_req_t request;
+
+    request.spi = TS_SPI;
+    request.ssDeassert = 0;
+    request.txData = (uint8_t *)(&datain);
+    request.rxData = NULL;
+    request.txLen = 1;
+    request.rxLen = 0;
+    request.ssIdx = 0;
+
+    MXC_SPI_SetFrequency(TS_SPI, TS_SPI_FREQ);
+    MXC_SPI_SetDataSize(TS_SPI, 8);
+
+    // Software controlled Slave Select
+    MXC_GPIO_OutClr(ts_ss_pin.port, ts_ss_pin.mask);
+
+    MXC_SPI_MasterTransaction(&request);
+
+    // Wait to clear TS busy signal
+    for (i = 0; i < 200; i++) {
+        __asm volatile("nop\n");
+    }
+
+    request.ssDeassert = 1;
+    request.txData = NULL;
+    request.rxData = (uint8_t *)(rx);
+    request.txLen = 0;
+    request.rxLen = 2;
+
+    MXC_SPI_MasterTransaction(&request);
+
+    // MAX78002 Evaluation Kit is designed for firmware control of device select.
+    // Wait here until done as caller will negate select on return, possibly before FIFO is empty.
+    while (!(TS_SPI->intfl & MXC_F_SPI_INTFL_MST_DONE)) {}
+
+    TS_SPI->intfl = TS_SPI->intfl;
+
+    if (dataout != NULL) {
+        *dataout = (rx[1] | (rx[0] << 8)) >> 4;
+    }
+
+    MXC_GPIO_OutSet(ts_ss_pin.port, ts_ss_pin.mask);
 }
 #endif // TFT_NEWHAVEN
 
@@ -211,6 +307,15 @@ int Board_Init(void)
         MXC_ASSERT_FAIL();
         return err;
     }
+
+#ifdef TFT_NEWHAVEN
+    // Set falling edge triggered interrupt for TouchScreen
+    // MXC_TS_PreInit is not used because we need to take more direct
+    // control of SPI routines and initialization 
+    ts_irq_pin.port->intmode |= ts_irq_pin.mask;
+    ts_irq_pin.port->intpol &= ~(ts_irq_pin.mask);
+    MXC_TS_AssignInterruptPin(ts_irq_pin);
+#endif
 
 // AI87-TODO: What's the reason for this deletion?
 // MXC_SIMO->vrego_c = 0x43; // Set CNN voltage

--- a/Libraries/Boards/MAX78002/EvKit_V1/board.mk
+++ b/Libraries/Boards/MAX78002/EvKit_V1/board.mk
@@ -54,6 +54,11 @@ ifeq "$(TFT)" "NEWHAVEN"
 PROJ_CFLAGS+=-DTFT_NEWHAVEN
 SRCS += tft_st7789v.c
 # NewHaven TFT board has an integrated tsc2046 touchscreen driver
+# The TFT display is typically oriented with a 270 degree rotation,
+# so we need to flip the screen and swap the X,Y coordinates for
+# the touchscreen drivers to match it.
+PROJ_CFLAGS += -DFLIP_SCREEN
+PROJ_CFLAGS += -DSWAP_XY
 SRCS += tsc2046.c
 endif
 SRCS += camera.c

--- a/Libraries/Boards/MAX78002/EvKit_V1/board.mk
+++ b/Libraries/Boards/MAX78002/EvKit_V1/board.mk
@@ -53,6 +53,8 @@ endif
 ifeq "$(TFT)" "NEWHAVEN"
 PROJ_CFLAGS+=-DTFT_NEWHAVEN
 SRCS += tft_st7789v.c
+# NewHaven TFT board has an integrated tsc2046 touchscreen driver
+SRCS += tsc2046.c
 endif
 SRCS += camera.c
 SRCS += mipi_camera.c

--- a/Libraries/MiscDrivers/Touchscreen/tsc2046.c
+++ b/Libraries/MiscDrivers/Touchscreen/tsc2046.c
@@ -142,8 +142,8 @@ static void tsHandler(void)
         if (pressed_key == 0) { // wait until prev key process
             for (i = 0; i < TS_MAX_BUTTONS; i++) {
                 if (ts_buttons[i].key_code != TS_INVALID_KEY_CODE) {
-                    if (is_inBox(g_x, g_y, ts_buttons[i].x0, ts_buttons[i].y0,
-                                 ts_buttons[i].x1, ts_buttons[i].y1)) {
+                    if (is_inBox(g_x, g_y, ts_buttons[i].x0, ts_buttons[i].y0, ts_buttons[i].x1,
+                                 ts_buttons[i].y1)) {
                         // pressed key
                         pressed_key = ts_buttons[i].key_code;
                         break;
@@ -158,7 +158,8 @@ static void tsHandler(void)
     MXC_TS_Start();
 }
 
-int MXC_TS_AssignInterruptPin(mxc_gpio_cfg_t pin) {
+int MXC_TS_AssignInterruptPin(mxc_gpio_cfg_t pin)
+{
     if (pin.port) {
         int_gpio = pin;
         return E_NO_ERROR;
@@ -233,16 +234,19 @@ void MXC_TS_Stop(void)
     TS_SPI_Transmit(TSC_STOP, NULL);
 }
 
-void MXC_TS_GetXY(unsigned int *x, unsigned int *y) {
+void MXC_TS_GetXY(unsigned int *x, unsigned int *y)
+{
     *x = g_x;
     *y = g_y;
 }
 
-int MXC_TS_GetTSEvent() {
+int MXC_TS_GetTSEvent()
+{
     return ts_event;
 }
 
-void MXC_TS_ClearTSEvent() {
+void MXC_TS_ClearTSEvent()
+{
     ts_event = false;
 }
 

--- a/Libraries/MiscDrivers/Touchscreen/tsc2046.c
+++ b/Libraries/MiscDrivers/Touchscreen/tsc2046.c
@@ -45,6 +45,9 @@
 #ifndef FLIP_SCREEN
 #define FLIP_SCREEN 0
 #endif
+#ifndef SWAP_XY
+#define SWAP_XY 0
+#endif
 #ifndef ROTATE_SCREEN
 #define ROTATE_SCREEN 0
 #endif
@@ -93,9 +96,15 @@ static int tsGetXY(uint16_t *x, uint16_t *y)
     TS_SPI_Transmit(TSC_DIFFZ1, &tsZ1);
 
     if (tsZ1 & 0x7F0) {
-        TS_SPI_Transmit(TSC_DIFFX, &tsX);
-        *x = tsX * 320 / 0x7FF;
+#if (SWAP_XY == 1)
+        TS_SPI_Transmit(TSC_DIFFY, &tsX);
+        TS_SPI_Transmit(TSC_DIFFX, &tsY);
+#else
         TS_SPI_Transmit(TSC_DIFFY, &tsY);
+        TS_SPI_Transmit(TSC_DIFFX, &tsX);
+#endif
+
+        *x = tsX * 320 / 0x7FF;
         *y = tsY * 240 / 0x7FF;
 
         // Wait Release

--- a/Libraries/MiscDrivers/Touchscreen/tsc2046.h
+++ b/Libraries/MiscDrivers/Touchscreen/tsc2046.h
@@ -71,6 +71,28 @@ typedef struct {
 
 /************************************************************************************/
 
+// SPI Transport layer functions
+
+/**
+ * @brief       Initialize the SPI instance connected to the TouchScreen driver.
+ *              Board files must implement this.
+ */
+extern void TS_SPI_Init(void);
+
+/**
+ * @brief       Send a byte of data to the TouchScreen driver over SPI.
+ *              Board files must implement this.
+ * 
+ * @param       datain      Input value to write
+ * @param[out]  dataout     Output pointer.  This function will decode and save
+ *                          the SPI response to this pointer.
+ */
+extern void TS_SPI_Transmit(uint8_t datain, uint16_t *dataout);
+
+/************************************************************************************/
+
+int MXC_TS_AssignInterruptPin(mxc_gpio_cfg_t pin);
+
 /**
  * @brief      Used to register hw related configuration, need to be called before MXC_TS_Init()
  *
@@ -101,6 +123,25 @@ void MXC_TS_Start(void);
  *
  */
 void MXC_TS_Stop(void);
+
+/**
+ * @brief      Get the x,y coordinates of the last touchscreen press
+ *
+ * @param[out] x    (Output) Where to save the x coordinate
+ * @param[out] y    (Output) Where to save the y coordinate
+ */
+void MXC_TS_GetXY(unsigned int *x, unsigned int *y);
+
+/**
+ * @brief       Returns true if there is a touchscreen event pending,
+ *              otherwise returns false.
+ */
+int MXC_TS_GetTSEvent();
+
+/**
+ * @brief      Clears the pending touchscreen event flag.
+ */
+void MXC_TS_ClearTSEvent();
 
 /**
  * @brief      Register a button


### PR DESCRIPTION
This PR adds touchscreen support for the AI87 EVKIT (tsc2046.c)

The SPI transport layer had to be moved out of the tsc2046.c file and into the board files.  The AI87 EVKIT requires software control of the Chip Select pin, and additionally does not have the TS_BUSY signal routed, so its SPI transport function differs completely from the old one.

Currently, the drivers and hardware works but there is a mismatch between the TFT display's coordinate system and the touchscreen's.  This can most likely be fixed in software by post-processing the X,Y coordinates returned from the touchscreen to match the TFT.  I've already tried swapping x,y values alongside various `FLIP_SCREEN` and `ROTATE_SCREEN` combinations, but haven't successfully matched the correct coordinates yet.