### PR TITLE
ME12: Removed LP registers relating to non-existent port 1.

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.svd
@@ -933,7 +933,7 @@
    <baseAddress>0x40207400</baseAddress>
    <addressBlock>
     <offset>0x00</offset>
-    <size>0x800</size>
+    <size>0x400</size>
     <usage>registers</usage>
    </addressBlock>
    <registers>
@@ -8636,32 +8636,6 @@ domain.</description>
        <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
        <bitOffset>0</bitOffset>
        <bitWidth>31</bitWidth>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>LPWKFL1</name>
-     <description>Low Power I/O Wakeup Status Flag Register 1. This register indicates the low power wakeup status for GPIO1.</description>
-     <addressOffset>0x0C</addressOffset>
-     <fields>
-      <field>
-       <name>WAKEFL</name>
-       <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>10</bitWidth>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>LPWKEN1</name>
-     <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
-     <addressOffset>0x10</addressOffset>
-     <fields>
-      <field>
-       <name>WAKEEN</name>
-       <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>10</bitWidth>
       </field>
      </fields>
     </register>

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/pwrseq_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/pwrseq_regs.h
@@ -89,9 +89,7 @@ typedef struct {
     __IO uint32_t lpctrl;               /**< <tt>\b 0x00:</tt> PWRSEQ LPCTRL Register */
     __IO uint32_t lpwkfl0;              /**< <tt>\b 0x04:</tt> PWRSEQ LPWKFL0 Register */
     __IO uint32_t lpwken0;              /**< <tt>\b 0x08:</tt> PWRSEQ LPWKEN0 Register */
-    __IO uint32_t lpwkfl1;              /**< <tt>\b 0x0C:</tt> PWRSEQ LPWKFL1 Register */
-    __IO uint32_t lpwken1;              /**< <tt>\b 0x10:</tt> PWRSEQ LPWKEN1 Register */
-    __R  uint32_t rsv_0x14_0x2f[7];
+    __R  uint32_t rsv_0xc_0x2f[9];
     __IO uint32_t lppwkfl;              /**< <tt>\b 0x30:</tt> PWRSEQ LPPWKFL Register */
     __IO uint32_t lppwken;              /**< <tt>\b 0x34:</tt> PWRSEQ LPPWKEN Register */
     __R  uint32_t rsv_0x38_0x3f[2];
@@ -108,8 +106,6 @@ typedef struct {
 #define MXC_R_PWRSEQ_LPCTRL                ((uint32_t)0x00000000UL) /**< Offset from PWRSEQ Base Address: <tt> 0x0000</tt> */
 #define MXC_R_PWRSEQ_LPWKFL0               ((uint32_t)0x00000004UL) /**< Offset from PWRSEQ Base Address: <tt> 0x0004</tt> */
 #define MXC_R_PWRSEQ_LPWKEN0               ((uint32_t)0x00000008UL) /**< Offset from PWRSEQ Base Address: <tt> 0x0008</tt> */
-#define MXC_R_PWRSEQ_LPWKFL1               ((uint32_t)0x0000000CUL) /**< Offset from PWRSEQ Base Address: <tt> 0x000C</tt> */
-#define MXC_R_PWRSEQ_LPWKEN1               ((uint32_t)0x00000010UL) /**< Offset from PWRSEQ Base Address: <tt> 0x0010</tt> */
 #define MXC_R_PWRSEQ_LPPWKFL               ((uint32_t)0x00000030UL) /**< Offset from PWRSEQ Base Address: <tt> 0x0030</tt> */
 #define MXC_R_PWRSEQ_LPPWKEN               ((uint32_t)0x00000034UL) /**< Offset from PWRSEQ Base Address: <tt> 0x0034</tt> */
 #define MXC_R_PWRSEQ_LPMEMSD               ((uint32_t)0x00000040UL) /**< Offset from PWRSEQ Base Address: <tt> 0x0040</tt> */
@@ -212,30 +208,6 @@ typedef struct {
 #define MXC_F_PWRSEQ_LPWKEN0_WAKEEN                    ((uint32_t)(0x7FFFFFFFUL << MXC_F_PWRSEQ_LPWKEN0_WAKEEN_POS)) /**< LPWKEN0_WAKEEN Mask */
 
 /**@} end of group PWRSEQ_LPWKEN0_Register */
-
-/**
- * @ingroup  pwrseq_registers
- * @defgroup PWRSEQ_LPWKFL1 PWRSEQ_LPWKFL1
- * @brief    Low Power I/O Wakeup Status Flag Register 1. This register indicates the low
- *           power wakeup status for GPIO1.
- * @{
- */
-#define MXC_F_PWRSEQ_LPWKFL1_WAKEFL_POS                0 /**< LPWKFL1_WAKEFL Position */
-#define MXC_F_PWRSEQ_LPWKFL1_WAKEFL                    ((uint32_t)(0x3FFUL << MXC_F_PWRSEQ_LPWKFL1_WAKEFL_POS)) /**< LPWKFL1_WAKEFL Mask */
-
-/**@} end of group PWRSEQ_LPWKFL1_Register */
-
-/**
- * @ingroup  pwrseq_registers
- * @defgroup PWRSEQ_LPWKEN1 PWRSEQ_LPWKEN1
- * @brief    Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup
- *           functionality for GPIO1.
- * @{
- */
-#define MXC_F_PWRSEQ_LPWKEN1_WAKEEN_POS                0 /**< LPWKEN1_WAKEEN Position */
-#define MXC_F_PWRSEQ_LPWKEN1_WAKEEN                    ((uint32_t)(0x3FFUL << MXC_F_PWRSEQ_LPWKEN1_WAKEEN_POS)) /**< LPWKEN1_WAKEEN Mask */
-
-/**@} end of group PWRSEQ_LPWKEN1_Register */
 
 /**
  * @ingroup  pwrseq_registers

--- a/Libraries/PeriphDrivers/Source/LP/lp_me12.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me12.c
@@ -178,7 +178,6 @@ void MXC_LP_ClearWakeStatus(void)
 {
     /* Write 1 to clear */
     MXC_PWRSEQ->lpwkfl0 = 0xFFFFFFFF;
-    MXC_PWRSEQ->lpwkfl1 = 0xFFFFFFFF;
     MXC_PWRSEQ->lppwkfl = 0xFFFFFFFF;
 }
 
@@ -201,7 +200,7 @@ void MXC_LP_DisableGPIOWakeup(const mxc_gpio_cfg_t *wu_pins)
         break;
     }
 
-    if (MXC_PWRSEQ->lpwken1 == 0 && MXC_PWRSEQ->lpwken0 == 0) {
+    if (MXC_PWRSEQ->lpwken0 == 0) {
         MXC_GCR->pm &= ~MXC_F_GCR_PM_GPIO_WE;
     }
 }

--- a/Libraries/PeriphDrivers/Source/LP/pwrseq_me12.svd
+++ b/Libraries/PeriphDrivers/Source/LP/pwrseq_me12.svd
@@ -279,32 +279,6 @@ domain.</description>
         </fields>
       </register>
       <register>
-        <name>LPWKFL1</name>
-        <description>Low Power I/O Wakeup Status Flag Register 1. This register indicates the low power wakeup status for GPIO1.</description>
-        <addressOffset>0x0C</addressOffset>
-        <fields>
-          <field>
-            <name>WAKEFL</name>
-            <description>Wakeup IRQ flags (write ones to clear). One or more of these bits will be set when the corresponding dedicated GPIO pin (s) transition (s) from low to high or high to low. If GPIO wakeup source is selected, using PM.GPIOWKEN register, and the corresponding bit is also selected in LPWKEN register, an interrupt will be gnerated to wake up the CPU from a low power mode.</description>
-            <bitOffset>0</bitOffset>
-            <bitWidth>10</bitWidth>
-          </field>
-        </fields>
-      </register>
-      <register>
-        <name>LPWKEN1</name>
-        <description>Low Power I/O Wakeup Enable Register 1. This register enables low power wakeup functionality for GPIO1.</description>
-        <addressOffset>0x10</addressOffset>
-        <fields>
-          <field>
-            <name>WAKEEN</name>
-            <description>Enable wakeup. These bits allow wakeup from the corresponding GPIO pin (s) on transition (s) from low to high or high to low when PM.GPIOWKEN is set. Wakeup status is indicated in PPWKST register.</description>
-            <bitOffset>0</bitOffset>
-            <bitWidth>10</bitWidth>
-          </field>
-        </fields>
-      </register>
-      <register>
         <name>LPPWKFL</name>
         <description>Low Power Peripheral Wakeup Status Flag Register.</description>
         <addressOffset>0x30</addressOffset>


### PR DESCRIPTION
ME12 doesn't have a port 1, so PWRSEQ LPWKFL1 and LPWKEN1 registers should be removed.