### PR TITLE
Ci tests update

### DIFF
--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -19,6 +19,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+     # Clean and remove any local modifications
       - name: Clean
         continue-on-error: true
         run: |
@@ -36,16 +37,39 @@ jobs:
           fi
 
           set -e
-
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
         with:
           submodules: false
           fetch-depth: 0
+      
+      # Locks all board preventing them from being used during a test
+      # even if only one board is being tested. This is so that another job
+      # does not possibly used one of the free boards that may connect to the 
+      #current board undertest
+      - name: Lock All Boards
+        if: ${{ always() }}
+        run: |          
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 780 /home/$USER/Workspace/Resource_Share/max32655_0.txt
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 600 /home/$USER/Workspace/Resource_Share/max32655_1.txt
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 780 /home/$USER/Workspace/Resource_Share/max32665_13.txt
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 780 /home/$USER/Workspace/Resource_Share/max32690_w1.txt
 
-      # Runs a set of commands using the runners shell
-      - name: BLE examples functionality test
+      # ME17
+      - name: TEST MAX32655
         run: |
+
+          # Remove local modifications
+          git scorch
+          # Update the submodules, this will use ssh
+          git submodule init
+          git submodule sync
+          git submodule update --init --recursive
+          cd Libraries/Cordio
+          git stash
+          git checkout 55b7bdcb76ec8ca3f4b7454fd2137cac01970cb0
+          cd ../../
+
           BLE_FILES_CHANGED=0
           
           # Check for changes made to these files
@@ -86,24 +110,153 @@ jobs:
           fi
           
           echo "Running Test"
+
+          cd .github/workflows/ci-tests/Examples_tests
+          chmod +x test_launcher.sh
+          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+          dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['uart0'])"`
+          dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])"`
+          ./test_launcher.sh max32655 $dut_uart $dut_serial
+      
+      # ME14
+      - name: TEST MAX32665
+        run: |
+          # Remove local modifications
+          git scorch
+          # Update the submodules, this will use ssh
+          git submodule init
+          git submodule sync
+          git submodule update --init --recursive
+          cd Libraries/Cordio
+          git stash
+          git checkout 55b7bdcb76ec8ca3f4b7454fd2137cac01970cb0
+          cd ../../
+
+          BLE_FILES_CHANGED=0
           
-          # Lock hardware resources
-          python3 /home/btm-ci/Workspace/Resource_Share/Resource_Share.py -l -t 600 /home/btm-ci/Workspace/Resource_Share/max32655_0.txt
-          python3 /home/btm-ci/Workspace/Resource_Share/Resource_Share.py -l -t 600 /home/btm-ci/Workspace/Resource_Share/max32655_1.txt
-          cp -r .github/workflows/ci-tests/Examples_tests .
-          chmod +x Examples_tests/local_testLauncher.sh
-          cd Examples_tests/
-          ./local_testLauncher.sh
+          # Check for changes made to these files
+          WATCH_FILES="\
+          Examples/MAX32665/BLE \
+          Libraries/libs.mk \
+          Libraries/CMSIS/Device/Maxim/MAX32665 \
+          Libraries/PeriphDrivers/libPeriphDriver.mk \
+          Libraries/PeriphDrivers/periphdriver.mk \
+          Libraries/PeriphDrivers/max32665_files.mk \
+          Libraries/PeriphDrivers/Source \
+          Libraries/PeriphDrivers/Include/MAX32665 \
+          Libraries/BlePhy/MAX32665 \
+          Libraries/Boards/MAX32665"
           
+          # Get the diff from main
+          CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/origin/main)
+          
+          echo "Watching these locations and files"
+          echo $WATCH_FILES
+          
+          echo "Checking the following changes"
+          echo $CHANGE_FILES
+          
+          # Assume we want to actually run the workflow if no files changed
+          if [[ "$CHANGE_FILES" != "" ]]; then
+            for watch_file in $WATCH_FILES; do 
+              if [[ "$CHANGE_FILES" == *"$watch_file"* ]]; then
+                BLE_FILES_CHANGED=1
+              fi
+            done
+            if [[ $BLE_FILES_CHANGED -eq 0 ]]
+            then
+              echo "Skipping Test"
+              exit 0
+            fi
+          fi
+          
+          echo "Running Test"
+          
+          cd .github/workflows/ci-tests/Examples_tests
+          chmod +x test_launcher.sh
+          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+          dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['uart1'])"`
+          dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])"`
+          ./test_launcher.sh max32665 $dut_uart $dut_serial          
+      
+      # ME18
+      - name: TEST MAX32690
+        run: |
+          # Remove local modifications
+          git scorch
+          # Update the submodules, this will use ssh
+          git submodule init
+          git submodule sync
+          git submodule update --init --recursive
+          cd Libraries/Cordio
+          git stash
+          git checkout 55b7bdcb76ec8ca3f4b7454fd2137cac01970cb0
+          cd ../../
+
+          BLE_FILES_CHANGED=0
+          
+          # Check for changes made to these files
+          WATCH_FILES="\
+          Examples/MAX32690/BLE \
+          Libraries/libs.mk \
+          Libraries/CMSIS/Device/Maxim/MAX32690 \
+          Libraries/PeriphDrivers/libPeriphDriver.mk \
+          Libraries/PeriphDrivers/periphdriver.mk \
+          Libraries/PeriphDrivers/max32690_files.mk \
+          Libraries/PeriphDrivers/Source \
+          Libraries/PeriphDrivers/Include/MAX32690 \
+          Libraries/BlePhy/MAX32690 \
+          Libraries/Boards/MAX32690"
+          
+          # Get the diff from main
+          CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/origin/main)
+          
+          echo "Watching these locations and files"
+          echo $WATCH_FILES
+          
+          echo "Checking the following changes"
+          echo $CHANGE_FILES
+          
+          # Assume we want to actually run the workflow if no files changed
+          if [[ "$CHANGE_FILES" != "" ]]; then
+            for watch_file in $WATCH_FILES; do 
+              if [[ "$CHANGE_FILES" == *"$watch_file"* ]]; then
+                BLE_FILES_CHANGED=1
+              fi
+            done
+            if [[ $BLE_FILES_CHANGED -eq 0 ]]
+            then
+              echo "Skipping Test"
+              exit 0
+            fi
+          fi
+          
+          echo "Running Test"
+          
+          cd .github/workflows/ci-tests/Examples_tests
+          chmod +x test_launcher.sh
+          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+          dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['uart2'])"`
+          dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['daplink'])"`            
+          ./test_launcher.sh max32690 $dut_uart $dut_serial          
+      
+      # Save test reports
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
             name: failure-report
-            path: Examples_tests/results/
+            path: .github/workflows/ci-tests/Examples_tests/results/
       
       # Unlock even when cancelled or failed
-      - name: unlock
+      # This needs some work, if the job is cancelled or times out because it could not get a LOCK
+      # it then jumps here and removes all locks, that were set by a different job   
+      - name: Unlock All Boards
         if: always()
         run: |
-          python3 /home/btm-ci/Workspace/Resource_Share/Resource_Share.py /home/btm-ci/Workspace/Resource_Share/max32655_1.txt
-          python3 /home/btm-ci/Workspace/Resource_Share/Resource_Share.py /home/btm-ci/Workspace/Resource_Share/max32655_0.txt
+
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py /home/$USER/Workspace/Resource_Share/max32655_0.txt
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py /home/$USER/Workspace/Resource_Share/max32655_1.txt
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py /home/$USER/Workspace/Resource_Share/max32665_13.txt
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py /home/$USER/Workspace/Resource_Share/max32690_w1.txt
+
+          

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -61,14 +61,6 @@ jobs:
 
           # Remove local modifications
           git scorch
-          # Update the submodules, this will use ssh
-          git submodule init
-          git submodule sync
-          git submodule update --init --recursive
-          cd Libraries/Cordio
-          git stash
-          git checkout 55b7bdcb76ec8ca3f4b7454fd2137cac01970cb0
-          cd ../../
 
           BLE_FILES_CHANGED=0
           
@@ -123,14 +115,6 @@ jobs:
         run: |
           # Remove local modifications
           git scorch
-          # Update the submodules, this will use ssh
-          git submodule init
-          git submodule sync
-          git submodule update --init --recursive
-          cd Libraries/Cordio
-          git stash
-          git checkout 55b7bdcb76ec8ca3f4b7454fd2137cac01970cb0
-          cd ../../
 
           BLE_FILES_CHANGED=0
           
@@ -184,14 +168,6 @@ jobs:
         run: |
           # Remove local modifications
           git scorch
