### PR TITLE
Porting Temp_Monitor example.

### DIFF
--- a/Examples/MAX32572/Temp_Monitor/.cproject
+++ b/Examples/MAX32572/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32572/Temp_Monitor/.project
+++ b/Examples/MAX32572/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32572/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32572/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32572/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32572/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32572/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32572/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32572
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32572/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32572/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32572/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32572/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32572/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32572/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32572/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32572/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32572/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32572/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32572",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32670.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32572/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32572/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32572/Temp_Monitor/Makefile
+++ b/Examples/MAX32572/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32572
+TARGET_UC := MAX32572
+TARGET_LC := max32572
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32572/Temp_Monitor/README.md
+++ b/Examples/MAX32572/Temp_Monitor/README.md
@@ -1,0 +1,42 @@
+## Description
+
+This simple application demonstrates the use of the MAX32572 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing push button SW3 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
+-   Select RX0 and TX0 on Headers JP1 and JP3 (UART 0).
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Close jumper JP1 (LED1 EN).
+-   Close jumper JP2 (LED2 EN).
+-   Make the following connections between the MAX32572 and MAX31889 EV Kits: P0.6-->SCL(J2.11), P0.7-->SDA(J2.12), VDD(JH3.7)-->VDD(J1.2), GND(JH3.8)-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32572 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW3 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX32572/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32572/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32572.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32572/Include/max32572.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32572/Temp_Monitor/main.c
+++ b/Examples/MAX32572/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32572 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press SW3 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32572/Temp_Monitor/project.mk
+++ b/Examples/MAX32572/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32572/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32572/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable();
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable();
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(1); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32572/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32572/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32572_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32572_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32572_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX32650/Temp_Monitor/.cproject
+++ b/Examples/MAX32650/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32650/Temp_Monitor/.project
+++ b/Examples/MAX32650/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32650/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32650/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32650/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32650/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32650/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32650/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32650
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32650/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32650/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32650/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32650/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32650/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32650",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32650.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32650/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32650/Temp_Monitor/Makefile
+++ b/Examples/MAX32650/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32650
+TARGET_UC := MAX32650
+TARGET_LC := max32650
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32650/Temp_Monitor/README.md
+++ b/Examples/MAX32650/Temp_Monitor/README.md
@@ -1,0 +1,40 @@
+## Description
+
+This simple application demonstrates the use of the MAX32650 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing push button SW3 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN2 (USB/PWR) connector.
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Make the following connections between the MAX32650 and MAX31889 EV Kits: P2.8-->SCL(J2.11), P2.7-->SDA(J2.12), VDD("1V8" or "3V3")-->VDD(J1.2), GND-->GND(J1.4)
+-   Ensure jumpers JP3 and JP5 are set to the same level as VDD.
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32650 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW3 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX32650/Temp_Monitor/README.md
+++ b/Examples/MAX32650/Temp_Monitor/README.md
@@ -34,7 +34,7 @@ will be printed in the terminal and the red warning LED will begin to blink.
 Otherwise if the temperature is within the defined limits, the green LED
 will continue to toggle each time a new measurement is taken.
 
