### PR TITLE
Set -O2 as Default for AI85, AI87 

### DIFF
--- a/Examples/MAX78000/ADC/Makefile
+++ b/Examples/MAX78000/ADC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ADC/Makefile
+++ b/Examples/MAX78000/ADC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ADC/project.mk
+++ b/Examples/MAX78000/ADC/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/AES/Makefile
+++ b/Examples/MAX78000/AES/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/AES/Makefile
+++ b/Examples/MAX78000/AES/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/AES/project.mk
+++ b/Examples/MAX78000/AES/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/UNet-demo/Makefile
+++ b/Examples/MAX78000/CNN/UNet-demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/UNet-demo/Makefile
+++ b/Examples/MAX78000/CNN/UNet-demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/UNet-demo/project.mk
+++ b/Examples/MAX78000/CNN/UNet-demo/project.mk
@@ -14,10 +14,9 @@
 $(info Note: This project is designed and tested for the OV7692 only.)
 override CAMERA=OV7692
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 # Add some additional directories to the build based on the

--- a/Examples/MAX78000/CNN/UNet-demo/project.mk
+++ b/Examples/MAX78000/CNN/UNet-demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/Makefile
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/UNet-highres-demo/Makefile
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/UNet-highres-demo/project.mk
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/project.mk
@@ -16,10 +16,9 @@
 $(info Note: This project is designed and tested for the OV7692 only.)
 override CAMERA=OV7692
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 # Add some additional directories to the build based on what board

--- a/Examples/MAX78000/CNN/UNet-highres-demo/project.mk
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/Makefile
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/Makefile
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/project.mk
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/project.mk
@@ -17,10 +17,9 @@ override CAMERA=OV7692
 # Uncomment the line below to build for the MAX78000FTHR
 #BOARD=FTHR_RevA
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 # Add some additional directories to the project based on

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/project.mk
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/aisegment_unet/Makefile
+++ b/Examples/MAX78000/CNN/aisegment_unet/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/aisegment_unet/Makefile
+++ b/Examples/MAX78000/CNN/aisegment_unet/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/aisegment_unet/project.mk
+++ b/Examples/MAX78000/CNN/aisegment_unet/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/aisegment_unet/project.mk
+++ b/Examples/MAX78000/CNN/aisegment_unet/project.mk
@@ -5,15 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
-

--- a/Examples/MAX78000/CNN/asl/Makefile
+++ b/Examples/MAX78000/CNN/asl/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/asl/Makefile
+++ b/Examples/MAX78000/CNN/asl/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/asl/project.mk
+++ b/Examples/MAX78000/CNN/asl/project.mk
@@ -13,5 +13,8 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/asl/project.mk
+++ b/Examples/MAX78000/CNN/asl/project.mk
@@ -5,16 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level.  The increased performance
-# is required for the CameraIF DMA code to work within the
-# timing requirements of the Parallel Camera Interface.
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/asl_demo/Makefile
+++ b/Examples/MAX78000/CNN/asl_demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/asl_demo/Makefile
+++ b/Examples/MAX78000/CNN/asl_demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/asl_demo/project.mk
+++ b/Examples/MAX78000/CNN/asl_demo/project.mk
@@ -16,10 +16,9 @@
 $(info Note: This project is designed and tested for the OV7692 only.)
 override CAMERA=OV7692
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 # Place build files specific to EvKit_V1 here.

--- a/Examples/MAX78000/CNN/asl_demo/project.mk
+++ b/Examples/MAX78000/CNN/asl_demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/camvid_unet/Makefile
+++ b/Examples/MAX78000/CNN/camvid_unet/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/camvid_unet/Makefile
+++ b/Examples/MAX78000/CNN/camvid_unet/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/camvid_unet/project.mk
+++ b/Examples/MAX78000/CNN/camvid_unet/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/camvid_unet/project.mk
+++ b/Examples/MAX78000/CNN/camvid_unet/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cats-dogs/Makefile
+++ b/Examples/MAX78000/CNN/cats-dogs/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/cats-dogs/Makefile
+++ b/Examples/MAX78000/CNN/cats-dogs/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/cats-dogs/project.mk
+++ b/Examples/MAX78000/CNN/cats-dogs/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cats-dogs/project.mk
+++ b/Examples/MAX78000/CNN/cats-dogs/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cats-dogs_demo/Makefile
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/cats-dogs_demo/Makefile
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/cats-dogs_demo/project.mk
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/project.mk
@@ -16,10 +16,9 @@
 $(info Note: This project is designed and tested for the OV7692 only.)
 override CAMERA=OV7692
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 # Place build files specific to EvKit_V1 here.