-          # Update the submodules, this will use ssh
-          git submodule init
-          git submodule sync
-          git submodule update --init --recursive
-          cd Libraries/Cordio
-          git stash
-          git checkout 55b7bdcb76ec8ca3f4b7454fd2137cac01970cb0
-          cd ../../
 
           BLE_FILES_CHANGED=0
           

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -67,7 +67,7 @@ jobs:
           
           # Check for changes made to these files
           WATCH_FILES="\
-          .github/workflows/ci-tests/Examples_tests\
+          .github/workflows/ci-tests/Examples_tests \
           Examples/MAX32655/BLE \
           Libraries/libs.mk \
           Libraries/Cordio \
@@ -131,7 +131,7 @@ jobs:
           
           # Check for changes made to these files
           WATCH_FILES="\
-          .github/workflows/ci-tests/Examples_tests\
+          .github/workflows/ci-tests/Examples_tests \
           Examples/MAX32665/BLE \
           Libraries/libs.mk \
           Libraries/CMSIS/Device/Maxim/MAX32665 \
@@ -190,7 +190,7 @@ jobs:
           RUN_TEST=0
           # Check for changes made to these files
           WATCH_FILES="\
-          .github/workflows/ci-tests/Examples_tests\
+          .github/workflows/ci-tests/Examples_tests \
           Examples/MAX32690/BLE \
           Libraries/libs.mk \
           Libraries/CMSIS/Device/Maxim/MAX32690 \

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -63,9 +63,11 @@ jobs:
           git scorch
 
           BLE_FILES_CHANGED=0
+          RUN_TEST=0
           
           # Check for changes made to these files
           WATCH_FILES="\
+          .github/workflows/ci-tests/Examples_tests\
           Examples/MAX32655/BLE \
           Libraries/libs.mk \
           Libraries/Cordio \
@@ -92,23 +94,31 @@ jobs:
             for watch_file in $WATCH_FILES; do 
               if [[ "$CHANGE_FILES" == *"$watch_file"* ]]; then
                 BLE_FILES_CHANGED=1
+                RUN_TEST=1
               fi
             done
             if [[ $BLE_FILES_CHANGED -eq 0 ]]
             then
-              echo "Skipping Test"
-              exit 0
+              echo "Skipping MAX32655 Test"
+              # Files were changed but not in MAX32655
+              RUN_TEST=0
             fi
+          else 
+          # Assume we want to actually run the workflow if no files changed
+            RUN_TEST=1
           fi
-          
-          echo "Running Test"
 
-          cd .github/workflows/ci-tests/Examples_tests
-          chmod +x test_launcher.sh
-          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
-          dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['uart0'])"`
-          dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])"`
-          ./test_launcher.sh max32655 $dut_uart $dut_serial
+          if [[ $RUN_TEST -eq 1 ]]
+          then
+            echo "Running Test"
+
+            cd .github/workflows/ci-tests/Examples_tests
+            chmod +x test_launcher.sh
+            FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+            dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['uart0'])"`
+            dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])"`
+            ./test_launcher.sh max32655 $dut_uart $dut_serial
+          fi
       
       # ME14
       - name: TEST MAX32665
@@ -117,9 +127,11 @@ jobs:
           git scorch
 
           BLE_FILES_CHANGED=0
+          RUN_TEST=0
           
           # Check for changes made to these files
           WATCH_FILES="\
+          .github/workflows/ci-tests/Examples_tests\
           Examples/MAX32665/BLE \
           Libraries/libs.mk \
           Libraries/CMSIS/Device/Maxim/MAX32665 \
@@ -145,24 +157,29 @@ jobs:
             for watch_file in $WATCH_FILES; do 
               if [[ "$CHANGE_FILES" == *"$watch_file"* ]]; then
                 BLE_FILES_CHANGED=1
+                RUN_TEST=1
               fi
             done
             if [[ $BLE_FILES_CHANGED -eq 0 ]]
             then
-              echo "Skipping Test"
-              exit 0
+              echo "Skipping MAX32665 Test"
+              # Files were changed but not in MAX32665
+              RUN_TEST=0
             fi
+          else 
+            RUN_TEST=1
           fi
-          
-          echo "Running Test"
-          
-          cd .github/workflows/ci-tests/Examples_tests
-          chmod +x test_launcher.sh
-          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
-          dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['uart1'])"`
-          dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])"`
-          ./test_launcher.sh max32665 $dut_uart $dut_serial          
-      
+
+          if [[ $RUN_TEST -eq 1 ]]
+          then
+            echo "Running Test"   
+            cd .github/workflows/ci-tests/Examples_tests
+            chmod +x test_launcher.sh
+            FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+            dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['uart1'])"`
+            dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])"`
+            ./test_launcher.sh max32665 $dut_uart $dut_serial          
+          fi
       # ME18
       - name: TEST MAX32690
         run: |
@@ -170,9 +187,10 @@ jobs:
           git scorch
 
           BLE_FILES_CHANGED=0
-          
+          RUN_TEST=0
           # Check for changes made to these files
           WATCH_FILES="\
+          .github/workflows/ci-tests/Examples_tests\
           Examples/MAX32690/BLE \
           Libraries/libs.mk \
           Libraries/CMSIS/Device/Maxim/MAX32690 \
@@ -198,23 +216,31 @@ jobs:
             for watch_file in $WATCH_FILES; do 
               if [[ "$CHANGE_FILES" == *"$watch_file"* ]]; then
                 BLE_FILES_CHANGED=1
+                RUN_TEST=1
               fi
             done
             if [[ $BLE_FILES_CHANGED -eq 0 ]]
             then
-              echo "Skipping Test"
-              exit 0
+              echo "Skipping MAX32690 Test"
+              # Files were changed but not in MAX32690
+              RUN_TEST=0
             fi
+          else 
+            RUN_TEST=1
           fi
           
-          echo "Running Test"
-          
-          cd .github/workflows/ci-tests/Examples_tests
-          chmod +x test_launcher.sh
-          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
-          dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['uart2'])"`
-          dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['daplink'])"`            
-          ./test_launcher.sh max32690 $dut_uart $dut_serial          
+          if [[ $RUN_TEST -eq 1 ]]
+          then
+
+            echo "Running Test"
+            
+            cd .github/workflows/ci-tests/Examples_tests
+            chmod +x test_launcher.sh
+            FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+            dut_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['uart2'])"`
+            dut_serial=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['daplink'])"`            
+            ./test_launcher.sh max32690 $dut_uart $dut_serial     
+          fi     
       
       # Save test reports
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-tests/Examples_tests/resources/serialPortReader.py
+++ b/.github/workflows/ci-tests/Examples_tests/resources/serialPortReader.py
@@ -68,6 +68,7 @@ def expect_and_timeout(send=None,expect=None, timeout= 10, port=None):
     while True:
         attempt_count+=1
         timeStart = time.time()
+        char_list=[]
         while used_ports[port].is_open != True:
             time.sleep(0.1)
         if used_ports[port].is_open == True:
@@ -79,9 +80,11 @@ def expect_and_timeout(send=None,expect=None, timeout= 10, port=None):
             # send data if any
             if send != None:
                 time.sleep(0.1)
+                char_list = list(send)
+                for char in char_list:
                 # start test, send command
-                used_ports[port].write(bytes(send, encoding='utf-8'))
-                time.sleep(0.2)
+                    used_ports[port].write(bytes(char, encoding='utf-8'))
+                    time.sleep(0.2)
             # read lines
             while (time.time()-timeStart) < timeout:
                 try:

--- a/.github/workflows/ci-tests/Examples_tests/resources/serialPortReader.py
+++ b/.github/workflows/ci-tests/Examples_tests/resources/serialPortReader.py
@@ -6,12 +6,21 @@ from robot.libraries.BuiltIn import BuiltIn
 # stores open ports for later use
 used_ports=dict()
 #--------------------------------------------------------------------------------------
+'''
+Prints the output form serial port as well as debugging messages
+this switch is used to help differentiate by add "(robot)" to debugging messages
+'''
 def write_to_console(s, log=True):
     if log == True:
         logger.console("(robot)> "+ s ,newline=True)
     else:
         logger.console(s,newline=False)
 #--------------------------------------------------------------------------------------
+'''
+Opens up to 2 ports used during tests,
+stores in global dictionary for late use
+This is only called once upon test setup
+'''
 def open_ports(port_1=None , port_2=None):
     global used_ports
     if port_1 != None :
@@ -28,9 +37,11 @@ def open_ports(port_1=None , port_2=None):
         while used_ports[port_2].is_open != True:
             time.sleep(0.1)
         write_to_console(f"Serial Port {port_2} Opened Succesfully",True)
-       
-    
 #--------------------------------------------------------------------------------------
+'''
+Closes instances of ope ports found in global dicitonary
+This is only called once dudring test teardown
+'''
 def close_ports():
     global used_ports
     for port in used_ports.values():
@@ -42,8 +53,14 @@ def close_ports():
                 write_to_console("Serial Port Closed Succesfully\r\n")
 
         except Exception as err:
-            write_to_console("Port 2 was not open to begin with \r\n")
+            write_to_console("Port was not open to begin with \r\n")
 #--------------------------------------------------------------------------------------
+'''
+Can optioanlly send a string through serial port
+and expect a string in return on  a single port
+if timeout is exceeded the test is attempted once more
+before failing.
+'''
 def expect_and_timeout(send=None,expect=None, timeout= 10, port=None):
     attempt_count=0
     x=""
@@ -82,12 +99,16 @@ def expect_and_timeout(send=None,expect=None, timeout= 10, port=None):
     write_to_console("\r\n-------\r\n",False)
     BuiltIn().fail(".")
 #--------------------------------------------------------------------------------------