-Press SW3 to print the last 12 temperature readings taken.
+Press SW2 to print the last 12 temperature readings taken.
 ```
 
 Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX32650/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32650/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32650.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32650/Include/max32650.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32650/Temp_Monitor/main.c
+++ b/Examples/MAX32650/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32650 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press SW2 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32650/Temp_Monitor/project.mk
+++ b/Examples/MAX32650/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32650/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32650/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable();
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable();
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(1); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32650/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32650/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32650_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32650_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32650_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX32655/Temp_Monitor/.cproject
+++ b/Examples/MAX32655/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32655/Temp_Monitor/.project
+++ b/Examples/MAX32655/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32655/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32655/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32655/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32655/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32655/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32655/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32655
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32655/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32655/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32655/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32655/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32655/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32655",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32655.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32655/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32655/Temp_Monitor/Makefile
+++ b/Examples/MAX32655/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32655
+TARGET_UC := MAX32655
+TARGET_LC := max32655
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32655/Temp_Monitor/README.md
+++ b/Examples/MAX32655/Temp_Monitor/README.md
@@ -1,0 +1,43 @@
+## Description
+
+This simple application demonstrates the use of the MAX32655 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing push button SW3 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
+-   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Close jumper JP2 (LED0 EN).
+-   Close jumper JP3 (LED1 EN).
+-   Set jumper JP21 to "VDDIOH".
+-   Make the following connections between the MAX32655 and MAX31889 EV Kits: P0.10-->SCL(J2.11), P0.11-->SDA(J2.12), VDDIOH(JP20.3)-->VDD(J1.2), GND-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32655 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW3 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX32655/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32655/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32655.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32655/Temp_Monitor/main.c
+++ b/Examples/MAX32655/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32655 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press SW3 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32655/Temp_Monitor/project.mk
+++ b/Examples/MAX32655/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32655/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32655/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 2
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable(MXC_ICC0);
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable(MXC_ICC0);
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(1); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32655/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32655/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32655_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32655_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32655_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX32660/Temp_Monitor/.cproject
+++ b/Examples/MAX32660/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32660/Temp_Monitor/.project
+++ b/Examples/MAX32660/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32660/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32660/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32660/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32660/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32660/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32660/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32660
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32660/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32660/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32660/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32660/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32660/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32660",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32660.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32660/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32660/Temp_Monitor/Makefile
+++ b/Examples/MAX32660/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32660
+TARGET_UC := MAX32660
+TARGET_LC := max32660
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32660/Temp_Monitor/README.md
+++ b/Examples/MAX32660/Temp_Monitor/README.md
@@ -1,0 +1,38 @@
+## Description
+
+This simple application demonstrates the use of the MAX32660 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the LED will begin to flash at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the LED will stay illuminated until a temperature warning occurs.
+
+Additionally, pressing push button SW2 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+-   Connect a USB cable between the PC and the CN2 (USB/PWR) connector.
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Make the following connections between the MAX32660 and MAX31889 EV Kits: P0.8(JH3.6)-->SCL(J2.11), P0.7(JH3.7)-->SDA(J2.12), VDDIO(JH3.9)-->VDD(J1.2), GND(JH4.9)-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32660 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the LED will begin to flash ata rate of
+4Hz. Otherwise if the temperature is within the defined limits, the LED will
+stay illuminated until a temperature warning occurs.
+
+Press SW2 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX32660/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32660/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32660.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32660/Include/max32660.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32660/Temp_Monitor/main.c
+++ b/Examples/MAX32660/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32660 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the LED will begin to flash at a rate of\n");
+    printf("4Hz. Otherwise if the temperature is within the defined limits, the LED will\n");
+    printf("stay illuminated until a temperature warning occurs.\n\n");
+
+    printf("Press SW2 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32660/Temp_Monitor/project.mk
+++ b/Examples/MAX32660/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32660/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32660/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable();
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable();
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(0);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(0);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_On(0); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32660/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32660/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32660_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32660_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32660_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX32662/Temp_Monitor/.cproject
+++ b/Examples/MAX32662/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32662/Temp_Monitor/.project
+++ b/Examples/MAX32662/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32662/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32662/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32662/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32662/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32662/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32662/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32662
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32662/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32662/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32662/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32662/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32662/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32662",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32662.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32662/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32662/Temp_Monitor/Makefile
+++ b/Examples/MAX32662/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32662
+TARGET_UC := MAX32662
+TARGET_LC := max32662
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32662/Temp_Monitor/README.md
+++ b/Examples/MAX32662/Temp_Monitor/README.md
@@ -1,0 +1,41 @@
+## Description
+
+This simple application demonstrates the use of the MAX32662 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the LED will begin to flash at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the LED will stay illuminated until a temperature warning occurs.
+
+Additionally, pressing push button SW2 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
+-   Install headers JP7(RX\_EN) and JP8(TX\_EN).
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Remove the "VREF" jumper (JP1) on the MAX32662 EV Kit.
+-   Make the following connections between the MAX32662 and MAX31889 EV Kits: P0.12(JH2.3)-->SCL(J2.11), P0.13(JH2.1)-->SDA(J2.12), VAUX-->VDD(J1.2), GND-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32662 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the LED will begin to flash at a rate of
+4Hz. Otherwise if the temperature is within the defined limits, the LED will
+stay illuminated until the next temperature warning occurs.
+
+Press SW2 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED either illuminated or flashing.

--- a/Examples/MAX32662/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32662/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32662.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32662/Temp_Monitor/main.c
+++ b/Examples/MAX32662/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32662 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the LED will begin to flash at a rate of\n");
+    printf("4Hz. Otherwise if the temperature is within the defined limits, the LED will\n");
+    printf("stay illuminated until the next temperature warning occurs.\n\n");
+
+    printf("Press SW2 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32662/Temp_Monitor/project.mk
+++ b/Examples/MAX32662/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32662/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32662/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable();
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable();
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(0);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(0);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_On(0); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32662/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32662/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32662_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32662_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32662_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX32665/Temp_Monitor/.cproject
+++ b/Examples/MAX32665/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32665/Temp_Monitor/.project
+++ b/Examples/MAX32665/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32665/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32665/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32665/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32665/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32665/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32665/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32665
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32665/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32665/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32665/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32665/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32665/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32665",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32665.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32665/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32665/Temp_Monitor/Makefile
+++ b/Examples/MAX32665/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32665
+TARGET_UC := MAX32665
+TARGET_LC := max32665
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32665/Temp_Monitor/README.md
+++ b/Examples/MAX32665/Temp_Monitor/README.md
@@ -1,0 +1,40 @@
+## Description
+
+This simple application demonstrates the use of the MAX32665 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing push button SW2 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN2 (USB/PWR) connector.
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Ensure the I2C1 pullup enable jumper (JP2) is installed.
+-   Make the following connections between the MAX32665 and MAX31889 EV Kits: P0.14-->SCL(J2.11), P0.15-->SDA(J2.12), VDDIOH(JP1.2)-->VDD(J1.2), GND(JH3.8)-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32665 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW2 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED D2 or LED D3 being toggled periodically.

--- a/Examples/MAX32665/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32665/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32665.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32665/Include/max32665.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32665/Temp_Monitor/main.c
+++ b/Examples/MAX32665/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32665 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press SW2 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32665/Temp_Monitor/project.mk
+++ b/Examples/MAX32665/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32665/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32665/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C1_BUS0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable();
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable();
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(1); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32665/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32665/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32665_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32665_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32665_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX32670/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32670/Temp_Monitor/.vscode/settings.json
@@ -23,7 +23,7 @@
     "symbol_file":"${config:program_file}",
 
     "M4_OCD_interface_file":"cmsis-dap.cfg",
-    "M4_OCD_target_file":"${config:target}.cfg",
+    "M4_OCD_target_file":"max32670.cfg",
     "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
     "RV_OCD_target_file":"${config:target}_riscv.cfg",
 

--- a/Examples/MAX32670/Temp_Monitor/README.md
+++ b/Examples/MAX32670/Temp_Monitor/README.md
@@ -8,7 +8,7 @@ If a temperature reading exceeds the upper or lower limits, a warning message wi
 
 Additionally, pressing push button SW3 will print the last 12 temperature readings in the terminal.
 
-The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO_TEMP_THRESHOLD, TR_STORAGE_PAGE, and TEMP_CHECK_PERIOD defines respectively.
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
 
 ## Required Connections
 

--- a/Examples/MAX32672/Temp_Monitor/.cproject
+++ b/Examples/MAX32672/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32672/Temp_Monitor/.project
+++ b/Examples/MAX32672/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32672/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32672/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32672/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32672/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32672/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32672/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32672
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32672/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32672/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32672/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32672/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32672/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32672",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32672.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32672/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32672/Temp_Monitor/Makefile
+++ b/Examples/MAX32672/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32672
+TARGET_UC := MAX32672
+TARGET_LC := max32672
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32672/Temp_Monitor/README.md
+++ b/Examples/MAX32672/Temp_Monitor/README.md
@@ -1,0 +1,41 @@
+## Description
+
+This simple application demonstrates the use of the MAX32672 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing push button SW3 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
+-   Select RX0 and TX0 on Headers JP10 and JP11 (UART 0).
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Ensure the I2C0 pullup enable jumpers (JP4 and JP5) are installed.
+-   Make the following connections between the MAX32672 and MAX31889 EV Kits: P0.6-->SCL(J2.11), P0.7-->SDA(J2.12), VAUX(JH3.7)-->VDD(J1.2), GND(JH3.8)-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32672 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW3 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX32672/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32672/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32672.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32672/Temp_Monitor/main.c
+++ b/Examples/MAX32672/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32672 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press SW3 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32672/Temp_Monitor/project.mk
+++ b/Examples/MAX32672/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32672/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32672/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable();
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable();
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(1); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32672/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32672/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32672_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32672_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32672_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX32680/Temp_Monitor/.cproject
+++ b/Examples/MAX32680/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32680/Temp_Monitor/.project
+++ b/Examples/MAX32680/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32680/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32680/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32680/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32680/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32680/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32680/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32680
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32680/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32680/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32680/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32680/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32680/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32680",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32680.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32680/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32680/Temp_Monitor/Makefile
+++ b/Examples/MAX32680/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32680
+TARGET_UC := MAX32680
+TARGET_LC := max32680
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32680/Temp_Monitor/README.md
+++ b/Examples/MAX32680/Temp_Monitor/README.md
@@ -1,0 +1,43 @@
+## Description
+
+This simple application demonstrates the use of the MAX32680 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing push button SW1 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
+-   Connect pins JP22(RX_SEL) and JP23(TX_SEL) to UART1 header.
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Close jumper JP2 (LED0 EN).
+-   Close jumper JP3 (LED1 EN).
+-   Select "VDDIOH" on the I2C0 pullup level select jumper (JP8).
+-   Make the following connections between the MAX32680 and MAX31889 EV Kits: P0.10-->SCL(J2.11), P0.11-->SDA(J2.12), VDDIOH(JP9.3)-->VDD(J1.2), GND-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32680 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW1 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX32680/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32680/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32680.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32680/Temp_Monitor/main.c
+++ b/Examples/MAX32680/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32680 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press SW1 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32680/Temp_Monitor/project.mk
+++ b/Examples/MAX32680/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32680/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32680/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable(MXC_ICC0);
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable(MXC_ICC0);
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(1); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32680/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32680/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32680_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32680_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32680_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX32690/Temp_Monitor/.cproject
+++ b/Examples/MAX32690/Temp_Monitor/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32690/Temp_Monitor/.project
+++ b/Examples/MAX32690/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32690/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX32690/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32690/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32690/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32690/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32690/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32690
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32690/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32690/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32690/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32690/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32690/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32690",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32690.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32690/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32690/Temp_Monitor/Makefile
+++ b/Examples/MAX32690/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32690
+TARGET_UC := MAX32690
+TARGET_LC := max32690
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32690/Temp_Monitor/README.md
+++ b/Examples/MAX32690/Temp_Monitor/README.md
@@ -1,0 +1,44 @@
+2## Description
+
+This simple application demonstrates the use of the MAX32690 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing push button SW2 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN2 (USB/PWR) connector.
+-   Install JP7(RX_EN) and JP8(TX_EN) headers.
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Close jumper JP5 (LED1 EN).
+-   Close jumper JP6 (LED2 EN).
+-   Select "1V8" on the V_AUX_SEL jumper (JP11) and "VDDIO" on the I2C0 pullup level select jumper (JP2).
+-   Ensure the I2C0 pullup enable jumpers (JP3 and JP4) are installed.
+-   Make the following connections between the MAX32690 and MAX31889 EV Kits: P2.8-->SCL(J2.11), P2.7-->SDA(J2.12), VAUX-->VDD(J1.2), GND-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX32690 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW2 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX32690/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX32690/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32690.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32690/Temp_Monitor/main.c
+++ b/Examples/MAX32690/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX32690 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press SW2 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX32690/Temp_Monitor/project.mk
+++ b/Examples/MAX32690/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX32690/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX32690/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH0_MEM_BASE + MXC_FLASH0_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH0_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable(MXC_ICC0);
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable(MXC_ICC0);
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(1);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(1); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(0); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(0);
+}

--- a/Examples/MAX32690/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX32690/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX32690_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX32690_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX32690_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX78000/Temp_Monitor/.cproject
+++ b/Examples/MAX78000/Temp_Monitor/.cproject
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/LED&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/PMIC&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/PushButton&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/CODEC&quot;"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX78000/Temp_Monitor/.project
+++ b/Examples/MAX78000/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX78000/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX78000/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX78000/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX78000/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX78000/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX78000/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX78000
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX78000/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX78000/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX78000/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX78000/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX78000/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,89 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX78000",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max78000.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/CODEC"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/CODEC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX78000/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX78000/Temp_Monitor/Makefile
+++ b/Examples/MAX78000/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX78000
+TARGET_UC := MAX78000
+TARGET_LC := max78000
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX78000/Temp_Monitor/README.md
+++ b/Examples/MAX78000/Temp_Monitor/README.md
@@ -1,0 +1,50 @@
+## Description
+
+This simple application demonstrates the use of the MAX78000 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing the push button will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+If using the Standard EvKit (EvKit_V1):
+-   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
+-   Connect pins 1 and 2 (P0_1) of the JH1 (UART 0 EN) header.
+-   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Close jumper JP1 (LED1 EN).
+-   Close jumper JP2 (LED2 EN).
+-	Select "EvKit_V1" for _BOARD_ in "project.mk"
+-   Make the following connections between the MAX78000 and MAX31889 EV Kits: P0.30-->SCL(J2.11), P0.31-->SDA(J2.12), VDDIO(JP9.3)-->VDD(J1.2), GND-->GND(J1.4)
+
+If using the Featherboard (FTHR_RevA):
+-   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
+-	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-	Select "FTHR_RevA" for _BOARD_ in "project.mk"
+-   Make the following connections between the MAX78000 and MAX31889 EV Kits: P0.16(J4.11)-->SCL(J2.11), P0.17(J4.12)-->SDA(J2.12), 3V3(J8.2)-->VDD(J1.2), GND(J8.4)-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX78000 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW2 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX78000/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX78000/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max78000.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX78000/Temp_Monitor/main.c
+++ b/Examples/MAX78000/Temp_Monitor/main.c
@@ -1,0 +1,121 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Defines *****/
+#ifdef BOARD_EVKIT_V1
+#define PB "SW2"
+#else
+#define PB "SW1"
+#endif
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX78000 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press %s to print the last 12 temperature readings taken.\n\n", PB);
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX78000/Temp_Monitor/project.mk
+++ b/Examples/MAX78000/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX78000/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX78000/Temp_Monitor/temp_monitor.c
@@ -66,7 +66,6 @@
 #define HEARTBEAT_LED 1
 #endif
 
-
 #define TEMP_SENS_FREQ 100000
 
 #define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)

--- a/Examples/MAX78000/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX78000/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,303 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#ifdef BOARD_EVKIT_V1
+#define TEMP_SENS_I2C MXC_I2C2
+#define WARNING_LED 1
+#define HEARTBEAT_LED 0
+#else
+#define TEMP_SENS_I2C MXC_I2C1
+#define WARNING_LED 0
+#define HEARTBEAT_LED 1
+#endif
+
+
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable(MXC_ICC0);
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable(MXC_ICC0);
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(HEARTBEAT_LED);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(HEARTBEAT_LED);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(HEARTBEAT_LED); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(WARNING_LED); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(WARNING_LED);
+}

--- a/Examples/MAX78000/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX78000/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX78000_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX78000_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX78000_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Examples/MAX78002/Temp_Monitor/.cproject
+++ b/Examples/MAX78002/Temp_Monitor/.cproject
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/LED&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/PMIC&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/PushButton&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen&quot;"/>
+<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/CODEC&quot;"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Temp_Monitor.null.923778415" name="Temp_Monitor"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/Temp_Monitor"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX78002/Temp_Monitor/.project
+++ b/Examples/MAX78002/Temp_Monitor/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Temp_Monitor</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX78002/Temp_Monitor/.settings/language.settings.xml
+++ b/Examples/MAX78002/Temp_Monitor/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX78002/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX78002/Temp_Monitor/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX78002/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX78002/Temp_Monitor/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=Temp_Monitor
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX78002
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX78002/Temp_Monitor/.vscode/README.md
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX78002/Temp_Monitor/.vscode/c_cpp_properties.json
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX78002/Temp_Monitor/.vscode/flash.gdb
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX78002/Temp_Monitor/.vscode/launch.json
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX78002/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/settings.json
@@ -1,0 +1,89 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX78002",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max78002.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/CODEC"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/CODEC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX78002/Temp_Monitor/.vscode/tasks.json
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX78002/Temp_Monitor/Makefile
+++ b/Examples/MAX78002/Temp_Monitor/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX78002
+TARGET_UC := MAX78002
+TARGET_LC := max78002
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX78002/Temp_Monitor/README.md
+++ b/Examples/MAX78002/Temp_Monitor/README.md
@@ -1,0 +1,43 @@
+## Description
+
+This simple application demonstrates the use of the MAX78002 as a temperature monitor. **NOTE: A MAX31889EVSYS is required to run the example.**
+
+The device uses the RTC to trigger periodic measurements of the air temperature. Each time the RTC time-of-day alarm expires, the latest temperature reading is taken from an external MAX31889 temperature sensor which is connected to the device via I2C. The measurment is then time-stamped with the current time in the RTC and placed in a buffer. Once four successful measurements have been taken, they are stored in flash.
+
+If a temperature reading exceeds the upper or lower limits, a warning message will be printed in the terminal and the red warning LED will begin to blink at a frequnecy of 4Hz. Otherwise if the temperature is within the defined limits, the green LED will continue to toggle each time a new measurement is taken.
+
+Additionally, pressing push button SW4 will print the last 12 temperature readings in the terminal.
+
+The temperature limits, flash storage page, and RTC time-of-day alarm period are defined in [temp_monitor.c](./temp_monitor.c) with the HI/LO\_TEMP\_THRESHOLD, TR\_STORAGE\_PAGE, and TEMP\_CHECK\_PERIOD defines respectively.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN2 (USB/PWR) connector.
+-   Connect the 5V power cable at (5V IN).
+-   Close jumper (RX - P0.0) and (TX - P0.1) at Headers JP23 (UART 0 EN).
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Close jumper JP1 (LED1 EN).
+-   Close jumper JP2 (LED2 EN).
+-   Make the following connections between the MAX78002 and MAX31889 EV Kits: P0.10-->SCL(J2.11), P0.11-->SDA(J2.12), 1V8(JP37.1)-->VDD(J1.2), GND-->GND(J1.4)
+
+## Expected Output
+
+The Console UART of the device will output these messages:
+
+```
+********************** Temperature Monitor Demo **********************
+This simple example demonstrates the use of the MAX78002 as a temperature
+monitor.
+
+The device periodically measures the air temperature using an external
+MAX31889 temperature sensor.
+
+If a temperature reading exceeds the upper or lower limits, a warning message
+will be printed in the terminal and the red warning LED will begin to blink.
+Otherwise if the temperature is within the defined limits, the green LED
+will continue to toggle each time a new measurement is taken.
+
+Press SW4 to print the last 12 temperature readings taken.
+```
+
+Additonally you should see either LED 0 or LED 1 being toggled periodically.

--- a/Examples/MAX78002/Temp_Monitor/Temp_Monitor.launch
+++ b/Examples/MAX78002/Temp_Monitor/Temp_Monitor.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max78002.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/Temp_Monitor.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="Temp_Monitor"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/Temp_Monitor"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX78002/Temp_Monitor/main.c
+++ b/Examples/MAX78002/Temp_Monitor/main.c
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   Low-Power Temp Monitor example.
+ * @details In this example the MCU is used monitor the air temperature. Temperature 
+ *          readings are timestamped and placed in flash. If a reading exceeds the 
+ *          user defined temperature limits a warning message will be printed to the 
+ *          terminal and the red warning light will begin to flash.  
+ */
+
+/***** Included Files *****/
+#include <stdio.h>
+#include "board.h"
+#include "lp.h"
+#include "temp_monitor.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "pb.h"
+#include "rtc.h"
+#include "uart.h"
+
+/***** Functions *****/
+void RTC_IRQHandler(void)
+{
+    int flags = MXC_RTC_GetFlags();
+    MXC_RTC_ClearFlags(flags);
+
+    // RTC TOD alarm --> check temperature
+    if (flags & MXC_RTC_INT_FL_LONG) {
+        temp_monitor_check_temp();
+    }
+
+    // RTC SSEC alarm --> toggle warning light
+    if (flags & MXC_RTC_INT_FL_SHORT) {
+        temp_monitor_flash_warning_light();
+    }
+}
+
+void PB_Handler(void *pb)
+{
+    temp_monitor_print_temps();
+}
+
+int main(void)
+{
+    int err;
+
+    MXC_Delay(MXC_DELAY_SEC(2)); //Delay to give debugger a connection window
+
+    printf("\n********************** Temperature Monitor Demo **********************\n");
+
+    printf("This simple example demonstrates the use of the MAX78002 as a temperature\n");
+    printf("monitor.\n\n");
+
+    printf("The device periodically measures the air temperature using an external\n");
+    printf("MAX31889 temperature sensor.\n\n");
+
+    printf("If a temperature reading exceeds the upper or lower limits, a warning message\n");
+    printf("will be printed in the terminal and the red warning LED will begin to blink.\n");
+    printf("Otherwise if the temperature is within the defined limits, the green LED\n");
+    printf("will continue to toggle each time a new measurement is taken.\n\n");
+
+    printf("Press SW4 to print the last 12 temperature readings taken.\n\n");
+
+    // Initialize Temperature Monitor
+    if ((err = temp_monitor_init()) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Configure pushbutton as a wakeup source and set interrupt callback
+    MXC_LP_EnableGPIOWakeup((mxc_gpio_cfg_t *)&pb_pin[0]);
+    PB_RegisterCallback(0, PB_Handler);
+    PB_IntEnable(0);
+
+    while (1) {
+        while (MXC_UART_GetActive(MXC_UART_GET_UART(CONSOLE_UART))) {}
+        //Make sure print statements have finished before sleeping
+        MXC_LP_EnterSleepMode(); //Wait for next RTC interrupt
+    }
+
+    return E_NO_ERROR;
+}

--- a/Examples/MAX78002/Temp_Monitor/project.mk
+++ b/Examples/MAX78002/Temp_Monitor/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+# **********************************************************
+
+# Include MAX31889 drivers from MiscDrivers library.
+SRCS+=max31889_driver.c
+
+VPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor
+IPATH+=$(LIBS_DIR)/MiscDrivers/TempSensor

--- a/Examples/MAX78002/Temp_Monitor/temp_monitor.c
+++ b/Examples/MAX78002/Temp_Monitor/temp_monitor.c
@@ -1,0 +1,293 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+#include <stdbool.h>
+#include <stdio.h>
+#include "flc.h"
+#include "i2c.h"
+#include "icc.h"
+#include "led.h"
+#include "lp.h"
+#include "max31889_driver.h"
+#include "mxc_device.h"
+#include "rtc.h"
+#include "temp_monitor.h"
+
+/***** Definitions *****/
+/***** Modifiable defines *****/
+#define HI_TEMP_THRESHOLD 30
+#define LO_TEMP_THRESHOLD 15
+#define TEMP_CHECK_PERIOD 5
+#define TR_STORAGE_PAGE 1
+//NOTE: Ensure "TR_STORAGE_PAGE" is less than the total number of flash pages in the device.
+//      If you select a higher value, consider setting LINKERFILE to $(TARGET_LC)_ram.ld in
+//      project.mk otherwise application code may get overwritten.
+
+/****** Do not Modify these Defines *****/
+#define TR_STORAGE_BASE_ADDR \
+    (MXC_FLASH_MEM_BASE + MXC_FLASH_MEM_SIZE - (TR_STORAGE_PAGE * MXC_FLASH_PAGE_SIZE))
+
+#define TEMP_SENS_I2C MXC_I2C0
+#define TEMP_SENS_FREQ 100000
+
+#define MSEC_TO_RSSA(msec) ((msec * 4096) / 1000)
+#define WARN_LIGHT_PERIOD (0xFFFFFFFF - MSEC_TO_RSSA(250))
+
+#define TEMPERATURE_MASK 0x0000FFFF
+#define TIMESTAMP_MASK 0xFFFF0000
+#define TIMESTAMP_OFFSET 16
+
+/***** Global Variables *****/
+static max31889_driver_t g_temp_sensor;
+static bool g_temp_warning = false;
+static uint32_t g_temp_readings[4];
+static uint32_t g_num_readings = 0;
+
+/******************************************************************/
+/************************ Private Functions ***********************/
+/******************************************************************/
+
+/***** Flash Functions *****/
+static int init_flash(void)
+{
+    int err;
+
+    // Initialize flash controller
+    err = MXC_FLC_Init();
+
+    // Clear flash page used to store temperature readings
+    err += MXC_FLC_PageErase(TR_STORAGE_BASE_ADDR);
+
+    return err;
+}
+
+static void store_temp_readings(void)
+{
+    // Calculate flash address to store temperature readings at
+    int flash_addr = TR_STORAGE_BASE_ADDR + (g_num_readings - 4) * sizeof(g_temp_readings[0]);
+
+    // Write last 4 temp readings to flash
+    MXC_ICC_Disable(MXC_ICC0);
+    if (MXC_FLC_Write128(flash_addr, g_temp_readings) != E_NO_ERROR) {
+        //Failed to write to flash, decrement num_readings to reflect fact
+        //that the last 4 readings taken are not stored in flash
+        g_num_readings -= 4;
+    }
+    MXC_ICC_Enable(MXC_ICC0);
+}
+
+/***** Temperature Sensor Functions *****/
+static int init_temp_sensor(void)
+{
+    int err;
+
+    // Initialize I2C connected to temperature sensor
+    if ((err = MXC_I2C_Init(TEMP_SENS_I2C, 1, 0)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_I2C_SetFrequency(TEMP_SENS_I2C, TEMP_SENS_FREQ);
+
+    // Get MAX31889 function pointers
+    g_temp_sensor = MAX31889_Open();
+
+    // Initialize MAX31889 temperature sensor
+    return g_temp_sensor.init(TEMP_SENS_I2C, MAX31889_I2C_SLAVE_ADDR0);
+}
+
+static void record_current_temp(uint32_t current_time)
+{
+    uint32_t temp_reading;
+    float temp_reading_float;
+
+    // Get current temperature
+    if (g_temp_sensor.read((void *)&temp_reading_float) != E_NO_ERROR) {
+        return;
+    }
+
+    // Record current temperature with timestamp
+    temp_reading = (uint32_t)temp_reading_float;
+    g_temp_readings[(g_num_readings % 4)] = (current_time << TIMESTAMP_OFFSET) | temp_reading;
+
+    // Increment readings counter (reset to 0 if flash page has been filled)
+    g_num_readings = (g_num_readings + 1) % (MXC_FLASH_PAGE_SIZE / sizeof(g_temp_readings[0]));
+
+    // Store temperatures to flash if 4 readings have been taken
+    // Note: we store them every 4 readings so we are able to do a 128-bit write
+    if (g_num_readings % 4 == 0) {
+        store_temp_readings();
+    }
+
+    // Check if temperature has exceeded a threshold
+    if (temp_reading > HI_TEMP_THRESHOLD) {
+        LED_Off(0);
+        g_temp_warning = true;
+        printf("Temperature exceeded upper threshold!\n");
+    } else if (temp_reading < LO_TEMP_THRESHOLD) {
+        LED_Off(0);
+        g_temp_warning = true;
+        printf("Temperature exceeded lower threshold!\n");
+    } else {
+        LED_Toggle(0); //Heartbeat
+        g_temp_warning = false;
+    }
+
+    return;
+}
+
+/***** RTC Functions *****/
+static int start_rtc(void)
+{
+    int err;
+
+    // Initialize RTC
+    if ((err = MXC_RTC_Init(0, 0)) != E_NO_ERROR) {
+        return err;
+    }
+
+    // Setup TOD alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG); //TOD alarm interrupt most be disabled to set period
+    if ((err = MXC_RTC_SetTimeofdayAlarm(TEMP_CHECK_PERIOD)) != E_NO_ERROR) {
+        return err;
+    }
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Enable RTC Wakeup
+    MXC_LP_EnableRTCAlarmWakeup();
+    NVIC_EnableIRQ(RTC_IRQn);
+
+    // Start RTC
+    return MXC_RTC_Start();
+}
+
+static void enable_warning_light(void)
+{
+    // Set subsecond alarm period and enable interrupt
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT); //SSEC alarm must be disabled to set period
+    MXC_RTC_SetSubsecondAlarm(WARN_LIGHT_PERIOD);
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_SHORT);
+    return;
+}
+
+static void disable_warning_light(void)
+{
+    // Disable SSEC alarm
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+
+    LED_Off(1); //Make sure warning light is off
+    return;
+}
+
+/******************************************************************/
+/************************ Public Functions ************************/
+/******************************************************************/
+
+/***** Initialization Function *****/
+int temp_monitor_init(void)
+{
+    int err;
+
+    if ((err = init_flash()) != E_NO_ERROR) { //Init flash space used to store temp readings
+        return err;
+    } else if ((err = init_temp_sensor()) != E_NO_ERROR) { //Init temperature sensor (and I2C)
+        return err;
+    } else if ((err = start_rtc()) != E_NO_ERROR) { //Init and start RTC, and set up TOD alarm
+        return err;
+    }
+
+    return E_NO_ERROR;
+}
+
+/***** Push Button ISR *****/
+void temp_monitor_print_temps(void)
+{
+    int addr_offset;
+    int num_temp;
+    uint32_t temps[12]; //Read a maximum of 12 temperatures
+    uint16_t time, temp;
+
+    // Calculate the number of temperature readings currently stored in flash
+    num_temp = g_num_readings - (g_num_readings % 4);
+
+    // Determine how many temperatures to read (limit 12) and where in flash they're located
+    if (num_temp == 0) {
+        printf("\nNo temperatures recorded, try reading again later.\n");
+        return;
+    } else if (num_temp < 12) {
+        addr_offset = 0;
+    } else {
+        addr_offset = (num_temp - 12) * sizeof(g_temp_readings[0]);
+        num_temp = 12;
+    }
+
+    // Read all temperature readings stored in flash
+    MXC_FLC_Read(TR_STORAGE_BASE_ADDR + addr_offset, temps, sizeof(temps));
+
+    // Print out each temperature reading with it's timestamp
+    printf("\nLast %d temperature Readings:\n", num_temp);
+    for (int i = 0; i < num_temp; i++) {
+        time = (temps[i] & TIMESTAMP_MASK) >> TIMESTAMP_OFFSET;
+        temp = temps[i] & TEMPERATURE_MASK;
+        printf("%ds - Temp: %dC\n", time, temp);
+    }
+}
+
+/***** RTC Alarm ISRs *****/
+void temp_monitor_check_temp(void)
+{
+    uint32_t current_sec, dummy;
+
+    // Get current time
+    while (MXC_RTC_GetTime(&current_sec, &dummy) == E_BUSY) {}
+
+    // Set next TOD alarm TEMP_CHECK_PERIOD seconds into the future
+    MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+    while (MXC_RTC_SetTimeofdayAlarm(current_sec + TEMP_CHECK_PERIOD) == E_BUSY) {}
+    MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
+
+    // Take temperature readinf
+    record_current_temp(current_sec);
+
+    // Enable or disable warning light if necessary
+    if (g_temp_warning && !(MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning active and warning light inactive --> enable
+        enable_warning_light();
+    } else if (!g_temp_warning && (MXC_RTC->ctrl & MXC_RTC_INT_EN_SHORT)) {
+        //Temp warning inactive and warning light active --> disable
+        disable_warning_light();
+    }
+}
+
+void temp_monitor_flash_warning_light(void)
+{
+    // Toggle warning light
+    LED_Toggle(1);
+}

--- a/Examples/MAX78002/Temp_Monitor/temp_monitor.h
+++ b/Examples/MAX78002/Temp_Monitor/temp_monitor.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a
+* copy of this software and associated documentation files (the "Software"),
+* to deal in the Software without restriction, including without limitation
+* the rights to use, copy, modify, merge, publish, distribute, sublicense,
+* and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included
+* in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+* OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+* Except as contained in this notice, the name of Maxim Integrated
+* Products, Inc. shall not be used except as stated in the Maxim Integrated
+* Products, Inc. Branding Policy.
+*
+* The mere transfer of this software does not imply any licenses
+* of trade secrets, proprietary technology, copyrights, patents,
+* trademarks, maskwork rights, or any other form of intellectual
+* property whatsoever. Maxim Integrated Products, Inc. retains all
+* ownership rights.
+*******************************************************************************
+*/
+
+#ifndef EXAMPLES_MAX78002_TEMP_MONITOR_TEMP_MONITOR_H_
+#define EXAMPLES_MAX78002_TEMP_MONITOR_TEMP_MONITOR_H_
+
+/*
+ * @brief Initializes the components of the temperature monitor (Flash, RTC, I2C, and MAX31889).
+ */
+int temp_monitor_init(void);
+
+/*
+ * @brief Reads the latest temperature readings from flash and prints them to the terminal.
+ */
+void temp_monitor_print_temps(void);
+
+/*
+ * @brief Checks the current air temperature. This function will activate or deactivate the warning
+ * 		  light if necessary, and will also print a temperature warning message if necessary.
+ */
+void temp_monitor_check_temp(void);
+
+/*
+ * @brief Toggles warning light. 
+ */
+void temp_monitor_flash_warning_light(void);
+
+#endif // EXAMPLES_MAX78002_TEMP_MONITOR_TEMP_MONITOR_H_

--- a/Libraries/Boards/MAX32572/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32572/EvKit_V1/examples.txt
@@ -40,6 +40,7 @@ SPIXF
 SPIXR
 SPI_MasterSlave
 SRCC
+Temp_Monitor
 TFT_Demo
 TMR
 TRNG

--- a/Libraries/Boards/MAX32650/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32650/EvKit_V1/examples.txt
@@ -46,6 +46,7 @@ SPIXF
 SPIXR
 SPI_MasterSlave
 SysTick
+Temp_Monitor
 TMR
 TRNG
 UART

--- a/Libraries/Boards/MAX32655/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32655/EvKit_V1/examples.txt
@@ -52,6 +52,7 @@ RTC
 RTC_Backup
 RV_ARM_Loader
 SPI
+Temp_Monitor
 TFT_Demo
 TMR
 TRNG

--- a/Libraries/Boards/MAX32660/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32660/EvKit_V1/examples.txt
@@ -31,6 +31,7 @@ RTC_Backup
 SPI
 SPIMSS
 SPI_MasterSlave
+Temp_Monitor
 TMR
 UART
 UART_Wakeup

--- a/Libraries/Boards/MAX32662/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32662/EvKit_V1/examples.txt
@@ -32,6 +32,7 @@ RTC_Backup
 SCPA_OTP_Dump
 SPI
 SPI_MasterSlave
+Temp_Monitor
 TMR
 TRNG
 UART

--- a/Libraries/Boards/MAX32665/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32665/EvKit_V1/examples.txt
@@ -57,6 +57,7 @@ SPI
 SPIXF
 SPIXR
 SRCC
+Temp_Monitor
 TMR
 TRNG
 UART

--- a/Libraries/Boards/MAX32670/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32670/EvKit_V1/examples.txt
@@ -29,6 +29,7 @@ RTC
 SPI
 SPI_Usecase
 SPI_MasterSlave
+Temp_Monitor
 TMR
 TRNG
 UART

--- a/Libraries/Boards/MAX32672/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32672/EvKit_V1/examples.txt
@@ -36,6 +36,7 @@ RTC_Backup
 SCPA_OTP_Dump
 SPI
 SPI_MasterSlave
+Temp_Monitor
 TMR
 TRNG
 UART

--- a/Libraries/Boards/MAX32680/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32680/EvKit_V1/examples.txt
@@ -35,6 +35,7 @@ LP
 Pulse_Train
 RV_ARM_Loader
 SPI
+Temp_Monitor
 TMR
 TRNG
 UART

--- a/Libraries/Boards/MAX32690/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32690/EvKit_V1/examples.txt
@@ -49,6 +49,7 @@ RTC_Backup
 RV_ARM_Loader
 SCPA_OTP_Dump
 SPI
+Temp_Monitor
 TFT_Demo
 TMR
 TRNG

--- a/Libraries/Boards/MAX78000/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX78000/EvKit_V1/examples.txt
@@ -54,6 +54,7 @@ Pulse_Train
 RTC
 RTC_Backup
 SPI
+Temp_Monitor
 TFT_Demo
 TMR
 TRNG

--- a/Libraries/Boards/MAX78000/FTHR_RevA/examples.txt
+++ b/Libraries/Boards/MAX78000/FTHR_RevA/examples.txt
@@ -55,6 +55,7 @@ RTC
 RTC_Backup
 SDHC_FTHR
 SPI
+Temp_Monitor
 TFT_Demo
 TMR
 TRNG

--- a/Libraries/Boards/MAX78002/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX78002/EvKit_V1/examples.txt
@@ -54,6 +54,7 @@ SDHC_FAT
 SDHC_Raw
 SPI
 SPI_MasterSlave
+Temp_Monitor
 TFT_Demo
 TMR
 TRNG


### PR DESCRIPTION
Porting the Temp_Monitor example (originally written for the MAX32670) to most other micros. MAX32520 excluded because it doesn't have an RTC and MAX32675 excluded because the EvKit doesn't have a VDDIO or VDDIOH pinout to connect to the MAX31889 VDD pin.