--- a/Examples/MAX78000/CNN/cats-dogs_demo/project.mk
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/Makefile
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/Makefile
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/project.mk
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/project.mk
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/project.mk
@@ -5,15 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
-

--- a/Examples/MAX78000/CNN/cifar-10/Makefile
+++ b/Examples/MAX78000/CNN/cifar-10/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/cifar-10/Makefile
+++ b/Examples/MAX78000/CNN/cifar-10/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/cifar-10/project.mk
+++ b/Examples/MAX78000/CNN/cifar-10/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-10/project.mk
+++ b/Examples/MAX78000/CNN/cifar-10/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-100-mixed/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/cifar-100-mixed/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/cifar-100-mixed/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-100-mixed/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-100-residual/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-residual/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/cifar-100-residual/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-residual/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/cifar-100-residual/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-residual/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-100-residual/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-residual/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-100/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/cifar-100/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/cifar-100/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/cifar-100/project.mk
+++ b/Examples/MAX78000/CNN/cifar-100/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/digit-detection-demo/Makefile
+++ b/Examples/MAX78000/CNN/digit-detection-demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/digit-detection-demo/Makefile
+++ b/Examples/MAX78000/CNN/digit-detection-demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/digit-detection-demo/project.mk
+++ b/Examples/MAX78000/CNN/digit-detection-demo/project.mk
@@ -16,10 +16,9 @@
 $(info Note: This project is designed and tested for the OV7692 only.)
 override CAMERA=OV7692
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 ifeq "$(BOARD)" "EvKit_V1"

--- a/Examples/MAX78000/CNN/digit-detection-demo/project.mk
+++ b/Examples/MAX78000/CNN/digit-detection-demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/faceid/Makefile
+++ b/Examples/MAX78000/CNN/faceid/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/faceid/Makefile
+++ b/Examples/MAX78000/CNN/faceid/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/faceid/project.mk
+++ b/Examples/MAX78000/CNN/faceid/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/faceid/project.mk
+++ b/Examples/MAX78000/CNN/faceid/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/faceid_demo/Makefile
+++ b/Examples/MAX78000/CNN/faceid_demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/faceid_demo/Makefile
+++ b/Examples/MAX78000/CNN/faceid_demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/faceid_demo/project.mk
+++ b/Examples/MAX78000/CNN/faceid_demo/project.mk
@@ -14,8 +14,7 @@
 $(info Note: This project is designed and tested for the OV7692 only.)
 override CAMERA=OV7692
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2

--- a/Examples/MAX78000/CNN/faceid_demo/project.mk
+++ b/Examples/MAX78000/CNN/faceid_demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/faceid_evkit/Makefile
+++ b/Examples/MAX78000/CNN/faceid_evkit/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/faceid_evkit/Makefile
+++ b/Examples/MAX78000/CNN/faceid_evkit/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/faceid_evkit/project.mk
+++ b/Examples/MAX78000/CNN/faceid_evkit/project.mk
@@ -16,6 +16,11 @@
 $(info Note: This project is designed and tested for the OV7692 only.)
 override CAMERA=OV7692
 
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
+MXC_OPTIMIZE_CFLAGS = -O2
+
 # Place build files specific to EvKit_V1 here.
 ifeq "$(BOARD)" "EvKit_V1"
 PROJ_CFLAGS+=-DTFT_ENABLE

--- a/Examples/MAX78000/CNN/faceid_evkit/project.mk
+++ b/Examples/MAX78000/CNN/faceid_evkit/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/kws20_demo/Makefile
+++ b/Examples/MAX78000/CNN/kws20_demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/kws20_demo/Makefile
+++ b/Examples/MAX78000/CNN/kws20_demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/kws20_demo/project.mk
+++ b/Examples/MAX78000/CNN/kws20_demo/project.mk
@@ -11,10 +11,9 @@
 
 # **********************************************************
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 # Place build files specific to EvKit_V1 here.

--- a/Examples/MAX78000/CNN/kws20_demo/project.mk
+++ b/Examples/MAX78000/CNN/kws20_demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/kws20_v3/Makefile
+++ b/Examples/MAX78000/CNN/kws20_v3/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/kws20_v3/Makefile
+++ b/Examples/MAX78000/CNN/kws20_v3/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/kws20_v3/project.mk
+++ b/Examples/MAX78000/CNN/kws20_v3/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/kws20_v3/project.mk
+++ b/Examples/MAX78000/CNN/kws20_v3/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/mnist/Makefile
+++ b/Examples/MAX78000/CNN/mnist/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/mnist/Makefile
+++ b/Examples/MAX78000/CNN/mnist/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/mnist/project.mk
+++ b/Examples/MAX78000/CNN/mnist/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/mnist/project.mk
+++ b/Examples/MAX78000/CNN/mnist/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/rps-demo/Makefile
+++ b/Examples/MAX78000/CNN/rps-demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/rps-demo/Makefile
+++ b/Examples/MAX78000/CNN/rps-demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/rps-demo/project.mk
+++ b/Examples/MAX78000/CNN/rps-demo/project.mk
@@ -16,10 +16,9 @@
 $(info Note: This project is designed and tested for the OV7692 only.)
 override CAMERA=OV7692
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 # Place build files specific to EvKit_V1 here.

