### PR TITLE
Reduce HM0360_MONO Integration Time, Fix Camera->TFT For AI87

### DIFF
--- a/Examples/MAX78000/CameraIF/README.md
+++ b/Examples/MAX78000/CameraIF/README.md
@@ -1,0 +1,16 @@
+# CameraIF
+
+This example demonstrates the Parallel Camera Interface (PCIF) drivers and camera-specific drivers for the following cameras:
+
+* OV7962 (Default)
+* HM0360 (MONO), for color use the CameraIF_Debayer example
+* OV5642
+* HM01B0
+
+To change the camera the project builds for, set the `CAMERA` build [configuration variable](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#how-to-set-a-configuration-variable) in [project.mk](project.mk)
+
+The project comes pre-configured for the [MAX78000EVKIT](https://github.com/MaximIntegratedAI/MaximAI_Documentation/tree/master/MAX78000_Evaluation_Kit) by default.  It also supports the MAX78000FTHR board (OV7692 only), and can be reconfigured using the `BOARD` [configuration variable](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#how-to-set-a-configuration-variable).  Depending on your development environment, set `BOARD=FTHR_RevA` in the following place:
+
+* Command-line development: project.mk
+* Visual Studio Code: [.vscode/settings.json](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#project-configuration)
+* Eclipse: Project Properties -> C/C++ Build -> Environment

--- a/Examples/MAX78000/CameraIF/README.md
+++ b/Examples/MAX78000/CameraIF/README.md
@@ -7,9 +7,9 @@ This example demonstrates the Parallel Camera Interface (PCIF) drivers and camer
 * OV5642
 * HM01B0
 
-To change the camera the project builds for, set the `CAMERA` build [configuration variable](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#how-to-set-a-configuration-variable) in [project.mk](project.mk)
+To change the camera the project builds for, set the `CAMERA` build [configuration variable](.vscode/README.md#build-configuration) in [project.mk](project.mk)
 
-The project comes pre-configured for the [MAX78000EVKIT](https://github.com/MaximIntegratedAI/MaximAI_Documentation/tree/master/MAX78000_Evaluation_Kit) by default.  It also supports the MAX78000FTHR board (OV7692 only), and can be reconfigured using the `BOARD` [configuration variable](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#how-to-set-a-configuration-variable).  Depending on your development environment, set `BOARD=FTHR_RevA` in the following place:
+The project comes pre-configured for the [MAX78000EVKIT](https://github.com/MaximIntegratedAI/MaximAI_Documentation/tree/master/MAX78000_Evaluation_Kit) by default.  It also supports the MAX78000FTHR board (OV7692 only), and can be reconfigured using the `BOARD` [configuration variable](.vscode/README.md#build-configuration).  Depending on your development environment, set `BOARD=FTHR_RevA` in the following place:
 
 * Command-line development: project.mk
 * Visual Studio Code: [.vscode/settings.json](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#project-configuration)

--- a/Examples/MAX78000/CameraIF/main.c
+++ b/Examples/MAX78000/CameraIF/main.c
@@ -64,7 +64,7 @@
 // Configuration options
 // ------------------------
 #define ENABLE_TFT // Comment out to disable TFT and send image to serial port instead.
-#define STREAM_ENABLE
+// #define STREAM_ENABLE
 /* If enabled, camera is setup in streaming mode to send the image
 line by line to TFT, or serial port as they are captured. Otherwise, it buffers the entire
 image first and then sends to TFT or serial port.
@@ -113,17 +113,14 @@ Compiler definitions...  These configure TFT and camera settings based on the op
 #endif
 #endif
 
-#if defined(CAMERA_HM0360_MONO) || defined(CAMERA_HM0360_COLOR) || defined(CAMERA_PAG7920)
+#if defined(CAMERA_HM0360_MONO) || defined(CAMERA_PAG7920)
 
-#ifdef STREAM_ENABLE
 #define IMAGE_XRES 320
 #define IMAGE_YRES 240
 
-#else
-#define IMAGE_XRES 320
-#define IMAGE_YRES 240
+#undef STREAM_ENABLE
+// ^ TFT cannot keep up with line-by-line capture time of HM0360 drivers.
 
-#endif
 #endif
 
 #if defined(CAMERA_OV7692) || defined(CAMERA_OV5642)

--- a/Examples/MAX78000/CameraIF/main.c
+++ b/Examples/MAX78000/CameraIF/main.c
@@ -268,7 +268,7 @@ int main(void)
 
     printf("Camera ID detected: %04x\n", id);
 
-#if defined(CAMERA_HM01B0) || defined(CAMERA_HM0360_MONO) || defined(CAMERA_HM0360_COLOR) || \
+#if defined(CAMERA_HM01B0) || defined(CAMERA_HM0360_MONO) || \
     defined(CAMERA_OV5642)
     camera_set_hmirror(0);
     camera_set_vflip(0);

--- a/Examples/MAX78000/CameraIF/main.c
+++ b/Examples/MAX78000/CameraIF/main.c
@@ -268,8 +268,7 @@ int main(void)
 
     printf("Camera ID detected: %04x\n", id);
 
-#if defined(CAMERA_HM01B0) || defined(CAMERA_HM0360_MONO) || \
-    defined(CAMERA_OV5642)
+#if defined(CAMERA_HM01B0) || defined(CAMERA_HM0360_MONO) || defined(CAMERA_OV5642)
     camera_set_hmirror(0);
     camera_set_vflip(0);
 #endif

--- a/Examples/MAX78002/CameraIF/README.md
+++ b/Examples/MAX78002/CameraIF/README.md
@@ -14,6 +14,18 @@ Use the pc_utility/grab_image.py script to grab the camera data and create a png
 -   Close Jumper JP45 (TFT_DC).
 -   Close Jumper JP46 (TFT_CS) to P0_3.
 
+## Build Configuration
+
+This example supports the following cameras:
+
+* OV7962 (Default)
+* HM0360 (MONO), for color use the CameraIF_Debayer example
+* OV5640
+* HM01B0
+
+To change the camera the project builds for, set the `CAMERA` build [configuration variable](.vscode/README.md#build-configuration) in [project.mk](project.mk)
+
+
 ## Expected Output
 
 The Console UART of the device will output these messages when streaming to the TFT Display:

--- a/Examples/MAX78002/CameraIF/main.c
+++ b/Examples/MAX78002/CameraIF/main.c
@@ -178,9 +178,21 @@ int main(void)
 #ifdef ENABLE_TFT
     printf("Init TFT\n");
     /* Initialize TFT display */
-    MXC_TFT_Init(MXC_SPI0, 1, NULL, NULL);
-    MXC_TFT_SetBackGroundColor(0);
+#ifdef TFT_ADAFRUIT
+    /* Initialize touch screen */
+    if (MXC_TS_Init(MXC_SPI0, -1, NULL, NULL) != E_NO_ERROR) {
+        printf("Touch screen initialization failed\n");
+        return E_ABORT;
+    }
+#else
+    /* Initialize TFT display */
+    if (MXC_TFT_Init(NULL, NULL) != E_NO_ERROR) {
+        printf("Touch screen initialization failed\n");
+        return E_ABORT;
+    }
 #endif
+#endif
+    MXC_TFT_SetBackGroundColor(0);
 
     // Setup the camera image dimensions, pixel format and data acquiring details.
 #ifndef CAMERA_MONO

--- a/Examples/MAX78002/CameraIF_Debayer/README.md
+++ b/Examples/MAX78002/CameraIF_Debayer/README.md
@@ -6,6 +6,8 @@ It requires debayering/demosaicking and color correction post-processing algorit
 
 The example builds for the TFT display by default.
 
+**Note: The CSI2 camera must be unplugged from J8 for this example to work.  Connecting both the DVP and CSI2 cameras at the same time will cause the DVP camera initialization to fail.**
+
 For instructions on setting up the MAX78002EVKIT see the [MAX78002EVKIT Quick-Start Guide](https://github.com/MaximIntegratedAI/MaximAI_Documentation/tree/master/MAX78002_Evaluation_Kit)
 
 For instructions on building and running the project, see the [.vscode/README.md](.vscode/README.md) file.

--- a/Examples/MAX78002/CameraIF_Debayer/main.c
+++ b/Examples/MAX78002/CameraIF_Debayer/main.c
@@ -213,7 +213,19 @@ int main(void)
 #ifdef ENABLE_TFT
     printf("Init TFT\n");
     /* Initialize TFT display */
-    MXC_TFT_Init(MXC_SPI0, 1, NULL, NULL);
+#ifdef TFT_ADAFRUIT
+    /* Initialize touch screen */
+    if (MXC_TS_Init(MXC_SPI0, -1, NULL, NULL) != E_NO_ERROR) {
+        printf("Touch screen initialization failed\n");
+        return E_ABORT;
+    }
+#else
+    /* Initialize TFT display */
+    if (MXC_TFT_Init(NULL, NULL) != E_NO_ERROR) {
+        printf("Touch screen initialization failed\n");
+        return E_ABORT;
+    }
+#endif
     MXC_TFT_SetBackGroundColor(4);
 #endif
 

--- a/Examples/MAX78002/CameraIF_Debayer/project.mk
+++ b/Examples/MAX78002/CameraIF_Debayer/project.mk
@@ -13,3 +13,7 @@ CAMERA=HM0360_COLOR
 
 # Enable optimization level 2 (faster code but this should be turned off for debugging)
 MXC_OPTIMIZE_CFLAGS = -O2
+
+# Select TFT display drivers to match the connected display
+# TFT=ADAFRUIT
+TFT=NEWHAVEN

--- a/Libraries/MiscDrivers/Camera/hm0360_mono.c
+++ b/Libraries/MiscDrivers/Camera/hm0360_mono.c
@@ -433,12 +433,11 @@ static const uint16_t default_regs[][2] = {
 
     // CONTEXT A START
     //
-    {   0x3500  ,   0x03    },  // PLL1CFG                  //74
+    {   0x3500  ,   0x74    },  // * PLL1CFG
     {   0x3501  ,   0x0A    },  // PLL2CFG
-    {   0x3502  ,   0x77    },  // PLL3CFG
-
-    {   0x3503  ,   0x01    },  // FRAME_LENGTH_LINES_H                                                         //01
-    {   0x3504  ,   0x1c    },  // FRAME_LENGTH_LINES_L                                                         //E0
+    {   0x3502  ,   0x77    },  // * PLL3CFG
+    {   0x3503  ,   0x00    },  // * FRAME_LENGTH_LINES_H
+    {   0x3504  ,   0x8E    },  // * FRAME_LENGTH_LINES_L                                                        //E0
 
     {   0x3505  ,   0x03    },  // LINE_LENGTH_PCK_H                                                            //03
     {   0x3506  ,   0x00    },  // LINE_LENGTH_PCK_L                                                            //00
@@ -508,14 +507,14 @@ static const uint16_t default_regs[][2] = {
 
 // Start of Context B
 //{0x355A, 0x74},  // clk_tb_div[1:0]=/1, plcko_div[3:2]=/1, clk_i2c_div[5:4]=/8, pll_pre_div=1
-    {0x355A, 0x7c},  // clk_tb_div[1:0]=/1, plcko_div[3:2]=/4, clk_i2c_div[5:4]=/8, pll_pre_div=1,  pclk=6MHz
+//    {0x355A, 0x7c},  // clk_tb_div[1:0]=/1, plcko_div[3:2]=/4, clk_i2c_div[5:4]=/8, pll_pre_div=1,  pclk=6MHz
 //{0x355A, 0x33},  // clk_tb_div[1:0]=/8, plcko_div[3:2]=/1, clk_i2c_div[5:4]=/8, pll_pre_div=0, pclk=3MHz
 //{0x355A, 0x03},  // clk_tb_div[1:0]=/8, plcko_div[3:2]=/1, clk_i2c_div[5:4]=/2, pll_pre_div=0, pclk=3MHz
-
-    {0x355B, 0x0A},
-    {0x355C, 0x77},
-    {0x355D, 0x00},
-    {0x355E, 0x8E},
+    {   0x355A  ,   0x74    },  // * PLL1CFG
+    {   0x355B  ,   0x0A    },  // PLL2CFG
+    {   0x355C  ,   0x77    },  // * PLL3CFG
+    {   0x355D  ,   0x00    },  // * FRAME_LENGTH_LINES_H
+    {   0x355E  ,   0x8E    },  // * FRAME_LENGTH_LINES_L
     {0x355F, 0x03},
     {0x3560, 0x00},
     {0x3561, 0x02},


### PR DESCRIPTION
The primary purpose of this PR is to apply the same integration time improvements from https://github.com/Analog-Devices-MSDK/Libraries-miscDrivers/pull/14 to the HM0360 _mono_ drivers as well.  The register config change in the mono drivers (https://github.com/Analog-Devices-MSDK/msdk/commit/7a52b65acf74320febc27d66931d87740a47b18e) reduces the time required to capture a single image down from 800ms to about 65ms, a 1230% improvement.

This change uncovered some other issues in the camera examples:
* A README has been added to CameraIF for the AI85
* Disable streaming by default for the AI85 CameraIF example.  The TFT cannot keep up with the reduced integration time, but there is enough SRAM for a full buffered image capture, which actually performs better.
* HM0360_COLOR `#ifdefs` have been removed from AI85 CameraIF, since  HM0360_COLOR is supported by the CameraIF_Debayer example
* Fix NewHaven TFT build errors for AI87 CameraIF and CameraIF_Debayer (https://github.com/Analog-Devices-MSDK/msdk/commit/d63a2e950ca2ad1f2617ca2e3d3859b0a0a88751) 
* Document CameraIF bug when CSI2 camera is also plugged in (https://github.com/Analog-Devices-MSDK/msdk/commit/08a19b4c20a6d19fb8054ed73d4eeac164a2c64d)

These changes have been tested and are fully functional on the AI85 EVKIT and AI87 EVKIT with the...
- [x] OV7692
- [x] HM0360_MONO
- [x] HM0360_COLOR

on both the NewHaven and Adafruit TFT displays