+'''
+Reads all incoming serial traffic, inclduing
+what is in the buffer, for some given time
+No multiple attemps and also expects a string to
+eventually be read, or else timeouts
+'''
 def read_all(expect=None,timeout=10,port=None):
     global used_ports
     timeStart = time.time()
-    attempt_count=0
     while True:
-        attempt_count+=1
         timeStart = time.time()   
         while used_ports[port].is_open != True:
             time.sleep(0.1)
@@ -102,20 +123,3 @@ def read_all(expect=None,timeout=10,port=None):
             # timed out
             break
     BuiltIn().fail(" .\r\n")
-#--------------------------------------------------------------------------------------
-def flush_junk( port=None):
-    with serial.Serial() as ser:
-        ser.baudrate = 115200
-        ser.port = port
-        ser.timeout=1
-        ser.open()
-        # serial tends to return before port is open
-        time.sleep(0.1)
-        # write something and read it back to get any junk data from start up
-        ser.write(bytes("\n", encoding='utf-8'))
-        # flushing does not seem to help
-        ser.reset_input_buffer()
-        ser.reset_output_buffer()
-        time.sleep(0.1)
-        ser.read_all()
-        ser.close()

--- a/.github/workflows/ci-tests/Examples_tests/resources/serialPortReader.py
+++ b/.github/workflows/ci-tests/Examples_tests/resources/serialPortReader.py
@@ -1,0 +1,121 @@
+import serial
+import time
+from robot.api import logger
+from robot.libraries.BuiltIn import BuiltIn
+
+# stores open ports for later use
+used_ports=dict()
+#--------------------------------------------------------------------------------------
+def write_to_console(s, log=True):
+    if log == True:
+        logger.console("(robot)> "+ s ,newline=True)
+    else:
+        logger.console(s,newline=False)
+#--------------------------------------------------------------------------------------
+def open_ports(port_1=None , port_2=None):
+    global used_ports
+    if port_1 != None :
+        
+        write_to_console(f"Trying to open port: {port_1}",True) 
+        used_ports[port_1] = serial.Serial(port=port_1,baudrate=115200, timeout=0)
+        while used_ports[port_1].is_open != True:
+            time.sleep(0.1)
+        write_to_console(f"Serial Port {port_1} Opened Succesfully",True)
+        
+    if port_2!= None :
+        write_to_console(f"Trying to open port: {port_2}" , True)
+        used_ports[port_2] = serial.Serial(port=port_2,baudrate=115200, timeout=0)
+        while used_ports[port_2].is_open != True:
+            time.sleep(0.1)
+        write_to_console(f"Serial Port {port_2} Opened Succesfully",True)
+       
+    
+#--------------------------------------------------------------------------------------
+def close_ports():
+    global used_ports
+    for port in used_ports.values():
+        try:
+            if isinstance(port, serial.Serial) == True:
+                port.close()
+                while port.is_open == True:
+                    time.sleep(0.1)
+                write_to_console("Serial Port Closed Succesfully\r\n")
+
+        except Exception as err:
+            write_to_console("Port 2 was not open to begin with \r\n")
+#--------------------------------------------------------------------------------------
+def expect_and_timeout(send=None,expect=None, timeout= 10, port=None):
+    attempt_count=0
+    x=""
+    #decide which port to use for this instance of the method call
+    while True:
+        attempt_count+=1
+        timeStart = time.time()
+        while used_ports[port].is_open != True:
+            time.sleep(0.1)
+        if used_ports[port].is_open == True:
+            #flush junk
+            used_ports[port].reset_input_buffer()
+            used_ports[port].reset_output_buffer()
+            time.sleep(0.1)
+            used_ports[port].write(bytes("\n", encoding='utf-8'))
+            # send data if any
+            if send != None:
+                time.sleep(0.1)
+                # start test, send command
+                used_ports[port].write(bytes(send, encoding='utf-8'))
+                time.sleep(0.2)
+            # read lines
+            while (time.time()-timeStart) < timeout:
+                try:
+                    x=used_ports[port].read(10000).decode("utf-8",'ignore')
+                except Exception as err:
+                    pass
+                x=str(x)
+                if x != "":
+                    write_to_console(x,False)
+                if str(expect) in x:
+                    BuiltIn().pass_execution(".")
+
+            if attempt_count == 2:
+                break
+    write_to_console("\r\n-------\r\n",False)
+    BuiltIn().fail(".")
+#--------------------------------------------------------------------------------------
+def read_all(expect=None,timeout=10,port=None):
+    global used_ports
+    timeStart = time.time()
+    attempt_count=0
+    while True:
+        attempt_count+=1
+        timeStart = time.time()   
+        while used_ports[port].is_open != True:
+            time.sleep(0.1)
+        if used_ports[port].is_open == True:
+            while (time.time()-timeStart) < timeout:
+                x=used_ports[port].readline().decode("utf-8")
+                x=str(x)
+                if x != "":
+                    write_to_console(x,False)
+                    if expect in x:                       
+                        BuiltIn().pass_execution(".")
+            # timed out
+            break
+    BuiltIn().fail(" .\r\n")
+#--------------------------------------------------------------------------------------
+def flush_junk( port=None):
+    with serial.Serial() as ser:
+        ser.baudrate = 115200
+        ser.port = port
+        ser.timeout=1
+        ser.open()
+        # serial tends to return before port is open
+        time.sleep(0.1)
+        # write something and read it back to get any junk data from start up
+        ser.write(bytes("\n", encoding='utf-8'))
+        # flushing does not seem to help
+        ser.reset_input_buffer()
+        ser.reset_output_buffer()
+        time.sleep(0.1)
+        ser.read_all()
+        ser.close()