--- a/Examples/MAX78000/CNN/rps-demo/project.mk
+++ b/Examples/MAX78000/CNN/rps-demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/rps/Makefile
+++ b/Examples/MAX78000/CNN/rps/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/rps/Makefile
+++ b/Examples/MAX78000/CNN/rps/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/rps/project.mk
+++ b/Examples/MAX78000/CNN/rps/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/rps/project.mk
+++ b/Examples/MAX78000/CNN/rps/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/snake_game_demo/Makefile
+++ b/Examples/MAX78000/CNN/snake_game_demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/snake_game_demo/Makefile
+++ b/Examples/MAX78000/CNN/snake_game_demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/snake_game_demo/project.mk
+++ b/Examples/MAX78000/CNN/snake_game_demo/project.mk
@@ -11,10 +11,9 @@
 
 # **********************************************************
 
-# A higher optimization level is used for this example, but it
-# may make debugging unreliable.  Comment out the line below
-# to use the default optimization level, which is optimized
-# for a good debugging experience.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2
 
 # Place build files specific to EvKit_V1 here.

--- a/Examples/MAX78000/CNN/snake_game_demo/project.mk
+++ b/Examples/MAX78000/CNN/snake_game_demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CNN/svhn_tinierssd/Makefile
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CNN/svhn_tinierssd/Makefile
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CNN/svhn_tinierssd/project.mk
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/project.mk
@@ -5,15 +5,11 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 
 # Add your config here!
-
-# Set a higher optimization level to maximize the performance
-# of CNN-related functions
-MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CNN/svhn_tinierssd/project.mk
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/project.mk
@@ -13,5 +13,7 @@
 
 # Add your config here!
 
-
+# Set a higher optimization level to maximize the performance
+# of CNN-related functions
+MXC_OPTIMIZE_CFLAGS = -O2
 

--- a/Examples/MAX78000/CRC/Makefile
+++ b/Examples/MAX78000/CRC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CRC/Makefile
+++ b/Examples/MAX78000/CRC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CRC/project.mk
+++ b/Examples/MAX78000/CRC/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/CameraIF/Makefile
+++ b/Examples/MAX78000/CameraIF/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CameraIF/Makefile
+++ b/Examples/MAX78000/CameraIF/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CameraIF_Debayer/Makefile
+++ b/Examples/MAX78000/CameraIF_Debayer/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/CameraIF_Debayer/Makefile
+++ b/Examples/MAX78000/CameraIF_Debayer/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/CameraIF_Debayer/project.mk
+++ b/Examples/MAX78000/CameraIF_Debayer/project.mk
@@ -11,6 +11,7 @@
 # These are the only drivers supported by this example.
 CAMERA=HM0360_COLOR
 
-# Set optimization level to -O2, which is required for the CameraIF DMA
-# timing to work properly.
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2

