### PR TITLE
Configure ERTCO enable bit.

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.svd
@@ -89,7 +89,7 @@
    <baseAddress>0x40007400</baseAddress>
    <addressBlock>
     <offset>0x00</offset>
-    <size>0x800</size>
+    <size>0x400</size>
     <usage>registers</usage>
    </addressBlock>
    <registers>
@@ -1745,7 +1745,7 @@
     <register>
      <dim>4</dim>
      <dimIncrement>4</dimIncrement>
-     <name>DATA</name>
+     <name>DATA[%s]</name>
      <description>Flash Write Data.</description>
      <addressOffset>0x30</addressOffset>
      <fields>
@@ -5495,7 +5495,7 @@
    <baseAddress>0x4002A000</baseAddress>
    <addressBlock>
     <offset>0x00</offset>
-    <size>0x400</size>
+    <size>0x800</size>
     <usage>registers</usage>
    </addressBlock>
    <registers>
@@ -6216,14 +6216,8 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
-       <name>TM_LPMODE</name>
-       <description>TBD</description>
-       <bitOffset>30</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>TM_PWRSEQ</name>
-       <description>TBD</description>
+       <name>ERTCO_PD</name>
+       <description>ERTCO Powerdown.</description>
        <bitOffset>31</bitOffset>
        <bitWidth>1</bitWidth>
       </field>

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/pwrseq_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/pwrseq_regs.h
@@ -186,11 +186,8 @@ typedef struct {
 #define MXC_F_PWRSEQ_LPCN_ERTCO_EN_POS                 29 /**< LPCN_ERTCO_EN Position */
 #define MXC_F_PWRSEQ_LPCN_ERTCO_EN                     ((uint32_t)(0x1UL << MXC_F_PWRSEQ_LPCN_ERTCO_EN_POS)) /**< LPCN_ERTCO_EN Mask */
 
-#define MXC_F_PWRSEQ_LPCN_TM_LPMODE_POS                30 /**< LPCN_TM_LPMODE Position */
-#define MXC_F_PWRSEQ_LPCN_TM_LPMODE                    ((uint32_t)(0x1UL << MXC_F_PWRSEQ_LPCN_TM_LPMODE_POS)) /**< LPCN_TM_LPMODE Mask */
-
-#define MXC_F_PWRSEQ_LPCN_TM_PWRSEQ_POS                31 /**< LPCN_TM_PWRSEQ Position */
-#define MXC_F_PWRSEQ_LPCN_TM_PWRSEQ                    ((uint32_t)(0x1UL << MXC_F_PWRSEQ_LPCN_TM_PWRSEQ_POS)) /**< LPCN_TM_PWRSEQ Mask */
+#define MXC_F_PWRSEQ_LPCN_ERTCO_PD_POS                 31 /**< LPCN_ERTCO_PD Position */
+#define MXC_F_PWRSEQ_LPCN_ERTCO_PD                     ((uint32_t)(0x1UL << MXC_F_PWRSEQ_LPCN_ERTCO_PD_POS)) /**< LPCN_ERTCO_PD Mask */
 
 /**@} end of group PWRSEQ_LPCN_Register */
 

--- a/Libraries/PeriphDrivers/Source/LP/pwrseq_me16.svd
+++ b/Libraries/PeriphDrivers/Source/LP/pwrseq_me16.svd
@@ -322,14 +322,8 @@
             <bitWidth>1</bitWidth>
           </field>
           <field>
-            <name>TM_LPMODE</name>
-            <description>TBD</description>
-            <bitOffset>30</bitOffset>
-            <bitWidth>1</bitWidth>
-          </field>
-          <field>
-            <name>TM_PWRSEQ</name>
-            <description>TBD</description>
+            <name>ERTCO_PD</name>
+            <description>Powerdown ERTCO.</description>
             <bitOffset>31</bitOffset>
             <bitWidth>1</bitWidth>
           </field>

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -158,6 +158,7 @@ void MXC_SYS_ClockEnable(mxc_sys_periph_clock_t clock)
 /* ************************************************************************** */
 void MXC_SYS_RTCClockEnable()
 {
+    MXC_PWRSEQ->lpcn &= ~(MXC_F_PWRSEQ_LPCN_ERTCO_PD);
     MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
 }
 
@@ -167,6 +168,7 @@ int MXC_SYS_RTCClockDisable(void)
     /* Check that the RTC is not the system clock source */
     if ((MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_SEL) != MXC_S_GCR_CLKCTRL_SYSCLK_SEL_ERTCO) {
         MXC_GCR->clkctrl &= ~MXC_F_GCR_CLKCTRL_ERTCO_EN;
+        MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_ERTCO_PD;
         return E_NO_ERROR;
     } else {
         return E_BAD_STATE;
@@ -204,7 +206,7 @@ int MXC_SYS_ClockSourceEnable(mxc_sys_system_clock_t clock)
         break;
 
     case MXC_SYS_CLOCK_ERTCO:
-        MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
+        MXC_SYS_RTCClockEnable();
         return MXC_SYS_Clock_Timeout(MXC_F_GCR_CLKCTRL_ERTCO_RDY);
         break;
 
@@ -248,8 +250,7 @@ int MXC_SYS_ClockSourceDisable(mxc_sys_system_clock_t clock)
         break;
 
     case MXC_SYS_CLOCK_ERTCO:
-        MXC_GCR->clkctrl &= ~MXC_F_GCR_CLKCTRL_ERTCO_EN;
-        break;
+        return MXC_SYS_RTCClockDisable();
 
     default:
         return E_BAD_PARAM;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -151,6 +151,7 @@ void MXC_SYS_ClockEnable(mxc_sys_periph_clock_t clock)
 /* ************************************************************************** */
 void MXC_SYS_RTCClockEnable()
 {
+    MXC_PWRSEQ->lpcn &= ~(MXC_F_PWRSEQ_LPCN_TM_PWRSEQ);
     MXC_GCR->clkctrl |= MXC_F_MCR_CLKCTRL_ERTCO_EN;
 }
 
@@ -160,6 +161,7 @@ int MXC_SYS_RTCClockDisable(void)
     /* Check that the RTC is not the system clock source */
     if ((MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_SEL) != MXC_S_GCR_CLKCTRL_SYSCLK_SEL_ERTCO) {
         MXC_GCR->clkctrl &= ~MXC_F_MCR_CLKCTRL_ERTCO_EN;
+        MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_TM_PWRSEQ;
         return E_NO_ERROR;
     } else {
         return E_BAD_STATE;
@@ -195,9 +197,7 @@ int MXC_SYS_ClockSourceEnable(mxc_sys_system_clock_t clock)
         break;
 
     case MXC_SYS_CLOCK_ERTCO:
-        MXC_MCR->clkctrl |= MXC_F_MCR_CLKCTRL_ERTCO_EN;
-        MXC_MCR->clkctrl &= ~(MXC_F_MCR_CLKCTRL_ERTCO_PD);
-
+        MXC_SYS_RTCClockEnable();
         return MXC_SYS_Clock_Timeout(MXC_F_GCR_CLKCTRL_ERTCO_RDY);
         break;
 
@@ -241,8 +241,7 @@ int MXC_SYS_ClockSourceDisable(mxc_sys_system_clock_t clock)
         break;
 
     case MXC_SYS_CLOCK_ERTCO:
-        MXC_GCR->clkctrl &= ~MXC_F_MCR_CLKCTRL_ERTCO_EN;
-        break;
+        return MXC_SYS_RTCClockDisable();
 
     default:
         return E_BAD_PARAM;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -52,6 +52,7 @@
 #include "gcr_regs.h"
 #include "fcr_regs.h"
 #include "mcr_regs.h"
+#include "pwrseq_regs.h"
 
 /**
  * @ingroup mxc_sys

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -153,6 +153,7 @@ void MXC_SYS_RTCClockEnable()
 {
     MXC_PWRSEQ->lpcn &= ~(MXC_F_PWRSEQ_LPCN_TM_PWRSEQ);
     MXC_GCR->clkctrl |= MXC_F_MCR_CLKCTRL_ERTCO_EN;
+    MXC_MCR->clkctrl &= ~(MXC_F_MCR_CLKCTRL_ERTCO_PD);
 }
 
 /* ************************************************************************** */
@@ -162,6 +163,7 @@ int MXC_SYS_RTCClockDisable(void)
     if ((MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_SEL) != MXC_S_GCR_CLKCTRL_SYSCLK_SEL_ERTCO) {
         MXC_GCR->clkctrl &= ~MXC_F_MCR_CLKCTRL_ERTCO_EN;
         MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_TM_PWRSEQ;
+        MXC_MCR->clkctrl |= MXC_F_MCR_CLKCTRL_ERTCO_PD;
         return E_NO_ERROR;
     } else {
         return E_BAD_STATE;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -153,7 +153,7 @@ void MXC_SYS_ClockEnable(mxc_sys_periph_clock_t clock)
 void MXC_SYS_RTCClockEnable()
 {
     MXC_PWRSEQ->lpcn &= ~(MXC_F_PWRSEQ_LPCN_TM_PWRSEQ);
-    MXC_GCR->clkctrl |= MXC_F_MCR_CLKCTRL_ERTCO_EN;
+    MXC_MCR->clkctrl |= MXC_F_MCR_CLKCTRL_ERTCO_EN;
     MXC_MCR->clkctrl &= ~(MXC_F_MCR_CLKCTRL_ERTCO_PD);
 }
 
@@ -162,7 +162,7 @@ int MXC_SYS_RTCClockDisable(void)
 {
     /* Check that the RTC is not the system clock source */
     if ((MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_SEL) != MXC_S_GCR_CLKCTRL_SYSCLK_SEL_ERTCO) {
-        MXC_GCR->clkctrl &= ~MXC_F_MCR_CLKCTRL_ERTCO_EN;
+        MXC_MCR->clkctrl &= ~MXC_F_MCR_CLKCTRL_ERTCO_EN;
         MXC_PWRSEQ->lpcn |= MXC_F_PWRSEQ_LPCN_TM_PWRSEQ;
         MXC_MCR->clkctrl |= MXC_F_MCR_CLKCTRL_ERTCO_PD;
         return E_NO_ERROR;


### PR DESCRIPTION
The B revisions of the MAX32670 and MAX32672 have a new RTC enable bit in the PWRSEQ register.  This PR properly configures this bit when enabling/disabling the ERTCO.