### PR TITLE
Fix ME15 RTC Bug, Disable ECC for Flash Examples, Fix LP

### DIFF
--- a/Examples/MAX32670/Flash/main.c
+++ b/Examples/MAX32670/Flash/main.c
@@ -48,6 +48,7 @@
 #include "flc.h"
 #include "icc.h"
 #include "gcr_regs.h"
+#include "ecc_regs.h"
 
 /***** Definitions *****/
 #define TESTSIZE 8192 //2 pages worth so we can do erase functions
@@ -299,6 +300,8 @@ int main(void)
     int error_status, i;
     uint32_t start, end;
     uint32_t buffer[0x1000];
+
+    MXC_ECC->en = 0; // Disable ECC on Flash, ICC, and SRAM
 
     /* Note: This example must execute out of RAM, due to MXC_FLC_MassErase() call, below */
     printf("\n\n***** Flash Control Example *****\n");

--- a/Examples/MAX32670/Flash_CLI/main.c
+++ b/Examples/MAX32670/Flash_CLI/main.c
@@ -60,6 +60,7 @@
 #include "semphr.h"
 #include "task.h"
 #include "uart.h"
+#include "ecc_regs.h"
 
 /* FreeRTOS+CLI */
 void vRegisterCLICommands(void);
@@ -353,6 +354,8 @@ int main(void)
     printf("\nThis example demonstrates the CLI commands feature of FreeRTOS, various features");
     printf("\nof the Flash Controller (page erase and write), and how to use the CRC to");
     printf("\ncompute the CRC value of an array. Enter commands in the terminal window.\n\n");
+
+    MXC_ECC->en = 0; // Disable ECC on Flash, ICC, and SRAM
 
     NVIC_SetRAM();
     // Initialize the Flash

--- a/Examples/MAX32670/LP/main.c
+++ b/Examples/MAX32670/LP/main.c
@@ -62,6 +62,7 @@
 #include "rtc.h"
 #include "uart.h"
 #include "nvic_table.h"
+#include "ecc_regs.h"
 
 #define DELAY_IN_SEC 2
 #define USE_CONSOLE 1
@@ -183,9 +184,18 @@ void configure_gpio(void)
 
 int main(void)
 {
+    MXC_ECC->en = 0; // Disable ECC on Flash, ICC, and SRAM
+
 #if USE_CONSOLE
     printf("****Low Power Mode Example****\n\n");
 #endif // USE_CONSOLE
+
+#if USE_BUTTON
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+#endif // USE_BUTTON
+#if USE_ALARM
+    MXC_LP_EnableRTCAlarmWakeup();
+#endif // USE_ALARM
 
 #if USE_ALARM
 #if USE_CONSOLE
@@ -198,7 +208,7 @@ int main(void)
 
 #if USE_BUTTON
 #if USE_CONSOLE
-    printf("This code cycles through the MAX32670 power modes, using a push button (SW2) to exit "
+    printf("This code cycles through the MAX32670 power modes, using a push button (SW3) to exit "
            "from each mode and enter the next.\n\n");
 #endif // USE_CONSOLE
     PB_RegisterCallback(0, buttonHandler);
@@ -215,34 +225,11 @@ int main(void)
     setTrigger(1);
 
     MXC_LP_ROMLightSleepEnable();
-
-    // MXC_LP_SysRam3LightSleepDisable();
-    MXC_LP_SysRam2LightSleepEnable();
-    MXC_LP_SysRam1LightSleepDisable();
-    MXC_LP_SysRam0LightSleepDisable(); // Global variables are in RAM0 and RAM1
-
 #if USE_CONSOLE
-    printf("All unused RAMs placed in LIGHT SLEEP mode.\n");
+    printf("ROM placed in LIGHT SLEEP mode.\n");
 #endif // USE_CONSOLE
+
     setTrigger(1);
-
-    // MXC_LP_SysRam3Shutdown();
-    MXC_LP_SysRam2Shutdown();
-
-    MXC_LP_SysRam1PowerUp();
-    MXC_LP_SysRam0PowerUp(); // Global variables are in RAM0 and RAM1
-
-#if USE_CONSOLE
-    printf("All unused RAMs shutdown.\n");
-#endif // USE_CONSOLE
-    setTrigger(1);
-
-#if USE_BUTTON
-    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
-#endif // USE_BUTTON
-#if USE_ALARM
-    MXC_LP_EnableRTCAlarmWakeup();
-#endif // USE_ALARM
 
     while (1) {
 #if DO_SLEEP

--- a/Examples/MAX32670/WearLeveling/main.c
+++ b/Examples/MAX32670/WearLeveling/main.c
@@ -45,9 +45,9 @@
 #include "mxc_assert.h"
 #include "mxc_device.h"
 #include "flc.h"
-
 #include "flash.h"
 #include "lfs.h"
+#include "ecc_regs.h"
 
 /***** Definitions *****/
 #define APP_PAGE_CNT 8 ///< Flash memory blocks reserved for the app code
@@ -106,6 +106,8 @@ const struct lfs_config cfg = {
 int main(void)
 {
     int error_status = E_NO_ERROR;
+
+    MXC_ECC->en = 0; // Disable ECC on Flash, ICC, and SRAM
 
     printf("\n\n***** MAX32670 Wear Leveling *****\n");
 

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_me15.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_me15.c
@@ -77,7 +77,7 @@ int MXC_RTC_Stop(void)
 int MXC_RTC_Init(uint32_t sec, uint16_t ssec)
 {
     // Enable clock
-    MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
+    MXC_SYS_RTCClockEnable();
 
     return MXC_RTC_RevA_Init((mxc_rtc_reva_regs_t *)MXC_RTC, sec, (ssec & MXC_F_RTC_SSEC_SSEC));
 }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -158,8 +158,8 @@ void MXC_SYS_ClockEnable(mxc_sys_periph_clock_t clock)
 /* ************************************************************************** */
 void MXC_SYS_RTCClockEnable()
 {
-    MXC_PWRSEQ->lpcn &= ~(MXC_F_PWRSEQ_LPCN_ERTCO_PD);
-    MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN;
+    MXC_PWRSEQ->lpcn &= ~(MXC_F_PWRSEQ_LPCN_ERTCO_PD); // For Rev B parts
+    MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERTCO_EN; // For Rev A parts
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
(Flash, Fash_CLI) The ME15 RTC initialization code was failing on Rev B parts.  Rev B requires a different bit for RTC clock enable, so the ME15 RTC drivers now call the SYS driver function that properly enables the RTC clock on both revisions.  See https://github.com/Analog-Devices-MSDK/msdk/commit/e6a271a8f136f24815b8a4cc2d8b543585027e7a

(RTC, RTC_Backup) New revisions of the ME15 also enable ECC by default, which caused the Flash examples to fail.  On those examples, ECC has been completely disabled.  See https://github.com/Analog-Devices-MSDK/msdk/commit/c2cbe716dde9be66c5918e749017d230e1d9c34c https://github.com/Analog-Devices-MSDK/msdk/pull/253/commits/e8ab4f7b8541ed5b6e22d4759825e782d0376b90

(LP) Disable RAM sleep/shutdown.  It broke the example, and power savings are minimal https://github.com/Analog-Devices-MSDK/msdk/pull/253/commits/73dc61234ef2ffdfdc8dda63e5da05dd1254b3d1