--- a/Examples/MAX78000/DMA/Makefile
+++ b/Examples/MAX78000/DMA/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/DMA/Makefile
+++ b/Examples/MAX78000/DMA/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/DMA/project.mk
+++ b/Examples/MAX78000/DMA/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ECC/Makefile
+++ b/Examples/MAX78000/ECC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ECC/Makefile
+++ b/Examples/MAX78000/ECC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ECC/project.mk
+++ b/Examples/MAX78000/ECC/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/FTHR_I2C/Makefile
+++ b/Examples/MAX78000/FTHR_I2C/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/FTHR_I2C/Makefile
+++ b/Examples/MAX78000/FTHR_I2C/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/FTHR_I2C/project.mk
+++ b/Examples/MAX78000/FTHR_I2C/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/Flash/Makefile
+++ b/Examples/MAX78000/Flash/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/Flash/Makefile
+++ b/Examples/MAX78000/Flash/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/Flash/project.mk
+++ b/Examples/MAX78000/Flash/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/Flash_CLI/Makefile
+++ b/Examples/MAX78000/Flash_CLI/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/Flash_CLI/Makefile
+++ b/Examples/MAX78000/Flash_CLI/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/Flash_CLI/project.mk
+++ b/Examples/MAX78000/Flash_CLI/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/FreeRTOSDemo/Makefile
+++ b/Examples/MAX78000/FreeRTOSDemo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/FreeRTOSDemo/Makefile
+++ b/Examples/MAX78000/FreeRTOSDemo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/FreeRTOSDemo/project.mk
+++ b/Examples/MAX78000/FreeRTOSDemo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/GPIO/Makefile
+++ b/Examples/MAX78000/GPIO/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/GPIO/Makefile
+++ b/Examples/MAX78000/GPIO/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/GPIO/project.mk
+++ b/Examples/MAX78000/GPIO/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/Hello_World/Makefile
+++ b/Examples/MAX78000/Hello_World/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/Hello_World/Makefile
+++ b/Examples/MAX78000/Hello_World/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/Hello_World/project.mk
+++ b/Examples/MAX78000/Hello_World/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/I2C_ADXL343/Makefile
+++ b/Examples/MAX78000/I2C_ADXL343/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/I2C_ADXL343/Makefile
+++ b/Examples/MAX78000/I2C_ADXL343/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/I2C_ADXL343/project.mk
+++ b/Examples/MAX78000/I2C_ADXL343/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/I2C_MNGR/Makefile
+++ b/Examples/MAX78000/I2C_MNGR/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/I2C_MNGR/Makefile
+++ b/Examples/MAX78000/I2C_MNGR/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/I2C_SCAN/Makefile
+++ b/Examples/MAX78000/I2C_SCAN/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/I2C_SCAN/Makefile
+++ b/Examples/MAX78000/I2C_SCAN/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/I2C_SCAN/project.mk
+++ b/Examples/MAX78000/I2C_SCAN/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/I2C_Sensor/Makefile
+++ b/Examples/MAX78000/I2C_Sensor/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/I2C_Sensor/Makefile
+++ b/Examples/MAX78000/I2C_Sensor/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/I2S/Makefile
+++ b/Examples/MAX78000/I2S/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/I2S/Makefile
+++ b/Examples/MAX78000/I2S/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/I2S/project.mk
+++ b/Examples/MAX78000/I2S/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/I2S_DMA/Makefile
+++ b/Examples/MAX78000/I2S_DMA/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/I2S_DMA/Makefile
+++ b/Examples/MAX78000/I2S_DMA/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/I2S_DMA/project.mk
+++ b/Examples/MAX78000/I2S_DMA/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/I2S_DMA_Target/Makefile
+++ b/Examples/MAX78000/I2S_DMA_Target/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/I2S_DMA_Target/Makefile
+++ b/Examples/MAX78000/I2S_DMA_Target/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ICC/Makefile
+++ b/Examples/MAX78000/ICC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ICC/Makefile
+++ b/Examples/MAX78000/ICC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ICC/project.mk
+++ b/Examples/MAX78000/ICC/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/ImgCapture/Makefile
+++ b/Examples/MAX78000/ImgCapture/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/ImgCapture/Makefile
+++ b/Examples/MAX78000/ImgCapture/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/ImgCapture/project.mk
+++ b/Examples/MAX78000/ImgCapture/project.mk
@@ -22,7 +22,9 @@ CAMERA=OV7692
 # CAMERA=HM0360_COLOR
 # CAMERA=HM01B0
 
-# Set higher optimization level (faster code but shouldn't be used while debugging)
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS=-O2
 
 ifeq ($(CONSOLE),1)