--- a/.github/workflows/ci-tests/Examples_tests/test_launcher.sh
+++ b/.github/workflows/ci-tests/Examples_tests/test_launcher.sh
@@ -1,0 +1,482 @@
+#!/bin/bash
+
+EXAMPLE_TEST_PATH=$(pwd)
+mkdir results
+cd ../../../../
+MSDK_DIR=$(pwd)
+failedTestList=" "
+numOfFailedTests=0
+
+if [ $(hostname) == "wall-e" ]; then
+    # main ME17 device used to test the rest
+    MAIN_DEVICE_NAME_UPPER=MAX32655
+    MAIN_DEVICE_NAME_LOWER=max32655
+
+    FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+    MAIN_DEVICE_ID=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board1']['daplink'])"`
+    main_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board1']['uart0'])"`
+    MAIN_DEVICE_SERIAL_PORT=/dev/"$(ls -la /dev/serial/by-id | grep -n $main_uart | rev | cut -d "/" -f1 | rev)"
+
+    # WALL-E  paths
+    export OPENOCD_TCL_PATH=/home/btm-ci/Tools/openocd/tcl
+    export OPENOCD=/home/btm-ci/Tools/openocd/src/openocd
+    export ROBOT=/home/btm-ci/.local/bin/robot
+
+    #get all device IDs to make sure nothing is running and attempts connection
+    DEVICE1=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board1']['daplink'])"`
+    DEVICE2=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])"`
+    DEVICE3=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])"`
+    DEVICE4=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['daplink'])"`
+
+# Local- eddie desktop
+else
+    # main ME17 device used to test the rest
+    MAIN_DEVICE_NAME_UPPER=MAX32655
+    MAIN_DEVICE_NAME_LOWER=max32655
+    FILE=/home/$USER/boards_config.json
+    MAIN_DEVICE_ID=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_0']['daplink'])"`
+    main_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_0']['uart0'])"`
+    MAIN_DEVICE_SERIAL_PORT=/dev/"$(ls -la /dev/serial/by-id | grep -n $main_uart | rev | cut -d "/" -f1 | rev)"
+
+    # local paths
+    export OPENOCD_TCL_PATH=/home/eddie/workspace/openocd/tcl
+    export OPENOCD=/home/eddie/workspace/openocd/src/openocd
+    export ROBOT=/home/eddie/.local/bin/robot
+fi
+
+# setup  all DUT varaibles
+DUT_NAME_LOWER=$1
+DUT_NAME_UPPER=$(echo $DUT_NAME_LOWER | tr '[:lower:]' '[:upper:]')
+DUT_SERIAL_PORT=/dev/$(ls -la /dev/serial/by-id | grep -n $2 | rev | cut -d "/" -f1 | rev)
+DUT_ID=$3
+
+
+#***************************************** Helper functions *****************************************
+#****************************************************************************************************
+function script_clean_up() {
+    # check if some runoff opeocd instance is running
+    set +e
+    if ps -p $openocd_dapLink_pid >/dev/null; then
+        kill -9 $openocd_dapLink_pid || true
+    fi
+
+    set -e
+}
+
+trap script_clean_up EXIT SIGINT
+
+# Function accepts parameters: device, CMSIS_DAP_ID_x
+function flash_with_openocd() {
+    # mass erase and flash
+    set +e
+    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$1.cfg -s $OPENOCD_TCL_PATH -c "cmsis_dap_serial  $2" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt;max32xxx mass_erase 0" -c "program $1.elf verify reset exit" >/dev/null &
+    openocd_dapLink_pid=$!
+    # wait for openocd to finish
+    while kill -0 $openocd_dapLink_pid; do
+        sleep 1
+        # we can add a timeout here if we want
+    done
+    set -e
+
+    # Check the return value to see if we received an error
+    if [ "$?" -ne "0" ]; then
+        printf "> Verify failed , flashibng again \r\n"
+        # Reprogram the device if the verify failed
+        $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$1.cfg -s $OPENOCD_TCL_PATH -c "cmsis_dap_serial  $2" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt;max32xxx mass_erase 0" -c "program $1.elf verify reset exit" >/dev/null &
+        openocd_dapLink_pid=$!
+    fi
+    if [[ $1 == "max32690" ]]; then
+    softreset_with_openocd $DUT_NAME_LOWER $DUT_ID
+    fi
+
+}
+# Function accepts parameters: device, CMSIS_DAP_ID_x
+function flash_with_openocd_fast() {
+    # mass erase and flash
+    set +e
+    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$1.cfg -s $OPENOCD_TCL_PATH -c "cmsis_dap_serial  $2" -c "gdb_port 333$3" -c "telnet_port 444$3" -c "tcl_port 666$3" -c "init; reset halt;max32xxx mass_erase 0" -c "program $1.elf verify reset exit" >/dev/null &
+    openocd_dapLink_pid=$!
+    set -e
+  
+
+}
+# Function accepts parameters: device, CMSIS_DAP_ID_x
+function softreset_with_openocd() {
+    
+    set +e
+    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$1.cfg -s $OPENOCD_TCL_PATH -c "cmsis_dap_serial  $2" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init;reset exit"  >/dev/null &
+    openocd_dapLink_pid=$!
+    # wait for openocd to finish
+    while kill -0 $openocd_dapLink_pid; do
+        sleep 1
+        # we can add a timeout here if we want
+    done
+    set -e
+  
+}
+# Function accepts parameters:device , CMSIS_DAP_ID_x
+function erase_with_openocd() {
+    printf "> Erasing $1 : $2 \r\n"
+    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$1.cfg -s $OPENOCD_TCL_PATH/ -c "cmsis_dap_serial  $2" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt; max32xxx mass_erase 0;" -c " exit" &
+    openocd_dapLink_pid=$!
+    # wait for openocd to finish
+    wait $openocd_dapLink_pid
+
+    # erase second bank of larger chips
+    if [[ $1 != "max32655" ]]; then
+        printf "> Erasing second bank of device: $1 with ID:$2 \r\n"
+        $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$1.cfg -s $OPENOCD_TCL_PATH/ -c "cmsis_dap_serial  $2" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt; max32xxx mass_erase 1;" -c " exit" &
+        openocd_dapLink_pid=$!
+        # wait for openocd to finish
+        wait $openocd_dapLink_pid
+    fi
+
+}
+
+function run_notConntectedTest() {
+    project_marker
+    cd $PROJECT_NAME
+    set +x
+    echo "> Flashing $DUT_NAME_UPPER $PROJECT_NAME"
+    # make -j8 projects are build in validation build step
+    cd build/
+    flash_with_openocd $DUT_NAME_LOWER $DUT_ID
+    #place to store robotframework results
+
+    cd $EXAMPLE_TEST_PATH/results/$DUT_NAME_UPPER
+    mkdir $PROJECT_NAME
+
+    cd $EXAMPLE_TEST_PATH/tests
+    # do not let a single failed test stop the testing of the rest
+    set +e
+    #runs desired test
+    $ROBOT -d $EXAMPLE_TEST_PATH/results/$DUT_NAME_UPPER/$PROJECT_NAME -v SERIAL_PORT_1:$DUT_SERIAL_PORT $PROJECT_NAME.robot
+    let "testResult=$?"
+    if [ "$testResult" -ne "0" ]; then
+        # update failed test count
+        let "numOfFailedTests+=$testResult"
+        failedTestList+="| $PROJECT_NAME ($DUT_NAME_UPPER) "
+    fi
+    set -e
+
+    # get back to target directory
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER
+}
+
+function flash_bootloader() {
+    #------ -----------Build & Flash Bootloader onto Device 2  : ME17
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/Bootloader
+    make -j8
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/Bootloader/build
+    printf "> Flashing Bootloader on DUT\r\n\r\n"
+    #not using the flash_with_openocd function here because that causes the application code to be erased and only
+    #bootloader to remain
+    set +e
+    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$DUT_NAME_LOWER.cfg -s $OPENOCD_TCL_PATH -c "cmsis_dap_serial  $DUT_ID" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt" -c "program $DUT_NAME_LOWER.elf verify reset exit" >/dev/null &
+    openocd_dapLink_pid=$!
+    # wait for openocd to finish
+    while kill -0 $openocd_dapLink_pid; do
+        sleep 1
+        # we can add a timeout here if we want
+    done
+    set -e
+    # Attempt to verify the image, prevent exit on error
+    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$DUT_NAME_LOWER.cfg -s $OPENOCD_TCL_PATH/ -c "cmsis_dap_serial  $DUT_ID" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt; flash verify_image $DUT_NAME_LOWER.elf; reset; exit"
+
+    # Check the return value to see if we received an error
+    if [ "$?" -ne "0" ]; then
+        # Reprogram the device if the verify failed
+        $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$DUT_NAME_LOWER.cfg -s $OPENOCD_TCL_PATH -c "cmsis_dap_serial  $DUT_ID" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt" -c "program $DUT_NAME_LOWER.elf verify reset exit" >/dev/null &
+        openocd_dapLink_pid=$!
+    fi
+}
+
+function erase_all_devices() {
+
+    if [ $(hostname) == "wall-e" ]; then
+        erase_with_openocd max32655 $DEVICE1
+        erase_with_openocd max32655 $DEVICE2
+        erase_with_openocd max32665 $DEVICE3
+        erase_with_openocd max32690 $DEVICE4
+    else
+        FILE=/home/$USER/boards_config.json    
+        DEVICE2=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])"`
+        DEVICE3=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])"`
+        DEVICE4=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['daplink'])"`
+        erase_with_openocd max32655 $DEVICE2
+        erase_with_openocd max32665 $DEVICE3
+        erase_with_openocd max32690 $DEVICE4
+    fi
+}
+
+function project_marker() {
+    echo "=============================================================================="
+    printf "> Start of testing $DUT_NAME_LOWER ($DUT_NAME_UPPER) \r\n> ID:$DUT_ID \r\n> Port:$DUT_SERIAL_PORT \r\n\r\n"
+}
+
+#***************************************** Start of test script *************************************
+#****************************************************************************************************
+
+# remove old robtoframework logs
+cd $EXAMPLE_TEST_PATH/results/
+rm -rf *
+
+erase_all_devices
+
+# change advertising name for projects under test to avoid
+# connections with office devices
+printf "> changing advertising names : $MSDK_DIR/Examples/$DUT_NAME_UPPER\r\n\r\n"
+if [ $(hostname) == "wall-e" ]; then
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_dats
+    perl -i -pe "s/\'D\'/\'X\'/g" dats_main.c
+
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_datc
+    perl -i -pe "s/\'D\'/\'X\'/g" datc_main.c
+
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otac
+    perl -i -pe "s/\'S\'/\'X\'/g" datc_main.c
+
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas
+    perl -i -pe "s/\'S\'/\'X\'/g" dats_main.c
+
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_FreeRTOS
+    perl -i -pe "s/\'S\'/\'X\'/g" dats_main.c
+
+    # change advertising name to scan for on the main device client apps
+    cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_datc
+    perl -i -pe "s/\'D\'/\'X\'/g" datc_main.c
+
+    cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
+    perl -i -pe "s/\'S\'/\'X\'/g" datc_main.c
+
+    # build BLE examples
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER
+    SUBDIRS=$(find . -type d -name "BLE*")
+    for dir in ${SUBDIRS}; do
+        echo "---------------------------------------"
+        echo " Validation build for ${dir}"
+        echo "---------------------------------------"
+        make -C ${dir} clean
+        make -C ${dir} libclean
+        make -C ${dir} -j8
+    done
+else
+ cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_dats
+    perl -i -pe "s/\'D\'/\'Z\'/g" dats_main.c
+
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_datc
+    perl -i -pe "s/\'D\'/\'Z\'/g" datc_main.c
+
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otac
+    perl -i -pe "s/\'S\'/\'Z\'/g" datc_main.c
+
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas
+    perl -i -pe "s/\'S\'/\'Z\'/g" dats_main.c
+
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_FreeRTOS
+    perl -i -pe "s/\'S\'/\'Z\'/g" dats_main.c
+
+    # change advertising name to scan for on the main device client apps
+    cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_datc
+    perl -i -pe "s/\'D\'/\'Z\'/g" datc_main.c
+
+    cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
+    perl -i -pe "s/\'S\'/\'Z\'/g" datc_main.c
+
+    # build BLE examples
+    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER
+    SUBDIRS=$(find . -type d -name "BLE*")
+    for dir in ${SUBDIRS}; do
+        echo "---------------------------------------"
+        echo " Validation build for ${dir}"
+        echo "---------------------------------------"
+    #    make -C ${dir} clean
+    #   make -C ${dir} libclean
+    #    make -C ${dir} -j8
+    done
+fi
+
+# directory for test resutls
+cd $EXAMPLE_TEST_PATH/results/
+mkdir $DUT_NAME_UPPER
+# enter current device under test directory
+cd $MSDK_DIR/Examples/$DUT_NAME_UPPER
+
+#no filter would support ALL projects not just ble
+project_filter='BLE_'
+
+#----------------------------- Run non connected tests
+for dir in ./*/; do
+    if [[ "$dir" == *"$project_filter"* ]]; then
+
+        export PROJECT_NAME=$(echo "$dir" | tr -d /.)
+        case $PROJECT_NAME in
+
+        "BLE_datc")
+            run_notConntectedTest
+
+            ;;
+
+        "BLE_dats")
+            run_notConntectedTest
+            ;;
+
+        "BLE_mcs")
+            run_notConntectedTest
+            ;;
+
+        "BLE_fit")
+            run_notConntectedTest
+            ;;
+
+        "BLE_fcc")
+
+            #Nothing to do here, no test for fcc
+            #project is built up top and that will detect a failure if any
+
+            ;;
+
+        "BLE_FreeRTOS")
+            if [[ $DUT_NAME_UPPER != "MAX32690" ]]; then
+                run_notConntectedTest
+            fi
+            ;;
+
+        "BLE_otac")
+          #  run_notConntectedTest
+            ;;
+
+        "BLE_otas")
+            # gets tested during conencted test below
+
+            ;;
+
+        "BLE_periph")
+            # No buttons implemented for this example so lets just make sure it builds, so we can ship it
+            # cd $PROJECT_NAME
+            # make -j8
+            # let "numOfFailedTests+=$?"
+
+            ;;
+
+        *) ;;
+
+        esac
+
+    fi
+
+    let projIdx++
+
+done # end non connected tests
+
+erase_all_devices
+#--------------------------start Datc/Dats conencted tests
+
+
+# Flash MAIN_DEVICE with BLE_datc
+cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_datc
+make -j8
+
+# flash client first because it takes longer
+cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_datc/build
+printf "> Flashing BLE_datc on main device: $MAIN_DEVICE_NAME_UPPER\r\n "
+flash_with_openocd_fast $MAIN_DEVICE_NAME_LOWER $MAIN_DEVICE_ID 1
+
+# flash DUT with BLE_dats
+cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_dats/build
+printf "> Flashing BLE_dats on DUT $DUT_NAME_UPPER \r\n"
+flash_with_openocd_fast $DUT_NAME_LOWER $DUT_ID 2
+
+# directory for resuilts logs
+cd $EXAMPLE_TEST_PATH/results/$DUT_NAME_UPPER/
+mkdir BLE_dat_cs
+cd $EXAMPLE_TEST_PATH/tests
+# runs desired test
+set +e
+$ROBOT -d $EXAMPLE_TEST_PATH/results/$DUT_NAME_UPPER/BLE_dat_cs/ -v SERIAL_PORT_1:$MAIN_DEVICE_SERIAL_PORT -v SERIAL_PORT_2:$DUT_SERIAL_PORT BLE_dat_cs.robot
+let "testResult=$?"
+if [ "$testResult" -ne "0" ]; then
+    # update failed test count
+    let "numOfFailedTests+=$testResult"
+    failedTestList+="| BLE_dat_cs ($DUT_NAME_UPPER) "
+fi
+set -e
+
+# make sure to erase main device and current DUT to it does not store bonding info
+erase_with_openocd $DUT_NAME_LOWER $DUT_ID
+erase_with_openocd $MAIN_DEVICE_NAME_LOWER $MAIN_DEVICE_ID
+
+#--------------------------start Otac/Otas conencted tests
+
+# directory for resuilts logs
+cd $EXAMPLE_TEST_PATH/results/$DUT_NAME_UPPER/
+mkdir BLE_ota_cs
+cd $EXAMPLE_TEST_PATH/tests
+
+# flash Firmware V1 BLE_otas  onto DUT
+cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas/build
+printf "> Flashing BLE_otas on DUT $DUT_NAME_UPP\r\n\r\n"
+flash_with_openocd $DUT_NAME_LOWER $DUT_ID
+
+flash_bootloader
+
+# change firmware version and rebuild
+cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas
+# change firmware version to verify otas worked
+perl -i -pe "s/FW_VERSION 1/FW_VERSION 2/g" wdxs_file.c
+make -j8
+
+# since  MAIN_DEVICE and DUT are not the same chip we need to make sure the
+# FW update binary is built for the DUT's mcu and not the  MAIN_DEVICE mcu
+# modify project.mk's recursive 'MAKE' call that builds the FW update bin
+cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
+
+#appends TARGET , TARGET_UC and TARGET_LC to the make commands and sets them to $DUT_NAME_UPPER and $DUT_NAME_LOWER
+sed -i 's/BUILD_DIR=\$(FW_BUILD_DIR) PROJECT=fw_update/BUILD_DIR=\$(FW_BUILD_DIR) PROJECT=fw_update TARGET='"$DUT_NAME_UPPER"' TARGET_UC='"$DUT_NAME_UPPER"' TARGET_LC='"$DUT_NAME_LOWER"'/g' project.mk
+sed -i 's/BUILD_DIR=\$(FW_BUILD_DIR) \$(FW_UPDATE_BIN)/BUILD_DIR=\$(FW_BUILD_DIR) \$(FW_UPDATE_BIN) TARGET='"$DUT_NAME_UPPER"' TARGET_UC='"$DUT_NAME_UPPER"' TARGET_LC='"$DUT_NAME_LOWER"'/g' project.mk
+# flash MAIN_DEVICE with BLE_OTAC, it will use the OTAS bin with new firmware
+make clean
+make FW_UPDATE_DIR=../../$DUT_NAME_UPPER/BLE_otas -j8
+
+cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac/build
+printf "> Flashing BLE_otac on main device: $MAIN_DEVICE_NAME_UPPER\r\n "
+flash_with_openocd $MAIN_DEVICE_NAME_LOWER $MAIN_DEVICE_ID
+printf "Flashing done"
+
+#revert files back, took me days to find this bug
+cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
+sed -i 's/TARGET='"$DUT_NAME_UPPER"'//' project.mk
+sed -i 's/TARGET_UC='"$DUT_NAME_UPPER"'//' project.mk
+sed -i 's/TARGET_LC='"$DUT_NAME_LOWER"'//' project.mk
+# give time to connect
+sleep 15
+
+set +e
+# runs desired test
+cd $EXAMPLE_TEST_PATH/tests
+$ROBOT -d $EXAMPLE_TEST_PATH/results/$DUT_NAME_UPPER/BLE_ota_cs/ -v SERIAL_PORT_1:$MAIN_DEVICE_SERIAL_PORT -v SERIAL_PORT_2:$DUT_SERIAL_PORT BLE_ota_cs.robot
+let "testResult=$?"
+if [ "$testResult" -ne "0" ]; then
+    # update failed test count
+    let "numOfFailedTests+=$testResult"
+    failedTestList+="| BLE_ota_cs ($DUT_NAME_UPPER) "
+fi
+set -e
+
+# make sure to erase main device and current DUT to it does not store bonding info
+erase_with_openocd $DUT_NAME_LOWER $DUT_ID
+erase_with_openocd $MAIN_DEVICE_NAME_LOWER $MAIN_DEVICE_ID
+
+erase_all_devices
+
+echo "=============================================================================="
+echo "=============================================================================="
+if [ "$numOfFailedTests" -ne "0" ]; then
+    echo "Test completed with $numOfFailedTests failed tests located in: \r\n $failedTestList"
+   
+else
+    echo "Relax! ALL TESTS PASSED"
+fi
+echo "=============================================================================="
+echo "=============================================================================="
+exit $numOfFailedTests

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_FreeRTOS.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_FreeRTOS.robot
@@ -1,42 +1,35 @@
 *** settings ***
-Library    SerialLibrary      encoding=ascii
 Library    String
-Resource     ../resources/Serial.robot
-Suite Setup        Serial.Open Serial Port    ${SERIAL_PORT_1}    NONE    
-Suite Teardown     Serial.Close Serial Port
+Library    ../resources/serialPortReader.py
+Suite Setup        Open Ports    ${SERIAL_PORT_1}
+Suite Teardown     Close Ports 
 
 *** Variables ***
 ${SERIAL_PORT_1}    None
-${VERBOSE}     None
 
 *** test cases ***
 Stop Advertising Test
     [Timeout]    30s
     # inital sleep to allow device time to boot up after programming
-    sleep    5
-    Serial.Send    btn 2 s\n    ${SERIAL_PORT_1}    
-    Serial.Expect And Timeout    >>> Advertising stopped <<<    10    ${SERIAL_PORT_1}
+    sleep    5  
+    Expect And Timeout    btn 2 s\n      >>> Advertising stopped <<<    10    ${SERIAL_PORT_1}
 
 
 Start Advertising Test  
     [Timeout]     30s
-    Serial.send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Advertising started <<<    10    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 s\n      >>> Advertising started <<<    10    ${SERIAL_PORT_1}
 
 
 Button M Press Test  
     [Timeout]     30s
-    Serial.send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Medium Button 1 Press    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 m\n      Medium Button 1 Press    5    ${SERIAL_PORT_1}
     
 
 Button L Press Test  
     [Timeout]     30s
-    Serial.send    btn 1 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Clear resolving list status 0x00    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 l\n      Clear resolving list status 0x00    5    ${SERIAL_PORT_1}
    
 
 Button X Press Test  
     [Timeout]     30s
-    Serial.send    btn 1 x\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Stack Version: Packetcraft Host    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 x\n      Stack Version: Packetcraft Host    5    ${SERIAL_PORT_1}

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_dat_cs.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_dat_cs.robot
@@ -1,49 +1,49 @@
 *** settings ***
-Library    SerialLibrary      encoding=ascii
 Library    String
-Resource     ../resources/Serial.robot
-Suite Setup        Open Serial Port    ${SERIAL_PORT_1}    ${SERIAL_PORT_2}
-#Suite Setup        Serial.Open Serial Port    ${SERIAL_PORT_1}    
-Suite Teardown     Serial.Close Serial Port
+Library    ../resources/serialPortReader.py
+Suite Setup        Open Ports    ${SERIAL_PORT_1}    ${SERIAL_PORT_2}
+Suite Teardown     Close Ports 
 
 *** Variables ***
 ${SERIAL_PORT_1}    /dev/ttyUSB0
 ${SERIAL_PORT_2}  /dev/ttyUSB1
-${VERBOSE}    1
 
 *** test cases ***
+Initial Connection Test Server
+    [Timeout]     100s
+    # inital sleep to allow device time to boot up after programming
+    Read ALL     >>> Prompt user to enter passkey <<<    60    ${SERIAL_PORT_1}
 
-Secured Connection Test
+Secured Connection Test Server
     [Timeout]     60s
     # inital sleep to allow device time to boot up after programming
-    sleep    5
-    Serial.send   pin 1 1234\n    ${SERIAL_PORT_2}
-    sleep    2
-    Serial.send    pin 1 1234\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Pairing completed successfully <<<    25    ${SERIAL_PORT_1}
+    
+    Expect And Timeout    pin 1 1234\n    > smpSmExecute event=4 state=12    5    ${SERIAL_PORT_2}
+
+Secured Connection Test Client
+    [Timeout]     90s
+    # inital sleep to allow device time to boot up after programming
+    
+    Expect And Timeout    pin 1 1234\n    >>> Pairing completed successfully <<<    25    ${SERIAL_PORT_1}
 
 Write Characteristic Test
     [Timeout]     30s
-    Serial.send    btn 2 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    hello back    5    ${SERIAL_PORT_1}    
+    sleep    1s
+    Expect And Timeout    btn 2 l\n     hello back     5    ${SERIAL_PORT_1}    
 
 Write Secure Characteristic Test
     [Timeout]     30s
-    Serial.send    btn 2 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Notification from secure data service    5    ${SERIAL_PORT_1}    
+    sleep    1s
+    Expect And Timeout    btn 2 m\n    Notification from secure data service      5      ${SERIAL_PORT_1}    
 
 
 Phy Switching Test 
     [Timeout]     30s
-    Serial.send    btn 2 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    DM_PHY_UPDATE_IND - RX: 2, TX: 2    5    ${SERIAL_PORT_1}    
-
-
+    sleep    1s
+    Expect And Timeout    btn 2 s\n    DM_PHY_UPDATE_IND - RX: 2, TX: 2    5    ${SERIAL_PORT_1}
+    
 Speed Test  
-    [Timeout]     120s
-    Serial.send    btn 2 x\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout     bits transferred in    120    ${SERIAL_PORT_1}
-
-
-
+    [Timeout]     180s
+    sleep    1
+    Expect And Timeout    btn 2 x\n    transferred    120    ${SERIAL_PORT_1}
 

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_datc.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_datc.robot
@@ -1,33 +1,28 @@
 *** settings ***
-Library    SerialLibrary      encoding=ascii
 Library    String
-Resource     ../resources/Serial.robot
-Suite Setup        Serial.Open Serial Port    ${SERIAL_PORT_1}    NONE    
-Suite Teardown     Serial.Close Serial Port
+Library    ../resources/serialPortReader.py
+Suite Setup        Open Ports    ${SERIAL_PORT_1}
+Suite Teardown     Close Ports 
 
 *** Variables ***
 ${SERIAL_PORT_1}    /dev/ttyUSB0
-${VERBOSE}     None
+
 
 *** test cases ***
 Stop Scanning Test
     [Timeout]    30s
     # inital sleep to allow device time to boot up after programming
-    Sleep     5s
-    Serial.Send    btn 1 s\n    ${SERIAL_PORT_1}   
-    Serial.Expect And Timeout    >>> Scanning stopped <<<    10    ${SERIAL_PORT_1}
+    sleep     5s  
+    Expect And Timeout    btn 1 s\n      >>> Scanning stopped <<<    10    ${SERIAL_PORT_1}
 
 Button Press Test
     [Timeout]    30s
-    Serial.Send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Medium Button 1 Press    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 m\n      Medium Button 1 Press    5    ${SERIAL_PORT_1}
 
 No button Action Test
     [Timeout]    30s
-    Serial.Send    btn 2 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    No action assigned    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 2 s\n      No action assigned    5    ${SERIAL_PORT_1}
 
 Clearing Bond Info Test
     [Timeout]    30s
-    Serial.Send    btn 1 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Clear bonding info    10    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 l\n      Clear bonding info    10    ${SERIAL_PORT_1}

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_dats.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_dats.robot
@@ -1,45 +1,39 @@
 *** settings ***
-Library    SerialLibrary      encoding=ascii
 Library    String
-Resource     ../resources/Serial.robot
-Suite Setup        Serial.Open Serial Port    ${SERIAL_PORT_1}    NONE
-Suite Teardown     Serial.Close Serial Port
+Library    ../resources/serialPortReader.py
+Suite Setup        Open Ports    ${SERIAL_PORT_1}
+Suite Teardown     Close Ports 
 
 *** Variables ***
 ${SERIAL_PORT_1}    None
-${VERBOSE}     None
+
 
 *** test cases ***
 Stop Advertising Test
     [Timeout]    30s
     # inital sleep to allow device time to boot up after programming
     sleep    5
-    Serial.Send     btn 2 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Advertising stopped <<<    10    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 2 s\n      >>> Advertising stopped <<<    10    ${SERIAL_PORT_1}
 
 
 Start Advertising Test  
     [Timeout]     30s
-    Serial.send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Advertising started <<<    10    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 s\n      >>> Advertising started <<<    10    ${SERIAL_PORT_1}
 
 
 Button M Press Test  
     [Timeout]     30s
-    Serial.send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Medium Button 1 Press    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 m\n      Medium Button 1 Press    5    ${SERIAL_PORT_1}
     
 
 Button L Press Test  
     [Timeout]     30s
-    Serial.send    btn 1 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Clear resolving list status 0x00    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 l\n      Clear resolving list status 0x00    5    ${SERIAL_PORT_1}
    
 
 Button X Press Test  
     [Timeout]     30s
-    Serial.send    btn 1 x\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Stack Version: Packetcraft Host    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 x\n      Stack Version: Packetcraft Host    5    ${SERIAL_PORT_1}
    
 
 

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_fit.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_fit.robot
@@ -1,21 +1,19 @@
 *** settings ***
-Library    SerialLibrary      encoding=ascii
 Library    String
-Resource     ../resources/Serial.robot
-Suite Setup        Serial.Open Serial Port    ${SERIAL_PORT_1}    NONE    
-Suite Teardown     Serial.Close Serial Port
+Library    ../resources/serialPortReader.py
+Suite Setup        Open Ports    ${SERIAL_PORT_1}
+Suite Teardown     Close Ports 
 
 *** Variables ***
 ${SERIAL_PORT_1}    None
-${VERBOSE}     None
+
 
 *** test cases ***
-Button Press Tests
+Button S Press Test
     [Timeout]    30s
-    # inital sleep to allow device time to boot up after programming
     Sleep     5s
-    Serial.Send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Short Button 1 Press    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 s\n      Short Button 1 Press    5    ${SERIAL_PORT_1}
 
-    Serial.Send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    Medium Button 1 Press    5    ${SERIAL_PORT_1}
+Button M Press Test
+    [Timeout]    30s
+    Expect And Timeout    btn 1 m\n      Medium Button 1 Press    5    ${SERIAL_PORT_1}

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_mcs.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_mcs.robot
@@ -1,24 +1,23 @@
 *** settings ***
-Library    SerialLibrary      encoding=ascii
 Library    String
-Resource     ../resources/Serial.robot
-Suite Setup        Serial.Open Serial Port    ${SERIAL_PORT_1}    NONE    
-Suite Teardown     Serial.Close Serial Port
+Library    ../resources/serialPortReader.py
+Suite Setup        Open Ports    ${SERIAL_PORT_1}
+Suite Teardown     Close Ports 
 
 *** Variables ***
 ${SERIAL_PORT_1}    None
-${VERBOSE}     None
 
 *** test cases ***
-Button Press Tests
+Button S Press Test
     [Timeout]    30s
     # inital sleep to allow device time to boot up after programming
     Sleep     5s
-    Serial.Send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    mcsAppBtnCback; 2    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 s\n      mcsAppBtnCback; 2    5    ${SERIAL_PORT_1}
 
-    Serial.Send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    mcsAppBtnCback; 3    5    ${SERIAL_PORT_1}
+Button M Press Test
+    [Timeout]    30s
+    Expect And Timeout    btn 1 m\n      mcsAppBtnCback; 3    5    ${SERIAL_PORT_1}
     
-    Serial.Send    btn 1 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    mcsAppBtnCback; 4    5    ${SERIAL_PORT_1}
+Button L Press Test
+    [Timeout]    30s
+    Expect And Timeout    btn 1 l\n      mcsAppBtnCback; 4    5    ${SERIAL_PORT_1}

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_ota_cs.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_ota_cs.robot
@@ -1,51 +1,49 @@
 *** settings ***
-Library    SerialLibrary      encoding=ascii
 Library    String
-Resource     ../resources/Serial.robot
-Suite Setup        Serial.Open Serial Port    ${SERIAL_PORT_1}    ${SERIAL_PORT_2}    
-Suite Teardown     Serial.Close Serial Port
+Library    ../resources/serialPortReader.py
+Suite Setup        Open Ports    ${SERIAL_PORT_1}    ${SERIAL_PORT_2}
+Suite Teardown     Close Ports 
 
 *** Variables ***
 ${SERIAL_PORT_1}  /dev/ttyUSB0
 ${SERIAL_PORT_2}  /dev/ttyUSB1
 
-${VERBOSE}     None
-
 *** test cases ***
 Original Firmware Test
     [Timeout]    30s
     Sleep     5s
-    # inital sleep to allow device time to boot up after programming
-    Serial.send    btn 2 m\n    ${SERIAL_PORT_2}
-    Serial.Expect And Timeout    FW_VERSION: 1   5    ${SERIAL_PORT_2}
+    Expect And Timeout    btn 2 m\n    FW_VERSION: 1     5     ${SERIAL_PORT_2}
 
 File Discovery Test
     [Timeout]    30s
-    Serial.send    btn 2 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> File discovery complete <<<    5    ${SERIAL_PORT_1}
+    sleep    2
+    Expect And Timeout    btn 2 s\n    >>> File discovery complete <<<    5    ${SERIAL_PORT_1}
 
 File Transfer Test
-    [Timeout]    30s
-    Serial.Send    btn 2 m\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> File transfer complete    20    ${SERIAL_PORT_1}
+    [Timeout]    60s
+    sleep    2
+    Expect And Timeout    btn 2 m\n    >>> File transfer complete    20    ${SERIAL_PORT_1}
 
 File Verification Test
     [Timeout]    30S
-    Serial.Send    btn 2 l\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Verify complete status: 0 <<<    2    ${SERIAL_PORT_1}
+    sleep    2
+    Expect And Timeout    btn 2 l\n    >>> Verify complete status: 0 <<<    2    ${SERIAL_PORT_1}
    
 Peer Device Reset Test
     [Timeout]    30s
-    Serial.Send    btn 2 x\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout    >>> Scanning started <<<    5    ${SERIAL_PORT_1}
+    sleep    2
+    Expect And Timeout   btn 2 x\n    >>> Scanning started <<<    5    ${SERIAL_PORT_1}
+
+Firmware Update Verification Test
+    [Timeout]    60s     
+    Read All    FW_VERSION: 2     15     ${SERIAL_PORT_2}
+
 
 Firmware Reconnect Succesful Test
     [Timeout]    60s
-    Serial.Expect And Timeout    AppDiscComplete connId:1 status:0x08    30    ${SERIAL_PORT_1}
-    
-Firmware Update Verification Test
-    [Timeout]    30s
-    Serial.send    btn 2 m\n    ${SERIAL_PORT_2}
+    sleep     10
+    Expect And Timeout    btn 2 s\n    >>> File discovery complete <<<    15    ${SERIAL_PORT_1}
     
 
+    
 

--- a/.github/workflows/ci-tests/Examples_tests/tests/BLE_otac.robot
+++ b/.github/workflows/ci-tests/Examples_tests/tests/BLE_otac.robot
@@ -1,28 +1,23 @@
 *** settings ***
-Library    SerialLibrary      encoding=ascii
 Library    String
-Resource     ../resources/Serial.robot
-Suite Setup        Serial.Open Serial Port    ${SERIAL_PORT_1}    NONE    
-Suite Teardown     Serial.Close Serial Port
+Library    ../resources/serialPortReader.py
+Suite Setup        Open Ports    ${SERIAL_PORT_1}
+Suite Teardown     Close Ports 
 
 *** Variables ***
 ${SERIAL_PORT_1}    None
-${VERBOSE}     None
 
 *** test cases ***
 Stop Scanning Test
     [Timeout]    30s
     # inital sleep to allow device time to boot up after programming
     Sleep    5s
-    Serial.Send    btn 1 s\n    ${SERIAL_PORT_1}
-    Serial.Expect And Timeout     >>> Scanning stopped <<<    5    ${SERIAL_PORT_1}
+    Expect And Timeout     btn 1 s\n     >>> Scanning stopped <<<    5    ${SERIAL_PORT_1}
 
 Connection ID Test
     [Timeout]    30s
-    Serial.Send    btn 1 m\n    ${SERIAL_PORT_1}
-    Serial.Expect and timeout    ConnID for Button Press:    5    ${SERIAL_PORT_1}
+    Expect and timeout    btn 1 m\n      ConnID for Button Press:    5    ${SERIAL_PORT_1}
 
 Clear Resolving List Test
     [Timeout]    30s
-    Serial.Send    btn 1 l\n    ${SERIAL_PORT_1}
-    serial.Expect And Timeout    Clear resolving list status 0x00    5    ${SERIAL_PORT_1}
+    Expect And Timeout    btn 1 l\n      Clear resolving list status 0x00    5    ${SERIAL_PORT_1}

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_timer.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_timer.c
@@ -61,7 +61,7 @@
 #define PAL_SLEEP_TMR                   MXC_TMR_GET_TMR(PAL_SLEEP_TMR_IDX)
 #define PAL_SLEEP_TMR_IRQn              MXC_TMR_GET_IRQ(PAL_SLEEP_TMR_IDX)
 
-#define PAL_TMR_SETUP_TICKS             9
+#define PAL_TMR_SETUP_US                300
 
 /**************************************************************************************************
   Global Variables
@@ -263,13 +263,15 @@ void PalTimerStart(uint32_t expUsec)
 
   MXC_TMR_SetCount(PAL_TMR, 0);
 
+  if(expUsec > PAL_TMR_SETUP_US) {
+    expUsec -= PAL_TMR_SETUP_US;
+  }
+
   /* Calculate the compare value */
   compareValue = ((uint64_t)expUsec * (uint64_t)PAL_RTC_TICKS_PER_SEC) / (uint64_t)1000000;
 
