### PR TITLE
AI85 TFT_Demo: Fix build issue for BOARD=FTHR_RevA, enable TFT by default

### DIFF
--- a/Examples/MAX78000/CameraIF/project.mk
+++ b/Examples/MAX78000/CameraIF/project.mk
@@ -5,10 +5,6 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
-
 # **********************************************************
 
 # Add your config here!
@@ -22,6 +18,6 @@ CAMERA=OV7692
 #CAMERA=HM0360_MONO
 #CAMERA=HM01B0
 
-#MAKECMDGOALS=release
-
-#BOARD=FTHR_RevA
+# Set optimization level to -O2, which is required for the CameraIF DMA
+# timing to work properly.
+MXC_OPTIMIZE_CFLAGS=-O2

--- a/Examples/MAX78000/CameraIF_Debayer/project.mk
+++ b/Examples/MAX78000/CameraIF_Debayer/project.mk
@@ -11,5 +11,6 @@
 # These are the only drivers supported by this example.
 CAMERA=HM0360_COLOR
 
-# Enable optimization level 2 (faster code but this should be turned off for debugging)
+# Set optimization level to -O2, which is required for the CameraIF DMA
+# timing to work properly.
 MXC_OPTIMIZE_CFLAGS = -O2

--- a/Examples/MAX78000/TFT_Demo/example_config.h
+++ b/Examples/MAX78000/TFT_Demo/example_config.h
@@ -36,23 +36,20 @@
 
 #include "board.h"
 
+// Enable TFT display
+#define ENABLE_TFT
+
+// Board specific options...
+// ---
 #ifdef BOARD_EVKIT_V1
 #include "tft_ssd2119.h"
 #include "bitmap.h"
-
-// Enable TFT display
-#define ENABLE_TFT
-// Enable Touchscreen
 #define ENABLE_TS
 #endif
 
 #ifdef BOARD_FTHR_REVA
 #include "tft_ili9341.h"
-
-// Enable TFT display
-// #define ENABLE_TFT
-// Enable Touchscreen
-// #define ENABLE_TS
 #endif
+// ---
 
 #endif // EXAMPLES_MAX78000_TFT_DEMO_EXAMPLE_CONFIG_H_

--- a/Examples/MAX78000/TFT_Demo/main.c
+++ b/Examples/MAX78000/TFT_Demo/main.c
@@ -98,7 +98,7 @@ void TFT_Feather_test(void)
     MXC_Delay(1000000);
     MXC_TFT_Circle(100, 100, 50, PURPLE);
     MXC_Delay(1000000);
-    MXC_TFT_FillCircle(150, 50, 40, PURPLE);
+    MXC_TFT_FillCircle(100, 100, 50, PURPLE);
     MXC_Delay(1000000);
 
     MXC_TFT_SetBackGroundColor(BLACK);

--- a/Examples/MAX78000/TFT_Demo/src/state_home.c
+++ b/Examples/MAX78000/TFT_Demo/src/state_home.c
@@ -39,7 +39,7 @@
 #include "bitmap.h"
 #include "keypad.h"
 #include "state.h"
-#include "tft_ssd2119.h"
+#include "example_config.h"
 
 /*********************************      DEFINES      *************************/
 #define TICK_TIMEOUT 2000

--- a/Examples/MAX78000/TFT_Demo/src/state_info.c
+++ b/Examples/MAX78000/TFT_Demo/src/state_info.c
@@ -40,7 +40,7 @@
 #include "keypad.h"
 #include "state.h"
 #include "utils.h"
-#include "tft_ssd2119.h"
+#include "example_config.h"
 
 //
 #define urw_gothic_16_white_bg_grey 0

--- a/Examples/MAX78000/TFT_Demo/src/state_keypad.c
+++ b/Examples/MAX78000/TFT_Demo/src/state_keypad.c
@@ -39,7 +39,7 @@
 #include "bitmap.h"
 #include "keypad.h"
 #include "state.h"
-#include "tft_ssd2119.h"
+#include "example_config.h"
 
 /*********************************      DEFINES      *************************/
 #define BUTTON_SIZE_X 42 + 4 // 6 for free space

--- a/Libraries/MiscDrivers/Display/tft_ili9341.h
+++ b/Libraries/MiscDrivers/Display/tft_ili9341.h
@@ -46,8 +46,7 @@
 /************************************ DEFINES ********************************/
 #define DISPLAY_WIDTH 320
 #define DISPLAY_HEIGHT 240
-//#define TFT_SPI_FREQ  10000000 // Hz
-#define TFT_SPI_FREQ 25000000 // Hz
+#define TFT_SPI_FREQ  10000000 // Hz
 #define TFT_SPI0_PINS MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7 | MXC_GPIO_PIN_11
 /************************************************************************************/
 typedef struct {

--- a/Libraries/MiscDrivers/Display/tft_ili9341.h
+++ b/Libraries/MiscDrivers/Display/tft_ili9341.h
@@ -46,7 +46,7 @@
 /************************************ DEFINES ********************************/
 #define DISPLAY_WIDTH 320
 #define DISPLAY_HEIGHT 240
-#define TFT_SPI_FREQ  10000000 // Hz
+#define TFT_SPI_FREQ 10000000 // Hz
 #define TFT_SPI0_PINS MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7 | MXC_GPIO_PIN_11
 /************************************************************************************/
 typedef struct {


### PR DESCRIPTION
- Remove hard-coded inclusions of the EVKIT's TFT header file in state machine files
- Set `TFT_ENABLE` by default in example_config.h
- Remove TS_ENABLE for FTHR board (no drivers, demo holds after TFT test finishes)
- Reduce ili_9341 driver speed back to 10Mhz

The project should now build cleanly with `make BOARD=FTHR_RevA`

```shell
❯ make BOARD=FTHR_RevA
Loaded project.mk
  CC    resources/tft_fthr/Arial12x12.c
  CC    resources/tft_fthr/Arial24x23.c
  CC    resources/tft_fthr/Arial28x28.c
  CC    resources/tft_fthr/SansSerif16x16.c
  CC    resources/tft_fthr/SansSerif19x19.c
  CC    resources/tft_fthr/img_1_rgb565.c
  CC    main.c
  CC    src/state.c
  CC    src/state_home.c
  CC    src/state_info.c
  CC    src/state_keypad.c
  CC    src/utils.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/Source/board.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/stdio.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/LED/led.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/PushButton/pb.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/Display/tft_ili9341.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/Camera/camera.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/Camera/ov7692.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/Camera/sccb.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/PMIC/max20303.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/Boards/MAX78000/FTHR_RevA/../../../MiscDrivers/CODEC/max9867.c
  AS    /home/jakecarter/repos/fork/msdk/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/startup_max78000.S
  CC    /home/jakecarter/repos/fork/msdk/Libraries/CMSIS/Device/Maxim/MAX78000/Source/heap.c
  CC    /home/jakecarter/repos/fork/msdk/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
  LD    /home/jakecarter/repos/fork/msdk/Examples/MAX78000/TFT_Demo/build/max78000.elf
arm-none-eabi-size --format=berkeley /home/jakecarter/repos/fork/msdk/Examples/MAX78000/TFT_Demo/build/max78000.elf
   text    data     bss     dec     hex filename
 223460    2504    1268  227232   377a0 /home/jakecarter/repos/fork/msdk/Examples/MAX78000/TFT_Demo/build/max78000.elf
```