--- a/Examples/MAX78000/LP/Makefile
+++ b/Examples/MAX78000/LP/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/LP/Makefile
+++ b/Examples/MAX78000/LP/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/LP/project.mk
+++ b/Examples/MAX78000/LP/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/LPCMP/Makefile
+++ b/Examples/MAX78000/LPCMP/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/LPCMP/Makefile
+++ b/Examples/MAX78000/LPCMP/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/LPCMP/project.mk
+++ b/Examples/MAX78000/LPCMP/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/Pulse_Train/Makefile
+++ b/Examples/MAX78000/Pulse_Train/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/Pulse_Train/Makefile
+++ b/Examples/MAX78000/Pulse_Train/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/Pulse_Train/project.mk
+++ b/Examples/MAX78000/Pulse_Train/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/RTC/Makefile
+++ b/Examples/MAX78000/RTC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/RTC/Makefile
+++ b/Examples/MAX78000/RTC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/RTC/project.mk
+++ b/Examples/MAX78000/RTC/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/RTC_Backup/Makefile
+++ b/Examples/MAX78000/RTC_Backup/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/RTC_Backup/Makefile
+++ b/Examples/MAX78000/RTC_Backup/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/RTC_Backup/project.mk
+++ b/Examples/MAX78000/RTC_Backup/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/SDHC_FTHR/Makefile
+++ b/Examples/MAX78000/SDHC_FTHR/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/SDHC_FTHR/Makefile
+++ b/Examples/MAX78000/SDHC_FTHR/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/SDHC_FTHR/project.mk
+++ b/Examples/MAX78000/SDHC_FTHR/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/SPI/Makefile
+++ b/Examples/MAX78000/SPI/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/SPI/Makefile
+++ b/Examples/MAX78000/SPI/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/SPI/project.mk
+++ b/Examples/MAX78000/SPI/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/TFT_Demo/Makefile
+++ b/Examples/MAX78000/TFT_Demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/TFT_Demo/Makefile
+++ b/Examples/MAX78000/TFT_Demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/TFT_Demo/project.mk
+++ b/Examples/MAX78000/TFT_Demo/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/TMR/Makefile
+++ b/Examples/MAX78000/TMR/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/TMR/Makefile
+++ b/Examples/MAX78000/TMR/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/TMR/project.mk
+++ b/Examples/MAX78000/TMR/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/TRNG/Makefile
+++ b/Examples/MAX78000/TRNG/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/TRNG/Makefile
+++ b/Examples/MAX78000/TRNG/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/TRNG/project.mk
+++ b/Examples/MAX78000/TRNG/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/UART/Makefile
+++ b/Examples/MAX78000/UART/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/UART/Makefile
+++ b/Examples/MAX78000/UART/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/UART/project.mk
+++ b/Examples/MAX78000/UART/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/WUT/Makefile
+++ b/Examples/MAX78000/WUT/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/WUT/Makefile
+++ b/Examples/MAX78000/WUT/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/WUT/project.mk
+++ b/Examples/MAX78000/WUT/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/Watchdog/Makefile
+++ b/Examples/MAX78000/Watchdog/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/Watchdog/Makefile
+++ b/Examples/MAX78000/Watchdog/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/Watchdog/project.mk
+++ b/Examples/MAX78000/Watchdog/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78000/WearLeveling/Makefile
+++ b/Examples/MAX78000/WearLeveling/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78000/WearLeveling/Makefile
+++ b/Examples/MAX78000/WearLeveling/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78000/WearLeveling/project.mk
+++ b/Examples/MAX78000/WearLeveling/project.mk
@@ -5,9 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-#BOARD=FTHR_RevA
-# ^ For example, you can uncomment this line to make the 
-# project build for the "FTHR_RevA" board.
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ADC/Makefile
+++ b/Examples/MAX78002/ADC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ADC/Makefile
+++ b/Examples/MAX78002/ADC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ADC/project.mk
+++ b/Examples/MAX78002/ADC/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/AES/Makefile
+++ b/Examples/MAX78002/AES/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/AES/Makefile
+++ b/Examples/MAX78002/AES/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/AES/project.mk
+++ b/Examples/MAX78002/AES/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/project.mk
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/Makefile
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/Makefile
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/project.mk
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Add your config here!

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/project.mk
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/project.mk
@@ -5,11 +5,7 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
-
 # **********************************************************
 
 # Add your config here!
-
-
 

--- a/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/project.mk
+++ b/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Add your config here!

--- a/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/project.mk
+++ b/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/project.mk
@@ -5,11 +5,7 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
-
 # **********************************************************
 
 # Add your config here!
-
-
 

--- a/Examples/MAX78002/CNN/imagenet/Makefile
+++ b/Examples/MAX78002/CNN/imagenet/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/CNN/imagenet/Makefile
+++ b/Examples/MAX78002/CNN/imagenet/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/CNN/imagenet/project.mk
+++ b/Examples/MAX78002/CNN/imagenet/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Add your config here!

--- a/Examples/MAX78002/CNN/imagenet/project.mk
+++ b/Examples/MAX78002/CNN/imagenet/project.mk
@@ -5,11 +5,7 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
-
 # **********************************************************
 
 # Add your config here!
-
-
 

--- a/Examples/MAX78002/CRC/Makefile
+++ b/Examples/MAX78002/CRC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/CRC/Makefile
+++ b/Examples/MAX78002/CRC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/CRC/project.mk
+++ b/Examples/MAX78002/CRC/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/CSI2/Makefile
+++ b/Examples/MAX78002/CSI2/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/CSI2/Makefile
+++ b/Examples/MAX78002/CSI2/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/CSI2/project.mk
+++ b/Examples/MAX78002/CSI2/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Add your config here!

--- a/Examples/MAX78002/CSI2/project.mk
+++ b/Examples/MAX78002/CSI2/project.mk
@@ -18,7 +18,12 @@ CAMERA=OV5640
 #CAMERA=HM0360_MONO
 #CAMERA=HM01B0
 
