### PR TITLE
Disable ci-test for ME18 examples that are WIP

### DIFF
--- a/.github/workflows/ci-tests/Examples_tests/test_launcher.sh
+++ b/.github/workflows/ci-tests/Examples_tests/test_launcher.sh
@@ -333,7 +333,9 @@ for dir in ./*/; do
             ;;
 
         "BLE_fit")
+        if [[ $DUT_NAME_UPPER != "MAX32690" ]]; then
             run_notConntectedTest
+        fi
             ;;
 
         "BLE_fcc")
@@ -342,7 +344,9 @@ for dir in ./*/; do
             ;;
 
         "BLE_FreeRTOS")
+        if [[ $DUT_NAME_UPPER != "MAX32690" ]]; then
             run_notConntectedTest
+        fi
             ;;
 
         "BLE_otac")


### PR DESCRIPTION
This is to disable ci-test for `BLE_fit` and `BLE_freeRTOS` examples for ME18 which are still a work in progress. Will be re-enabled once we get them working well.  This is related to #321 which still eludes us.