-  /* Account for setup time */
-  if (compareValue > PAL_TMR_SETUP_TICKS) {
-    compareValue -= PAL_TMR_SETUP_TICKS;
-  } else {
+  /* Make sure we get at least 1 tick */
+  if(compareValue == 0) {
     compareValue = 1;
   }
   MXC_TMR_SetCompare(PAL_TMR, compareValue);
@@ -333,13 +335,15 @@ void PalTimerSleep(uint32_t expUsec)
   MXC_TMR_Init(PAL_SLEEP_TMR, &tmr_cfg, FALSE);
   MXC_TMR_SetCount(PAL_SLEEP_TMR, 0);
 
+  if(expUsec > PAL_TMR_SETUP_US) {
+    expUsec -= PAL_TMR_SETUP_US;
+  }
+
   /* Calculate the compare value */
   compareValue = ((uint64_t)expUsec * (uint64_t)PAL_RTC_TICKS_PER_SEC) / (uint64_t)1000000;
 
-  /* Account for setup time */
-  if (compareValue > PAL_TMR_SETUP_TICKS) {
-    compareValue -= PAL_TMR_SETUP_TICKS;
-  } else {
+  /* Make sure we get at least 1 tick */
+  if(compareValue == 0) {
     compareValue = 1;
   }
   MXC_TMR_SetCompare(PAL_SLEEP_TMR, compareValue);
@@ -371,7 +375,7 @@ void PalTimerSleep(uint32_t expUsec)
 uint32_t PalTimerGetExpTime(void)
 {
   uint64_t time;
-
+  uint32_t compare, count;
   /* See if the timer is currently running */
   if(palTimerCb.state != PAL_TIMER_STATE_BUSY) {
     return 0;
@@ -381,18 +385,12 @@ uint32_t PalTimerGetExpTime(void)
   if(!(PAL_TMR->ctrl0 & MXC_F_TMR_CTRL0_EN_A)) {
     return 0;
   }
+  count = MXC_TMR_GetCount(PAL_TMR);
+  compare = MXC_TMR_GetCompare(PAL_TMR) + PAL_TMR_SETUP_US;
+  time = compare - count;
 
-  time = MXC_TMR_GetCompare(PAL_TMR) - MXC_TMR_GetCount(PAL_TMR);
+  /* Convert back to us */
+  time = ((uint64_t)time * (uint64_t)1000000) / (uint64_t)PAL_RTC_TICKS_PER_SEC;
 
-  /* Account for the setup time */
-  if(time > PAL_TMR_SETUP_TICKS) {
-    time -= PAL_TMR_SETUP_TICKS;
-
-    /* Convert back to us */
-    time = ((uint64_t)time * (uint64_t)1000000) / (uint64_t)PAL_RTC_TICKS_PER_SEC;
-  } else {
-    return 0;
-  }
-  
   return time;
 }

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_timer.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_timer.c
@@ -26,7 +26,7 @@
 #include "gcr_regs.h"
 #include "mxc_device.h"
 #include "wsf_trace.h"
-#include "pal_rtc.h"
+
 
 /**************************************************************************************************
   Macros
@@ -61,7 +61,7 @@
 #define PAL_SLEEP_TMR                   MXC_TMR_GET_TMR(PAL_SLEEP_TMR_IDX)
 #define PAL_SLEEP_TMR_IRQn              MXC_TMR_GET_IRQ(PAL_SLEEP_TMR_IDX)
 
-#define PAL_TMR_SETUP_US                300
+#define PAL_TMR_CALIB_TIME              100000
 
 /**************************************************************************************************
   Global Variables
@@ -71,6 +71,7 @@
 static struct {
   PalTimerState_t     state;           /*!< State. */
   PalTimerCompCback_t expCback;        /*!< Timer expiry call back function. */
+  int                 usecDiff;        /*!< Adjustment factor for timer. */
 } palTimerCb;
 
 /**************************************************************************************************
@@ -152,6 +153,8 @@ void TMR0_IRQHandler(void)
 void PalTimerInit(PalTimerCompCback_t expCback)
 {
   mxc_tmr_cfg_t tmr_cfg;
+  bool_t palBbState;
+  uint32_t tickStart, tickEnd;
 
   PAL_TIMER_CHECK(palTimerCb.state == PAL_TIMER_STATE_UNINIT);
   PAL_TIMER_CHECK(expCback != NULL);
@@ -164,7 +167,7 @@ void PalTimerInit(PalTimerCompCback_t expCback)
 
   tmr_cfg.pres = TMR_PRES_1;
   tmr_cfg.mode = TMR_MODE_ONESHOT;
-  tmr_cfg.clock = MXC_TMR_32K_CLK;
+  tmr_cfg.clock = MXC_TMR_APB_CLK;
 
   tmr_cfg.bitMode = TMR_BIT_MODE_32;
   tmr_cfg.pol = 0;
@@ -175,6 +178,30 @@ void PalTimerInit(PalTimerCompCback_t expCback)
 
   MXC_TMR_Stop(PAL_TMR);
   MXC_TMR_Init(PAL_TMR, &tmr_cfg, FALSE);
+
+  /* Make sure the BB clock is running */
+  if(PalBbGetCurrentTime() == 0) {
+    palBbState = FALSE;
+    PalBbEnable();
+  } else{
+    palBbState = TRUE;
+  }
+
+  /* Wait for the clock to run */
+  while(PalBbGetCurrentTime() == 0) {}
+
+  /* Save the ticks for PAL_TMR_CALIB_TIME usec */
+  tickStart = PalBbGetCurrentTime();
+  MXC_TMR_Delay(PAL_TMR, PAL_TMR_CALIB_TIME);
+  tickEnd = PalBbGetCurrentTime();
+
+  /* Save the difference */
+  palTimerCb.usecDiff = PAL_TMR_CALIB_TIME - (tickEnd - tickStart);
+
+  /* Restore the BB state */
+  if(!palBbState) {
+    PalBbDisable();
+  }
   
   palTimerCb.expCback = expCback;
   palTimerCb.state = PAL_TIMER_STATE_READY;
@@ -254,27 +281,18 @@ void PalTimerStart(uint32_t expUsec)
 {
   PAL_TIMER_CHECK(palTimerCb.state == PAL_TIMER_STATE_READY);
   PAL_TIMER_CHECK(expUsec != 0);
-  uint64_t compareValue;
 
   /* Make sure we don't wrap the timeout */
   if(expUsec == 0) {
     expUsec = 1;
   }
 
+  /* Convert the time based on our calibration */
+  expUsec += (expUsec/PAL_TMR_CALIB_TIME)*palTimerCb.usecDiff;
+
+  /* Convert the start time to ticks */
   MXC_TMR_SetCount(PAL_TMR, 0);
-
-  if(expUsec > PAL_TMR_SETUP_US) {
-    expUsec -= PAL_TMR_SETUP_US;
-  }
-
-  /* Calculate the compare value */
-  compareValue = ((uint64_t)expUsec * (uint64_t)PAL_RTC_TICKS_PER_SEC) / (uint64_t)1000000;
-
-  /* Make sure we get at least 1 tick */
-  if(compareValue == 0) {
-    compareValue = 1;
-  }
-  MXC_TMR_SetCompare(PAL_TMR, compareValue);
+  MXC_TMR_SetCompare(PAL_TMR, PeripheralClock/1000000 * expUsec);
 
   /* Clear and enable interrupts */
   MXC_TMR_ClearFlags(PAL_TMR);
@@ -317,7 +335,6 @@ void PalTimerStop(void)
 void PalTimerSleep(uint32_t expUsec)
 {
   mxc_tmr_cfg_t tmr_cfg;
-  uint64_t compareValue;
 
   /* Configure timer */
   tmr_cfg.pres = TMR_PRES_1;
@@ -333,20 +350,10 @@ void PalTimerSleep(uint32_t expUsec)
 
   MXC_TMR_Stop(PAL_SLEEP_TMR);
   MXC_TMR_Init(PAL_SLEEP_TMR, &tmr_cfg, FALSE);
+
+  /* Convert the start time to ticks */
   MXC_TMR_SetCount(PAL_SLEEP_TMR, 0);
-
-  if(expUsec > PAL_TMR_SETUP_US) {
-    expUsec -= PAL_TMR_SETUP_US;
-  }
-
-  /* Calculate the compare value */
-  compareValue = ((uint64_t)expUsec * (uint64_t)PAL_RTC_TICKS_PER_SEC) / (uint64_t)1000000;
-
-  /* Make sure we get at least 1 tick */
-  if(compareValue == 0) {
-    compareValue = 1;
-  }
-  MXC_TMR_SetCompare(PAL_SLEEP_TMR, compareValue);
+  MXC_TMR_SetCompare(PAL_SLEEP_TMR, PeripheralClock/1000000 * expUsec);
 
   /* Clear and enable interrupts */
   MXC_TMR_ClearFlags(PAL_SLEEP_TMR);
@@ -374,23 +381,18 @@ void PalTimerSleep(uint32_t expUsec)
 /*************************************************************************************************/
 uint32_t PalTimerGetExpTime(void)
 {
-  uint64_t time;
-  uint32_t compare, count;
+  uint32_t time;
+
   /* See if the timer is currently running */
   if(palTimerCb.state != PAL_TIMER_STATE_BUSY) {
     return 0;
   }
 
-  /* See if the timer is enabled */
-  if(!(PAL_TMR->ctrl0 & MXC_F_TMR_CTRL0_EN_A)) {
-    return 0;
-  }
-  count = MXC_TMR_GetCount(PAL_TMR);
-  compare = MXC_TMR_GetCompare(PAL_TMR) + PAL_TMR_SETUP_US;
-  time = compare - count;
+  time = MXC_TMR_GetCompare(PAL_TMR) - MXC_TMR_GetCount(PAL_TMR);
+  time /= (PeripheralClock/1000000);
 
-  /* Convert back to us */
-  time = ((uint64_t)time * (uint64_t)1000000) / (uint64_t)PAL_RTC_TICKS_PER_SEC;
-
+  /* Adjust time based on the calibrated value */
+  time = time - ((time/PAL_TMR_CALIB_TIME)*palTimerCb.usecDiff);
+  
   return time;
 }


### PR DESCRIPTION
-This will pass once the 32Khz fix is made and merged into main and then main merged into this

### Updates test launcher script
 - script accepts 3 parameters now as follows:
   - device  under test in lower caps  eg:  max32655
   - device serial port serial eg: DT309ZDF
   - CMSIS dap serial : 4440920139230423408230424312233

 - uses board_config.json to find devices instead of hard coded serial numbers
 - for BLE_datc/s connected test there is a short timeout period required to enter then pin
   sometimes if flashing took too long the timeout would pass. Now the script flashes them at the same time
   so that they start up closer to each other and have time to enter the pin.

-