+# Set a higher optimization level.  The increased performance
+# is required for the Camera DMA code to work within the
+# timing requirements of the CSI2 interface.
 MXC_OPTIMIZE_CFLAGS=-O2
 
+# Set the CSI2 linkerfile, which reserves an SRAM instance required
+# for the CSI2 hardware buffers
 LINKERFILE=max78002_csi2.ld
 

--- a/Examples/MAX78002/CameraIF/Makefile
+++ b/Examples/MAX78002/CameraIF/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/CameraIF/Makefile
+++ b/Examples/MAX78002/CameraIF/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/CameraIF/project.mk
+++ b/Examples/MAX78002/CameraIF/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Set the camera drivers.  Select a line to match the

--- a/Examples/MAX78002/CameraIF/project.mk
+++ b/Examples/MAX78002/CameraIF/project.mk
@@ -19,3 +19,8 @@ CAMERA=OV7692
 # Select TFT display drivers to match the connected display
 TFT=ADAFRUIT
 # TFT=NEWHAVEN
+
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
+MXC_OPTIMIZE_CFLAGS = -O2

--- a/Examples/MAX78002/CameraIF_Debayer/Makefile
+++ b/Examples/MAX78002/CameraIF_Debayer/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/CameraIF_Debayer/Makefile
+++ b/Examples/MAX78002/CameraIF_Debayer/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/CameraIF_Debayer/project.mk
+++ b/Examples/MAX78002/CameraIF_Debayer/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Set the camera driver to the HM0360 color drivers

--- a/Examples/MAX78002/CameraIF_Debayer/project.mk
+++ b/Examples/MAX78002/CameraIF_Debayer/project.mk
@@ -11,5 +11,7 @@
 # These are the only drivers supported by this example.
 CAMERA=HM0360_COLOR
 
-# Enable optimization level 2 (faster code but this should be turned off for debugging)
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS = -O2

--- a/Examples/MAX78002/DMA/Makefile
+++ b/Examples/MAX78002/DMA/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/DMA/Makefile
+++ b/Examples/MAX78002/DMA/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/DMA/project.mk
+++ b/Examples/MAX78002/DMA/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ECC/Makefile
+++ b/Examples/MAX78002/ECC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ECC/Makefile
+++ b/Examples/MAX78002/ECC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ECC/project.mk
+++ b/Examples/MAX78002/ECC/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/Flash/Makefile
+++ b/Examples/MAX78002/Flash/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/Flash/Makefile
+++ b/Examples/MAX78002/Flash/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/Flash/project.mk
+++ b/Examples/MAX78002/Flash/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/Flash_CLI/Makefile
+++ b/Examples/MAX78002/Flash_CLI/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/Flash_CLI/Makefile
+++ b/Examples/MAX78002/Flash_CLI/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/Flash_CLI/project.mk
+++ b/Examples/MAX78002/Flash_CLI/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/FreeRTOSDemo/Makefile
+++ b/Examples/MAX78002/FreeRTOSDemo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/FreeRTOSDemo/Makefile
+++ b/Examples/MAX78002/FreeRTOSDemo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/FreeRTOSDemo/project.mk
+++ b/Examples/MAX78002/FreeRTOSDemo/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/GPIO/Makefile
+++ b/Examples/MAX78002/GPIO/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/GPIO/Makefile
+++ b/Examples/MAX78002/GPIO/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/GPIO/project.mk
+++ b/Examples/MAX78002/GPIO/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/Hello_World/Makefile
+++ b/Examples/MAX78002/Hello_World/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/Hello_World/Makefile
+++ b/Examples/MAX78002/Hello_World/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/Hello_World/project.mk
+++ b/Examples/MAX78002/Hello_World/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/I2C/Makefile
+++ b/Examples/MAX78002/I2C/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/I2C/Makefile
+++ b/Examples/MAX78002/I2C/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/I2C/project.mk
+++ b/Examples/MAX78002/I2C/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/I2C_MNGR/Makefile
+++ b/Examples/MAX78002/I2C_MNGR/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/I2C_MNGR/Makefile
+++ b/Examples/MAX78002/I2C_MNGR/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/I2C_MNGR/project.mk
+++ b/Examples/MAX78002/I2C_MNGR/project.mk
@@ -1,11 +1,15 @@
-# This file can be used for project configuration.
-# It's a sibling to the core "Makefile", which offers
-# various configuration variables that you can set here
-# if the default setup isn't suitable.
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
 
-# See the comments in the "Makefile" for a detailed
-# description of the default behavior and the full list of
-# available options.
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
+# **********************************************************
 
 # Build the FreeRTOS Library
 LIB_FREERTOS = 1

