### PR TITLE
Fix ME15, ME16, ME21 SRAM Sections for ECC

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670.ld
@@ -36,7 +36,13 @@
 
 MEMORY {
     FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 384kB "FLASH" */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB SRAM */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K /* 160kB SRAM with ECC*/
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB SRAM, no ECC */
+    
 }
 
 SECTIONS {

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670_ram.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670_ram.ld
@@ -36,8 +36,13 @@
 
 MEMORY {
     ROM (rx)   : ORIGIN = 0x00000000, LENGTH = 0x00020000 /* 128kB ROM */
-    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 256kB "FLASH" */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 760kB SRAM */
+    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 384kB "FLASH" */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K /* 160kB SRAM with ECC*/
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB SRAM, no ECC */
 }
 
 SECTIONS {

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670_spix.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670_spix.ld
@@ -35,8 +35,13 @@
  ******************************************************************************/
 MEMORY {
     ROM (rx)   : ORIGIN = 0x00000000, LENGTH = 0x00020000 /* 128kB ROM */
-    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 0x00100000 /* 1MB flash */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x000BE000 /* 760kB SRAM */
+    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 384kB "FLASH" */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K /* 160kB SRAM with ECC*/
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB SRAM, no ECC */
 
     XIP_0 (rx)   : ORIGIN = 0x08000000, LENGTH = 0x00010000
     XIP_1 (rx)   : ORIGIN = 0x08010000, LENGTH = 0x00010000

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672.ld
@@ -36,7 +36,12 @@
 
 MEMORY {
     FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 1024K /* 1024kB "FLASH" */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB with ECC (200kB SRAM) */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 200kB SRAM with ECC */
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 200K /* 200kB SRAM, no ECC */
 }
 
 SECTIONS {

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672_ram.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672_ram.ld
@@ -37,7 +37,12 @@
 MEMORY {
     ROM (rx)   : ORIGIN = 0x00000000, LENGTH = 0x00020000 /* 128kB ROM */
     FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 1024K /* 1024kB "FLASH" */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 200K /* 160kB with ECC (200kB SRAM) */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 200kB SRAM with ECC */
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 200K /* 200kB SRAM, no ECC */
 }
 
 SECTIONS {

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672_scpa.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672_scpa.ld
@@ -35,7 +35,12 @@
 MEMORY {
     ROM (rx)   : ORIGIN = 0x00000000, LENGTH = 0x00020000 /* 128kB ROM */
     FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 1024K /* 1024kB "FLASH" */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 200K /* 200kB SRAM */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 200kB SRAM with ECC */
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 200K /* 200kB SRAM, no ECC */
 }
 
 /*

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672_sla.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672_sla.ld
@@ -37,7 +37,12 @@
 MEMORY {
     HEADER (rx) : ORIGIN = 0x10000000, LENGTH = 0x200
     FLASH (rx)  : ORIGIN = 0x10000200, LENGTH = 1024K - 0x200 /* 1024kB "FLASH" */
-    SRAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 200K /* 200kB SRAM */
+    SRAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 160K /* 200kB with ECC */
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 200K /* 200kB SRAM, no ECC */
 }
 
 ENTRY(Reset_Handler)

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675.ld
@@ -35,8 +35,13 @@
  ******************************************************************************/
 
 MEMORY {
-    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 256kB "FLASH" */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 760kB SRAM */
+    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 384kB "FLASH" */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K /* 160kB SRAM with ECC*/
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB SRAM, no ECC */
 }
 
 SECTIONS {

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675_ram.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675_ram.ld
@@ -36,8 +36,13 @@
 
 MEMORY {
     ROM (rx)   : ORIGIN = 0x00000000, LENGTH = 0x00020000 /* 128kB ROM */
-    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 256kB "FLASH" */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 760kB SRAM */
+    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 384kB "FLASH" */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K /* 160kB SRAM with ECC*/
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB SRAM, no ECC */
 }
 
 SECTIONS {

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675_spix.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675_spix.ld
@@ -35,8 +35,13 @@
  ******************************************************************************/
 MEMORY {
     ROM (rx)   : ORIGIN = 0x00000000, LENGTH = 0x00020000 /* 128kB ROM */
-    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 0x00100000 /* 1MB flash */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x000BE000 /* 760kB SRAM */
+    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 384kB "FLASH" */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K /* 160kB SRAM with ECC*/
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB SRAM, no ECC */
 
     XIP_0 (rx)   : ORIGIN = 0x08000000, LENGTH = 0x00010000
     XIP_1 (rx)   : ORIGIN = 0x08010000, LENGTH = 0x00010000


### PR DESCRIPTION
New revisions of the ME15-based parts now come with ECC-enabled by default.  This reduces the overall SRAM space, as ECC requires complete ownership of the last few sysram instances.

Our linkerfiles previously did not take this into account.  As a result, startup code would cause a HardFault as the stack as expanded into the reserved ECC space on newer die revisions.

This PR re-configures the ME15, ME16, and ME21 linkerfiles to assume that ECC is enabled by default.  It reduces SRAM to the sizes specified in each parts datasheet for ECC-enabled.

Several linkerfiles (_spix, _rom, etc.) also appear to be completely unused and unmaintained.  We should address these in a later PR