--- a/Examples/MAX78002/I2C_SCAN/Makefile
+++ b/Examples/MAX78002/I2C_SCAN/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/I2C_SCAN/Makefile
+++ b/Examples/MAX78002/I2C_SCAN/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/I2C_SCAN/project.mk
+++ b/Examples/MAX78002/I2C_SCAN/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/I2C_Sensor/Makefile
+++ b/Examples/MAX78002/I2C_Sensor/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/I2C_Sensor/Makefile
+++ b/Examples/MAX78002/I2C_Sensor/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/I2C_Sensor/project.mk
+++ b/Examples/MAX78002/I2C_Sensor/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Add your config here!

--- a/Examples/MAX78002/I2S/Makefile
+++ b/Examples/MAX78002/I2S/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/I2S/Makefile
+++ b/Examples/MAX78002/I2S/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/I2S/project.mk
+++ b/Examples/MAX78002/I2S/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/I2S_DMA/Makefile
+++ b/Examples/MAX78002/I2S_DMA/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/I2S_DMA/Makefile
+++ b/Examples/MAX78002/I2S_DMA/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/I2S_DMA/project.mk
+++ b/Examples/MAX78002/I2S_DMA/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ICC/Makefile
+++ b/Examples/MAX78002/ICC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ICC/Makefile
+++ b/Examples/MAX78002/ICC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ICC/project.mk
+++ b/Examples/MAX78002/ICC/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/ImgCapture/Makefile
+++ b/Examples/MAX78002/ImgCapture/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/ImgCapture/Makefile
+++ b/Examples/MAX78002/ImgCapture/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/ImgCapture/project.mk
+++ b/Examples/MAX78002/ImgCapture/project.mk
@@ -22,7 +22,9 @@ CAMERA=OV7692
 # CAMERA=HM0360_COLOR
 # CAMERA=HM01B0
 
-# Set higher optimization level (faster code but shouldn't be used while debugging)
+# Set a higher optimization level.  The increased performance
+# is required for the CameraIF DMA code to work within the
+# timing requirements of the Parallel Camera Interface.
 MXC_OPTIMIZE_CFLAGS=-O2
 
 ifeq ($(CONSOLE),1)

--- a/Examples/MAX78002/ImgCapture/project.mk
+++ b/Examples/MAX78002/ImgCapture/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Project options:

--- a/Examples/MAX78002/LP/Makefile
+++ b/Examples/MAX78002/LP/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/LP/Makefile
+++ b/Examples/MAX78002/LP/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/LP/project.mk
+++ b/Examples/MAX78002/LP/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/LPCMP/Makefile
+++ b/Examples/MAX78002/LPCMP/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/LPCMP/Makefile
+++ b/Examples/MAX78002/LPCMP/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/LPCMP/project.mk
+++ b/Examples/MAX78002/LPCMP/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/Pulse_Train/Makefile
+++ b/Examples/MAX78002/Pulse_Train/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/Pulse_Train/Makefile
+++ b/Examples/MAX78002/Pulse_Train/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/Pulse_Train/project.mk
+++ b/Examples/MAX78002/Pulse_Train/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/RTC/Makefile
+++ b/Examples/MAX78002/RTC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/RTC/Makefile
+++ b/Examples/MAX78002/RTC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/RTC/project.mk
+++ b/Examples/MAX78002/RTC/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/RTC_Backup/Makefile
+++ b/Examples/MAX78002/RTC_Backup/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/RTC_Backup/Makefile
+++ b/Examples/MAX78002/RTC_Backup/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/RTC_Backup/project.mk
+++ b/Examples/MAX78002/RTC_Backup/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/SDHC_FAT/Makefile
+++ b/Examples/MAX78002/SDHC_FAT/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/SDHC_FAT/Makefile
+++ b/Examples/MAX78002/SDHC_FAT/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/SDHC_FAT/project.mk
+++ b/Examples/MAX78002/SDHC_FAT/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/SDHC_Raw/Makefile
+++ b/Examples/MAX78002/SDHC_Raw/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/SDHC_Raw/Makefile
+++ b/Examples/MAX78002/SDHC_Raw/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/SDHC_Raw/project.mk
+++ b/Examples/MAX78002/SDHC_Raw/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/SPI/Makefile
+++ b/Examples/MAX78002/SPI/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/SPI/Makefile
+++ b/Examples/MAX78002/SPI/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/SPI/project.mk
+++ b/Examples/MAX78002/SPI/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/TFT_Demo/Makefile
+++ b/Examples/MAX78002/TFT_Demo/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/TFT_Demo/Makefile
+++ b/Examples/MAX78002/TFT_Demo/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/TFT_Demo/project.mk
+++ b/Examples/MAX78002/TFT_Demo/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Select TFT drivers to match the connected display 

--- a/Examples/MAX78002/TMR/Makefile
+++ b/Examples/MAX78002/TMR/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/TMR/Makefile
+++ b/Examples/MAX78002/TMR/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/TMR/project.mk
+++ b/Examples/MAX78002/TMR/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/TRNG/Makefile
+++ b/Examples/MAX78002/TRNG/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/TRNG/Makefile
+++ b/Examples/MAX78002/TRNG/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/TRNG/project.mk
+++ b/Examples/MAX78002/TRNG/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/UART/Makefile
+++ b/Examples/MAX78002/UART/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/UART/Makefile
+++ b/Examples/MAX78002/UART/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/UART/project.mk
+++ b/Examples/MAX78002/UART/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/USB_CDCACM/Makefile
+++ b/Examples/MAX78002/USB_CDCACM/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/USB_CDCACM/Makefile
+++ b/Examples/MAX78002/USB_CDCACM/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/USB_CDCACM/project.mk
+++ b/Examples/MAX78002/USB_CDCACM/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/project.mk
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/project.mk
@@ -5,6 +5,10 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
+
 # **********************************************************
 
 # Enable MAXUSB library

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_HID/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_HID/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_HID/project.mk
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_HID/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX78002/USB_HIDKeyboard/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX78002/USB_HIDKeyboard/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/USB_HIDKeyboard/project.mk
+++ b/Examples/MAX78002/USB_HIDKeyboard/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/USB_MassStorage/Makefile
+++ b/Examples/MAX78002/USB_MassStorage/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/USB_MassStorage/Makefile
+++ b/Examples/MAX78002/USB_MassStorage/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/USB_MassStorage/project.mk
+++ b/Examples/MAX78002/USB_MassStorage/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/USB_MassStorage_ThroughPut/Makefile
+++ b/Examples/MAX78002/USB_MassStorage_ThroughPut/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/USB_MassStorage_ThroughPut/Makefile
+++ b/Examples/MAX78002/USB_MassStorage_ThroughPut/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/USB_MassStorage_ThroughPut/project.mk
+++ b/Examples/MAX78002/USB_MassStorage_ThroughPut/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/WUT/Makefile
+++ b/Examples/MAX78002/WUT/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/WUT/Makefile
+++ b/Examples/MAX78002/WUT/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/WUT/project.mk
+++ b/Examples/MAX78002/WUT/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/Watchdog/Makefile
+++ b/Examples/MAX78002/Watchdog/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/Watchdog/Makefile
+++ b/Examples/MAX78002/Watchdog/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/Watchdog/project.mk
+++ b/Examples/MAX78002/Watchdog/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 

--- a/Examples/MAX78002/WearLeveling/Makefile
+++ b/Examples/MAX78002/WearLeveling/Makefile
@@ -233,9 +233,7 @@ ifeq ($(DEBUG),1)
 MXC_OPTIMIZE_CFLAGS := -Og
 endif
 
-# Fallback default optimizes for debugging as recommended
-# by GNU for code-edit-debug cycles
-# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+# Set default optimization level -O2 to maximize performance for CNN code
 MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags

--- a/Examples/MAX78002/WearLeveling/Makefile
+++ b/Examples/MAX78002/WearLeveling/Makefile
@@ -236,7 +236,7 @@ endif
 # Fallback default optimizes for debugging as recommended
 # by GNU for code-edit-debug cycles
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
-MXC_OPTIMIZE_CFLAGS ?= -Og
+MXC_OPTIMIZE_CFLAGS ?= -O2
 
 # Set compiler flags
 PROJ_CFLAGS += -Wall # Enable warnings

--- a/Examples/MAX78002/WearLeveling/project.mk
+++ b/Examples/MAX78002/WearLeveling/project.mk
@@ -5,7 +5,9 @@
 # For instructions on how to use this system, see
 # https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
 
-
+#MXC_OPTIMIZE_CFLAGS = -Og
+# ^ For example, you can uncomment this line to 
+# optimize the project for debugging
 
 # **********************************************************
 


### PR DESCRIPTION
This PR sets the default optimization level to `-O2` for the AI85 and AI87.

Projects interfacing with camera drivers also have their optimization level explicitly set to `-O2` in project.mk to increase visibility, since it's a hard requirement for the DMA timing.

It also replaces the example for setting `BOARD` with an example for setting the optimization level to `-Og`, since this was causing some confusion.  VS Code and Eclipse set `BOARD` on the command-line and have their own settings for changing it, which takes higher [precedence](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/blob/develop/README.md#precedence-hierarchy).  Future support for explicit debug builds will be improved in these IDEs in order to address this confusion more directly.