### PR TITLE
PTG: Added READY and STOP registers for ME12, ME18, and ME55.

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Include/max32572.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Include/max32572.svd
@@ -376,6 +376,67 @@
   </peripheral>
 <!--ADC 10-bit Analog to Digital Converter-->
   <peripheral>
+   <name>AESKEYS</name>
+   <description>AES Key Registers.</description>
+   <baseAddress>0x40005000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>KEY0</name>
+     <description>AES Key 0.</description>
+     <addressOffset>0x00</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY1</name>
+     <description>AES Key 1.</description>
+     <addressOffset>0x04</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY2</name>
+     <description>AES Key 2.</description>
+     <addressOffset>0x08</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY3</name>
+     <description>AES Key 3.</description>
+     <addressOffset>0x0C</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY4</name>
+     <description>AES Key 4.</description>
+     <addressOffset>0x10</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY5</name>
+     <description>AES Key 5.</description>
+     <addressOffset>0x14</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY6</name>
+     <description>AES Key 6.</description>
+     <addressOffset>0x18</addressOffset>
+     <size>32</size>
+    </register>
+    <register>
+     <name>KEY7</name>
+     <description>AES Key 7.</description>
+     <addressOffset>0x1C</addressOffset>
+     <size>32</size>
+    </register>
+   </registers>
+  </peripheral>
+<!--AESKEYS AES Key Registers.-->
+  <peripheral>
    <name>MSRADC</name>
    <description>Magnetic Strip Reader - 9 bit ADC</description>
    <baseAddress>0x4002B000</baseAddress>
@@ -7662,17 +7723,17 @@
   </peripheral>
 <!--I2C2 Inter-Integrated Circuit. 2-->
   <peripheral>
-   <name>ICC0</name>
-   <description>Instruction Cache Controller Registers</description>
-   <baseAddress>0x4002A000</baseAddress>
+   <name>SFCC</name>
+   <description>SPIXF Cache Controller Registers</description>
+   <baseAddress>0x4002F000</baseAddress>
    <addressBlock>
     <offset>0x00</offset>
-    <size>0x800</size>
+    <size>0x1000</size>
     <usage>registers</usage>
    </addressBlock>
    <registers>
     <register>
-     <name>INFO</name>
+     <name>CACHE_ID</name>
      <description>Cache ID Register.</description>
      <addressOffset>0x0000</addressOffset>
      <access>read-only</access>
@@ -7690,7 +7751,7 @@
        <bitWidth>4</bitWidth>
       </field>
       <field>
-       <name>ID</name>
+       <name>CCHID</name>
        <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
        <bitOffset>10</bitOffset>
        <bitWidth>6</bitWidth>
@@ -7698,20 +7759,20 @@
      </fields>
     </register>
     <register>
-     <name>SZ</name>
+     <name>MEMCFG</name>
      <description>Memory Configuration Register.</description>
      <addressOffset>0x0004</addressOffset>
      <access>read-only</access>
      <resetValue>0x00080008</resetValue>
      <fields>
       <field>
-       <name>CCH</name>
+       <name>CCHSZ</name>
        <description>Cache Size. Indicates total size in Kbytes of cache.</description>
        <bitOffset>0</bitOffset>
        <bitWidth>16</bitWidth>
       </field>
       <field>
-       <name>MEM</name>
+       <name>MEMSZ</name>
        <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
        <bitOffset>16</bitOffset>
        <bitWidth>16</bitWidth>
@@ -7719,12 +7780,12 @@
      </fields>
     </register>
     <register>
-     <name>CTRL</name>
+     <name>CACHE_CTRL</name>
      <description>Cache Control and Status Register.</description>
      <addressOffset>0x0100</addressOffset>
      <fields>
       <field>
-       <name>EN</name>
+       <name>CACHE_EN</name>
        <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
        <bitOffset>0</bitOffset>
        <bitWidth>1</bitWidth>
@@ -7742,7 +7803,7 @@
        </enumeratedValues>
       </field>
       <field>
-       <name>RDY</name>
+       <name>CACHE_RDY</name>
        <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
        <bitOffset>16</bitOffset>
        <bitWidth>1</bitWidth>
@@ -7767,18 +7828,10 @@
      <description>Invalidate All Registers.</description>
      <addressOffset>0x0700</addressOffset>
      <access>read-write</access>
-     <fields>
-      <field>
-       <name>INVALID</name>
-       <description>Invalidate.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>32</bitWidth>
-      </field>
-     </fields>
     </register>
    </registers>
   </peripheral>
-<!--ICC0 Instruction Cache Controller Registers-->
+<!--SFCC SPIXF Cache Controller Registers-->
   <peripheral>
    <name>OTP</name>
    <description>One-Time Programmable (OTP) Memory Controller.</description>
@@ -7977,523 +8030,6 @@
    </registers>
   </peripheral>
 <!--OTP One-Time Programmable (OTP) Memory Controller.-->
-  <peripheral>
-   <name>PTG</name>
-   <description>Pulse Train Generation</description>
-   <groupName>Pulse_Train</groupName>
-   <baseAddress>0x4003C000</baseAddress>
-   <size>32</size>
-   <access>read-write</access>
-   <addressBlock>
-    <offset>0</offset>
-    <size>0x0020</size>
-    <usage>registers</usage>
-   </addressBlock>
-   <interrupt>
-    <name>PT</name>
-    <description>Pulse Train IRQ</description>
-    <value>59</value>
-   </interrupt>
-   <registers>
-    <register>
-     <name>ENABLE</name>
-     <description>Global Enable/Disable Controls for All Pulse Trains</description>
-     <addressOffset>0x0000</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Enable/Disable control for PT0</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Enable/Disable control for PT1</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Enable/Disable control for PT2</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Enable/Disable control for PT3</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt4</name>
-       <description>Enable/Disable control for PT4</description>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt5</name>
-       <description>Enable/Disable control for PT5</description>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt6</name>
-       <description>Enable/Disable control for PT6</description>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt7</name>
-       <description>Enable/Disable control for PT7</description>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>RESYNC</name>
-     <description>Global Resync (All Pulse Trains) Control</description>
-     <addressOffset>0x0004</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Resync control for PT0</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Resync control for PT1</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Resync control for PT2</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Resync control for PT3</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt4</name>
-       <description>Resync control for PT4</description>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt5</name>
-       <description>Resync control for PT5</description>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt6</name>
-       <description>Resync control for PT6</description>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt7</name>
-       <description>Resync control for PT7</description>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>INTFL</name>
-     <description>Pulse Train Interrupt Flags</description>
-     <addressOffset>0x0008</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Pulse Train 0 Stopped Interrupt Flag</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Pulse Train 1 Stopped Interrupt Flag</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Pulse Train 2 Stopped Interrupt Flag</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Pulse Train 3 Stopped Interrupt Flag</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt4</name>
-       <description>Pulse Train 4 Stopped Interrupt Flag</description>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt5</name>
-       <description>Pulse Train 5 Stopped Interrupt Flag</description>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt6</name>
-       <description>Pulse Train 6 Stopped Interrupt Flag</description>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt7</name>
-       <description>Pulse Train 7 Stopped Interrupt Flag</description>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>INTEN</name>
-     <description>Pulse Train Interrupt Enable/Disable</description>
-     <addressOffset>0x000C</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt4</name>
-       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt5</name>
-       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt6</name>
-       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt7</name>
-       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>SAFE_EN</name>
-     <description>Pulse Train Global Safe Enable.</description>
-     <addressOffset>0x0010</addressOffset>
-     <access>write-only</access>
-     <fields>
-      <field>
-       <name>PT0</name>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT1</name>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT2</name>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT3</name>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT4</name>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT5</name>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT6</name>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT7</name>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>SAFE_DIS</name>
-     <description>Pulse Train Global Safe Disable.</description>
-     <addressOffset>0x0014</addressOffset>
-     <access>write-only</access>
-     <fields>
-      <field>
-       <name>PT0</name>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT1</name>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT2</name>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT3</name>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT4</name>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT5</name>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT6</name>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT7</name>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>READY_INTFL</name>
-     <description>Pulse Train Ready Interrupt Flags</description>
-     <addressOffset>0x0018</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Pulse Train 0 Stopped Interrupt Flag</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Pulse Train 1 Stopped Interrupt Flag</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Pulse Train 2 Stopped Interrupt Flag</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Pulse Train 3 Stopped Interrupt Flag</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt4</name>
-       <description>Pulse Train 4 Stopped Interrupt Flag</description>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt5</name>
-       <description>Pulse Train 5 Stopped Interrupt Flag</description>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt6</name>
-       <description>Pulse Train 6 Stopped Interrupt Flag</description>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt7</name>
-       <description>Pulse Train 7 Stopped Interrupt Flag</description>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>READY_INTEN</name>
-     <description>Pulse Train Ready Interrupt Enable/Disable</description>
-     <addressOffset>0x001C</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt4</name>
-       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt5</name>
-       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt6</name>
-       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt7</name>
-       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-   </registers>
-  </peripheral>
-<!--PTG Pulse Train Generation-->
   <peripheral>
    <name>PT</name>
    <description>Pulse Train</description>
@@ -8761,43 +8297,43 @@
   <peripheral derivedFrom="PT">
    <name>PT1</name>
    <description>Pulse Train 1</description>
-   <baseAddress>0x4003C040</baseAddress>
+   <baseAddress>0x4003C030</baseAddress>
   </peripheral>
 <!--PT1 Pulse Train 1-->
   <peripheral derivedFrom="PT">
    <name>PT2</name>
    <description>Pulse Train 2</description>
-   <baseAddress>0x4003C060</baseAddress>
+   <baseAddress>0x4003C040</baseAddress>
   </peripheral>
 <!--PT2 Pulse Train 2-->
   <peripheral derivedFrom="PT">
    <name>PT3</name>
    <description>Pulse Train 3</description>
-   <baseAddress>0x4003C080</baseAddress>
+   <baseAddress>0x4003C050</baseAddress>
   </peripheral>
 <!--PT3 Pulse Train 3-->
   <peripheral derivedFrom="PT">
    <name>PT4</name>
    <description>Pulse Train 4</description>
-   <baseAddress>0x4003C0A0</baseAddress>
+   <baseAddress>0x4003C060</baseAddress>
   </peripheral>
 <!--PT4 Pulse Train 4-->
   <peripheral derivedFrom="PT">
    <name>PT5</name>
    <description>Pulse Train 5</description>
-   <baseAddress>0x4003C0C0</baseAddress>
+   <baseAddress>0x4003C070</baseAddress>
   </peripheral>
 <!--PT5 Pulse Train 5-->
   <peripheral derivedFrom="PT">
    <name>PT6</name>
    <description>Pulse Train 6</description>
-   <baseAddress>0x4003C0E0</baseAddress>
+   <baseAddress>0x4003C080</baseAddress>
   </peripheral>
 <!--PT6 Pulse Train 6-->
   <peripheral derivedFrom="PT">
    <name>PT7</name>
    <description>Pulse Train 7</description>
-   <baseAddress>0x4003C100</baseAddress>
+   <baseAddress>0x4003C090</baseAddress>
   </peripheral>
 <!--PT7 Pulse Train 7-->
   <peripheral derivedFrom="PT">
@@ -8806,6 +8342,523 @@
    <baseAddress />
   </peripheral>
 <!--PT8 Pulse Train 8-->
+  <peripheral>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
+   <addressBlock>
+    <offset>0</offset>
+    <size>0x0020</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Enable/Disable control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Enable/Disable control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Enable/Disable control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Enable/Disable control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Resync control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Resync control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Resync control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Resync control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTFL</name>
+     <description>Pulse Train Stop Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTEN</name>
+     <description>Pulse Train Stop Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTFL</name>
+     <description>Pulse Train Ready Interrupt Flags</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Ready Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Ready Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Ready Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Ready Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTEN</name>
+     <description>Pulse Train Ready Interrupt Enable/Disable</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Ready Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Ready Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Ready Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Ready Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--PTG Pulse Train Generation-->
   <peripheral>
    <name>PWRSEQ</name>
    <description>Power Sequencer / Low Power Control Register.</description>
@@ -16323,25 +16376,6 @@
        </enumeratedValues>
       </field>
       <field>
-       <name>DMAREQEN</name>
-       <description> DMA Request Enable </description>
-       <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-       <enumeratedValues>
-        <enumeratedValue>
-         <name>dis</name>
-         <description>Disable DMA for this IN endpoint.</description>
-         <value>0</value>
-        </enumeratedValue>
-        <enumeratedValue>
-         <name>en</name>
-         <description>Enable DMA for this IN endpoint.</description>
-         <value>1</value>
-        </enumeratedValue>
-       </enumeratedValues>
-      </field>
-      <field>
        <name>FRCDATATOG</name>
        <description> Force In Data - Toggle</description>
        <bitOffset>3</bitOffset>
@@ -16356,25 +16390,6 @@
         <enumeratedValue>
          <name>dontcare</name>
          <description>Toggle data-toggle regardless of ACK. </description>
-         <value>1</value>
-        </enumeratedValue>
-       </enumeratedValues>
-      </field>
-      <field>
-       <name>DMAREQMODE</name>
-       <description> DMA Request Mode Enable </description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-       <enumeratedValues>
-        <enumeratedValue>
-         <name>0</name>
-         <description>Enable DMA Request Mode 0.</description>
-         <value>0</value>
-        </enumeratedValue>
-        <enumeratedValue>
-         <name>1</name>
-         <description>Enable DMA Request Mode 1.</description>
          <value>1</value>
         </enumeratedValue>
        </enumeratedValues>
@@ -16495,20 +16510,8 @@
        <access>read-write</access>
       </field>
       <field>
-       <name>DMAREQEN</name>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
        <name>DISNYET</name>
        <bitOffset>4</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>DMAREQMODE</name>
-       <bitOffset>3</bitOffset>
        <bitWidth>1</bitWidth>
        <access>read-write</access>
       </field>
@@ -16801,16 +16804,10 @@
     </register>
     <register>
      <name>RAMINFO</name>
-     <description>RAM width and DMA hardware information.</description>
+     <description>RAM width information.</description>
      <addressOffset>0x79</addressOffset>
      <size>8</size>
      <fields>
-      <field>
-       <name>DMACHANS</name>
-       <bitOffset>4</bitOffset>
-       <bitWidth>4</bitWidth>
-       <access>read-only</access>
-      </field>
       <field>
        <name>RAMBITS</name>
        <bitOffset>0</bitOffset>
@@ -16833,26 +16830,6 @@
       </field>
       <field>
        <name>RSTS</name>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>EARLYDMA</name>
-     <description>DMA timing control register.</description>
-     <addressOffset>0x7B</addressOffset>
-     <size>8</size>
-     <fields>
-      <field>
-       <name>EDMAIN</name>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>EDMAOUT</name>
        <bitOffset>0</bitOffset>
        <bitWidth>1</bitWidth>
        <access>read-write</access>
@@ -17134,20 +17111,14 @@
        <bitOffset>0</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
-      <field>
-       <name>DMA_INT</name>
-       <description>DMA_INT</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
      </fields>
     </register>
    </registers>
   </peripheral>
 <!--USBHS USB 2.0 High-speed Controller.-->
   <peripheral>
-   <name>WDT0</name>
-   <description>Watchdog Timer 0</description>
+   <name>WDT</name>
+   <description>Windowed Watchdog Timer</description>
    <baseAddress>0x40003000</baseAddress>
    <addressBlock>
     <offset>0x00</offset>
@@ -17155,7 +17126,7 @@
     <usage>registers</usage>
    </addressBlock>
    <interrupt>
-    <name>WDT0</name>
+    <name>WWDT</name>
     <value>1</value>
    </interrupt>
    <registers>
@@ -17163,11 +17134,11 @@
      <name>CTRL</name>
      <description>Watchdog Timer Control Register.</description>
      <addressOffset>0x00</addressOffset>
-     <resetMask>0x7FFFF000</resetMask>
+     <access>read-write</access>
      <fields>
       <field>
-       <name>INT_PERIOD</name>
-       <description>Watchdog Interrupt Period. The watchdog timer will assert an interrupt, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <name>INT_LATE_VAL</name>
+       <description>Windowed Watchdog Interrupt Upper Limit. Sets the number of WDTCLK cycles until a windowed watchdog timer interrupt is generated (if enabled) if the CPU does not write the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
        <bitOffset>0</bitOffset>
        <bitWidth>4</bitWidth>
        <enumeratedValues>
@@ -17254,8 +17225,8 @@
        </enumeratedValues>
       </field>
       <field>
-       <name>RST_PERIOD</name>
-       <description>Watchdog Reset Period. The watchdog timer will assert a reset, if enabled, if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <name>RST_LATE_VAL</name>
+       <description>Windowed Watchdog Reset Upper Limit. Sets the number of WDTCLK cycles until a system reset occurs (if enabled) if the CPU does not write the watchdog reset sequence to the WDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
        <bitOffset>4</bitOffset>
        <bitWidth>4</bitWidth>
        <enumeratedValues>
@@ -17342,8 +17313,8 @@
        </enumeratedValues>
       </field>
       <field>
-       <name>WDT_EN</name>
-       <description>Watchdog Timer Enable.</description>
+       <name>EN</name>
+       <description>Windowed Watchdog Timer Enable.</description>
        <bitOffset>8</bitOffset>
        <bitWidth>1</bitWidth>
        <enumeratedValues>
@@ -17360,12 +17331,12 @@
        </enumeratedValues>
       </field>
       <field>
-       <name>INT_FLAG</name>
-       <description>Watchdog Timer Interrupt Flag.</description>
+       <name>INT_LATE</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Late.</description>
        <bitOffset>9</bitOffset>
        <bitWidth>1</bitWidth>
-       <modifiedWriteValues>oneToClear</modifiedWriteValues>
        <enumeratedValues>
+        <usage>read-write</usage>
         <enumeratedValue>
          <name>inactive</name>
          <description>No interrupt is pending.</description>
@@ -17379,8 +17350,8 @@
        </enumeratedValues>
       </field>
       <field>
-       <name>INT_EN</name>
-       <description>Watchdog Timer Interrupt Enable.</description>
+       <name>WDT_INT_EN</name>
+       <description>Windowed Watchdog Timer Interrupt Enable.</description>
        <bitOffset>10</bitOffset>
        <bitWidth>1</bitWidth>
        <enumeratedValues>
@@ -17397,8 +17368,8 @@
        </enumeratedValues>
       </field>
       <field>
-       <name>RST_EN</name>
-       <description>Watchdog Timer Reset Enable.</description>
+       <name>WDT_RST_EN</name>
+       <description>Windowed Watchdog Timer Reset Enable.</description>
        <bitOffset>11</bitOffset>
        <bitWidth>1</bitWidth>
        <enumeratedValues>
@@ -17415,8 +17386,252 @@
        </enumeratedValues>
       </field>
       <field>
-       <name>RST_FLAG</name>
-       <description>Watchdog Timer Reset Flag.</description>
+       <name>INT_EARLY</name>
+       <description>Windowed Watchdog Timer Interrupt Flag Too Soon.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>inactive</name>
+         <description>No interrupt is pending.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>pending</name>
+         <description>An interrupt is pending.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>INT_EARLY_VAL</name>
+       <description>Windowed Watchdog Interrupt Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A windowed watchdog timer interrupt is generated (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY_VAL</name>
+       <description>Windowed Watchdog Reset Lower Limit. Sets the number of WDTCLK cycles that establishes the lower boundary of the watchdog window. A system reset occurs (if enabled) if the CPU writes the windowed watchdog reset sequence to the WWDT_RST register before the watchdog timer has counted this time period since the last timer reset.</description>
+       <bitOffset>20</bitOffset>
+       <bitWidth>4</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>wdt2pow31</name>
+         <description>2**31 clock cycles.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow30</name>
+         <description>2**30 clock cycles.</description>
+         <value>1</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow29</name>
+         <description>2**29 clock cycles.</description>
+         <value>2</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow28</name>
+         <description>2**28 clock cycles.</description>
+         <value>3</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow27</name>
+         <description>2^27 clock cycles.</description>
+         <value>4</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow26</name>
+         <description>2**26 clock cycles.</description>
+         <value>5</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow25</name>
+         <description>2**25 clock cycles.</description>
+         <value>6</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow24</name>
+         <description>2**24 clock cycles.</description>
+         <value>7</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow23</name>
+         <description>2**23 clock cycles.</description>
+         <value>8</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow22</name>
+         <description>2**22 clock cycles.</description>
+         <value>9</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow21</name>
+         <description>2**21 clock cycles.</description>
+         <value>10</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow20</name>
+         <description>2**20 clock cycles.</description>
+         <value>11</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow19</name>
+         <description>2**19 clock cycles.</description>
+         <value>12</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow18</name>
+         <description>2**18 clock cycles.</description>
+         <value>13</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow17</name>
+         <description>2**17 clock cycles.</description>
+         <value>14</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>wdt2pow16</name>
+         <description>2**16 clock cycles.</description>
+         <value>15</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>CLKRDY_IE</name>
+       <description>Switch Ready Interrupt Enable. Fires an interrupt when it is safe to swithc the clock.</description>
+       <bitOffset>27</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKRDY</name>
+       <description>Clock Status.</description>
+       <bitOffset>28</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WIN_EN</name>
+       <description>Enables the Windowed Watchdog Function.</description>
+       <bitOffset>29</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Windowed Mode Disabled (i.e. Compatibility Mode).</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Windowed Mode Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_EARLY</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Soon.</description>
+       <bitOffset>30</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <usage>read-write</usage>
+        <enumeratedValue>
+         <name>noEvent</name>
+         <description>The event has not occurred.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>occurred</name>
+         <description>The event has occurred.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RST_LATE</name>
+       <description>Windowed Watchdog Timer Reset Flag Too Late.</description>
        <bitOffset>31</bitOffset>
        <bitWidth>1</bitWidth>
        <enumeratedValues>
@@ -17437,13 +17652,13 @@
     </register>
     <register>
      <name>RST</name>
-     <description>Watchdog Timer Reset Register.</description>
+     <description>Windowed Watchdog Timer Reset Register.</description>
      <addressOffset>0x04</addressOffset>
      <access>write-only</access>
      <fields>
       <field>
-       <name>WDT_RST</name>
-       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD then a watchdog reset will occur, if enabled.</description>
+       <name>RESET</name>
+       <description>Writing the watchdog counter 'reset sequence' to this register resets the watchdog counter. If the watchdog count exceeds INT_PERIOD_UPPER_LIMIT then a watchdog interrupt will occur, if enabled. If the watchdog count exceeds RST_PERIOD_UPPER_LIMIT then a watchdog reset will occur, if enabled.</description>
        <bitOffset>0</bitOffset>
        <bitWidth>8</bitWidth>
        <enumeratedValues>
@@ -17461,12 +17676,40 @@
       </field>
      </fields>
     </register>
+    <register>
+     <name>CLKSEL</name>
+     <description>Windowed Watchdog Timer Clock Select Register.</description>
+     <addressOffset>0x08</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>SOURCE</name>
+       <description>WWDT Clock Selection Register.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>3</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CNT</name>
+     <description>Windowed Watchdog Timer Count Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>COUNT</name>
+       <description>Current Value of the Windowed Watchdog Timer Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
    </registers>
   </peripheral>
-<!--WDT0 Watchdog Timer 0-->
-  <peripheral derivedFrom="WDT0">
+<!--WDT Windowed Watchdog Timer-->
+  <peripheral derivedFrom="WDT">
    <name>WDT1</name>
-   <description>Watchdog Timer 0 1</description>
+   <description>Windowed Watchdog Timer 1</description>
    <baseAddress>0x40003400</baseAddress>
    <interrupt>
     <name>WDT1</name>
@@ -17474,7 +17717,7 @@
     <value>57</value>
    </interrupt>
   </peripheral>
-<!--WDT1 Watchdog Timer 0 1-->
+<!--WDT1 Windowed Watchdog Timer 1-->
   <peripheral>
    <name>SKBD</name>
    <description>Secure Keyboard</description>
@@ -17903,7 +18146,7 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
-       <name>cm4_irq</name>
+       <name>rv32_irq</name>
        <bitOffset>16</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
@@ -17934,7 +18177,7 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
-       <name>rv32_irq</name>
+       <name>cm4_irq</name>
        <bitOffset>16</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
@@ -18008,5 +18251,444 @@
                                      architect to decide how and when the semaphores are used and how they are allocated. Existing hardware does not have to be
                                      
                                      modified for this type of cooperative sharing, and the use of semaphores is exclusively within the software domain.-->
+  <peripheral>
+   <name>SC0</name>
+   <description>Smart Card Interface.</description>
+   <groupName>SCN</groupName>
+   <baseAddress>0x4002C000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x1000</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>SC0</name>
+    <description>SC0 IRQ</description>
+    <value>11</value>
+   </interrupt>
+   <registers>
+    <register>
+     <name>CR</name>
+     <description>Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>CONV</name>
+       <description>Convention Select Bit.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CREP</name>
+       <description>Character Repeat Enable Bit.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WTEN</name>
+       <description>Wait Time Counter Enable Bit.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>UART</name>
+       <description>Smart Card Mode Bit.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCEN</name>
+       <description>Clock Counter Enable Bit.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFLUSH</name>
+       <description>Receive FIFO Flush.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXFLUSH</name>
+       <description>Transmit FIFO Flush.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXTHD</name>
+       <description>Receive FIFO Depth.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TXTHD</name>
+       <description>Transmit FIFO Depth.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>DUAL_MODE</name>
+       <description>Dual Internal AFE and Bypass Mode.</description>
+       <bitOffset>23</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SR</name>
+     <description>Status Register.</description>
+     <addressOffset>0x04</addressOffset>
+     <fields>
+      <field>
+       <name>PAR</name>
+       <description>Parity Error Detector Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WTOV</name>
+       <description>Waiting Time Counter Overflow.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CCOV</name>
+       <description>Clock Counter Overflow Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXCF</name>
+       <description>Transmit Complete Flag.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXEMPTY</name>
+       <description>Receive FIFO Empty Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFULL</name>
+       <description>Receive FIFO Full Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXEMPTY</name>
+       <description>Transmit FIFO Empty Flag.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXFULL</name>
+       <description>Transmit FIFO Full Flag.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXELT</name>
+       <description>Number of Bytes in the Receive FIFO.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>TXELT</name>
+       <description>Number of Bytes in the Transmit FIFO.</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>PN</name>
+     <description>Pin Register,</description>
+     <addressOffset>0x08</addressOffset>
+     <fields>
+      <field>
+       <name>CRDRST</name>
+       <description>Smart Card Reset Pin Control.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRDCLK</name>
+       <description>Smart Card Clock Piin Control.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRDIO</name>
+       <description>Smart Card IO Pin Control.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRDC4</name>
+       <description>Smart Card SCn_C4 Pin Control.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CRDC8</name>
+       <description>Smart Card SCn_C8 Pin Control.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CLKSEL</name>
+       <description>Smart Card Clock Select.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>IO_C48_EN</name>
+       <description>Pin Enable.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ETUR</name>
+     <description>ETU Register.</description>
+     <addressOffset>0x0C</addressOffset>
+     <fields>
+      <field>
+       <name>ETU</name>
+       <description>Elemental Time Unit Value.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>15</bitWidth>
+      </field>
+      <field>
+       <name>COMP</name>
+       <description>Compensation Mode Enable Bit.</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>HALF</name>
+       <description>Half ETU Count Selection Bit.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>GTR</name>
+     <description>Guard Time Register.</description>
+     <addressOffset>0x10</addressOffset>
+     <fields>
+      <field>
+       <name>GT</name>
+       <description>Guard Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WT0R</name>
+     <description>Waiting Time 0 Register.</description>
+     <addressOffset>0x14</addressOffset>
+     <fields>
+      <field>
+       <name>WT</name>
+       <description>Wait Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>WT1R</name>
+     <description>Waiting Time 1 Register.</description>
+     <addressOffset>0x18</addressOffset>
+     <fields>
+      <field>
+       <name>WT</name>
+       <description>Wait Time.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>IER</name>
+     <description>Interrupt Enable Register.</description>
+     <addressOffset>0x1C</addressOffset>
+     <fields>
+      <field>
+       <name>PARIE</name>
+       <description>Parity Error Interrupt Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WTIE</name>
+       <description>Waiting Time Overflow Interrupt Enable.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTIE</name>
+       <description>Clock Counter Overflow Interrupt Enable.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TCIE</name>
+       <description>Character Transmission Completion Interrupt Enable.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXEIE</name>
+       <description>Receive FIFO Empty Interrupt Enable.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXTIE</name>
+       <description>Receive FIFO Threshold Reached Interrupt Enable.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFIE</name>
+       <description>Receive FIFO Full Interrupt Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXEIE</name>
+       <description>Transmit FIFO Empty Interrupt Enable.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXTIE</name>
+       <description>Transmit FIFO Threshold Reached Interrupt Enable.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>ISR</name>
+     <description>Interrupt Status Register.</description>
+     <addressOffset>0x20</addressOffset>
+     <fields>
+      <field>
+       <name>PARIS</name>
+       <description>Parity Error Interrupt Status Flag.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>WTIS</name>
+       <description>Waiting Time Overflow Interrupt Status Flag.</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>CTIS</name>
+       <description>Clock Counter Overflow Interrupt Status Flag.</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TCIS</name>
+       <description>Character Transmission Completion Interrupt Status Flag.</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXEIS</name>
+       <description>Receive FIFO Empty Interrupt Status Flag.</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXTIS</name>
+       <description>Receive FIFO Threshold Reached Interrupt Status Flag.</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>RXFIS</name>
+       <description>Receive FIFO Full Interrupt Status Flag.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXEIS</name>
+       <description>Transmit FIFO Empty Interrupt Status Flag.</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>TXTIS</name>
+       <description>Transmit FIFO Threshold Reached Interrupt Status Flag.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>TXR</name>
+     <description>Transmit Register.</description>
+     <addressOffset>0x24</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Transmit Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RXR</name>
+     <description>Receive Register.</description>
+     <addressOffset>0x28</addressOffset>
+     <fields>
+      <field>
+       <name>DATA</name>
+       <description>Receive Data.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>8</bitWidth>
+      </field>
+      <field>
+       <name>PARER</name>
+       <description>Parity Error Detect Bit.</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CCR</name>
+     <description>Clock Counter Register,</description>
+     <addressOffset>0x2C</addressOffset>
+     <fields>
+      <field>
+       <name>CCYC</name>
+       <description>Number of Clock Cycles to Count.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>24</bitWidth>
+      </field>
+      <field>
+       <name>MAN</name>
+       <description>Manual Mode.</description>
+       <bitOffset>31</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--SC0 Smart Card Interface.-->
  </peripherals>
 </device>

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Include/ptg_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Include/ptg_regs.h
@@ -5,7 +5,7 @@
  */
 
 /******************************************************************************
- * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -88,8 +88,8 @@ extern "C" {
 typedef struct {
     __IO uint32_t enable;               /**< <tt>\b 0x0000:</tt> PTG ENABLE Register */
     __IO uint32_t resync;               /**< <tt>\b 0x0004:</tt> PTG RESYNC Register */
-    __IO uint32_t intfl;                /**< <tt>\b 0x0008:</tt> PTG INTFL Register */
-    __IO uint32_t inten;                /**< <tt>\b 0x000C:</tt> PTG INTEN Register */
+    __IO uint32_t stop_intfl;           /**< <tt>\b 0x0008:</tt> PTG STOP_INTFL Register */
+    __IO uint32_t stop_inten;           /**< <tt>\b 0x000C:</tt> PTG STOP_INTEN Register */
     __O  uint32_t safe_en;              /**< <tt>\b 0x0010:</tt> PTG SAFE_EN Register */
     __O  uint32_t safe_dis;             /**< <tt>\b 0x0014:</tt> PTG SAFE_DIS Register */
     __IO uint32_t ready_intfl;          /**< <tt>\b 0x0018:</tt> PTG READY_INTFL Register */
@@ -105,8 +105,8 @@ typedef struct {
  */
 #define MXC_R_PTG_ENABLE                   ((uint32_t)0x00000000UL) /**< Offset from PTG Base Address: <tt> 0x0000</tt> */
 #define MXC_R_PTG_RESYNC                   ((uint32_t)0x00000004UL) /**< Offset from PTG Base Address: <tt> 0x0004</tt> */
-#define MXC_R_PTG_INTFL                    ((uint32_t)0x00000008UL) /**< Offset from PTG Base Address: <tt> 0x0008</tt> */
-#define MXC_R_PTG_INTEN                    ((uint32_t)0x0000000CUL) /**< Offset from PTG Base Address: <tt> 0x000C</tt> */
+#define MXC_R_PTG_STOP_INTFL               ((uint32_t)0x00000008UL) /**< Offset from PTG Base Address: <tt> 0x0008</tt> */
+#define MXC_R_PTG_STOP_INTEN               ((uint32_t)0x0000000CUL) /**< Offset from PTG Base Address: <tt> 0x000C</tt> */
 #define MXC_R_PTG_SAFE_EN                  ((uint32_t)0x00000010UL) /**< Offset from PTG Base Address: <tt> 0x0010</tt> */
 #define MXC_R_PTG_SAFE_DIS                 ((uint32_t)0x00000014UL) /**< Offset from PTG Base Address: <tt> 0x0014</tt> */
 #define MXC_R_PTG_READY_INTFL              ((uint32_t)0x00000018UL) /**< Offset from PTG Base Address: <tt> 0x0018</tt> */
@@ -179,67 +179,67 @@ typedef struct {
 
 /**
  * @ingroup  ptg_registers
- * @defgroup PTG_INTFL PTG_INTFL
- * @brief    Pulse Train Interrupt Flags
+ * @defgroup PTG_STOP_INTFL PTG_STOP_INTFL
+ * @brief    Pulse Train Stop Interrupt Flags
  * @{
  */
-#define MXC_F_PTG_INTFL_PT0_POS                        0 /**< INTFL_PT0 Position */
-#define MXC_F_PTG_INTFL_PT0                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT0_POS)) /**< INTFL_PT0 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT0_POS                   0 /**< STOP_INTFL_PT0 Position */
+#define MXC_F_PTG_STOP_INTFL_PT0                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT0_POS)) /**< STOP_INTFL_PT0 Mask */
 
-#define MXC_F_PTG_INTFL_PT1_POS                        1 /**< INTFL_PT1 Position */
-#define MXC_F_PTG_INTFL_PT1                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT1_POS)) /**< INTFL_PT1 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT1_POS                   1 /**< STOP_INTFL_PT1 Position */
+#define MXC_F_PTG_STOP_INTFL_PT1                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT1_POS)) /**< STOP_INTFL_PT1 Mask */
 
-#define MXC_F_PTG_INTFL_PT2_POS                        2 /**< INTFL_PT2 Position */
-#define MXC_F_PTG_INTFL_PT2                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT2_POS)) /**< INTFL_PT2 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT2_POS                   2 /**< STOP_INTFL_PT2 Position */
+#define MXC_F_PTG_STOP_INTFL_PT2                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT2_POS)) /**< STOP_INTFL_PT2 Mask */
 
-#define MXC_F_PTG_INTFL_PT3_POS                        3 /**< INTFL_PT3 Position */
-#define MXC_F_PTG_INTFL_PT3                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT3_POS)) /**< INTFL_PT3 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT3_POS                   3 /**< STOP_INTFL_PT3 Position */
+#define MXC_F_PTG_STOP_INTFL_PT3                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT3_POS)) /**< STOP_INTFL_PT3 Mask */
 
-#define MXC_F_PTG_INTFL_PT4_POS                        4 /**< INTFL_PT4 Position */
-#define MXC_F_PTG_INTFL_PT4                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT4_POS)) /**< INTFL_PT4 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT4_POS                   4 /**< STOP_INTFL_PT4 Position */
+#define MXC_F_PTG_STOP_INTFL_PT4                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT4_POS)) /**< STOP_INTFL_PT4 Mask */
 
-#define MXC_F_PTG_INTFL_PT5_POS                        5 /**< INTFL_PT5 Position */
-#define MXC_F_PTG_INTFL_PT5                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT5_POS)) /**< INTFL_PT5 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT5_POS                   5 /**< STOP_INTFL_PT5 Position */
+#define MXC_F_PTG_STOP_INTFL_PT5                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT5_POS)) /**< STOP_INTFL_PT5 Mask */
 
-#define MXC_F_PTG_INTFL_PT6_POS                        6 /**< INTFL_PT6 Position */
-#define MXC_F_PTG_INTFL_PT6                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT6_POS)) /**< INTFL_PT6 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT6_POS                   6 /**< STOP_INTFL_PT6 Position */
+#define MXC_F_PTG_STOP_INTFL_PT6                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT6_POS)) /**< STOP_INTFL_PT6 Mask */
 
-#define MXC_F_PTG_INTFL_PT7_POS                        7 /**< INTFL_PT7 Position */
-#define MXC_F_PTG_INTFL_PT7                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT7_POS)) /**< INTFL_PT7 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT7_POS                   7 /**< STOP_INTFL_PT7 Position */
+#define MXC_F_PTG_STOP_INTFL_PT7                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT7_POS)) /**< STOP_INTFL_PT7 Mask */
 
-/**@} end of group PTG_INTFL_Register */
+/**@} end of group PTG_STOP_INTFL_Register */
 
 /**
  * @ingroup  ptg_registers
- * @defgroup PTG_INTEN PTG_INTEN
- * @brief    Pulse Train Interrupt Enable/Disable
+ * @defgroup PTG_STOP_INTEN PTG_STOP_INTEN
+ * @brief    Pulse Train Stop Interrupt Enable/Disable
  * @{
  */
-#define MXC_F_PTG_INTEN_PT0_POS                        0 /**< INTEN_PT0 Position */
-#define MXC_F_PTG_INTEN_PT0                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT0_POS)) /**< INTEN_PT0 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT0_POS                   0 /**< STOP_INTEN_PT0 Position */
+#define MXC_F_PTG_STOP_INTEN_PT0                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT0_POS)) /**< STOP_INTEN_PT0 Mask */
 
-#define MXC_F_PTG_INTEN_PT1_POS                        1 /**< INTEN_PT1 Position */
-#define MXC_F_PTG_INTEN_PT1                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT1_POS)) /**< INTEN_PT1 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT1_POS                   1 /**< STOP_INTEN_PT1 Position */
+#define MXC_F_PTG_STOP_INTEN_PT1                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT1_POS)) /**< STOP_INTEN_PT1 Mask */
 
-#define MXC_F_PTG_INTEN_PT2_POS                        2 /**< INTEN_PT2 Position */
-#define MXC_F_PTG_INTEN_PT2                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT2_POS)) /**< INTEN_PT2 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT2_POS                   2 /**< STOP_INTEN_PT2 Position */
+#define MXC_F_PTG_STOP_INTEN_PT2                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT2_POS)) /**< STOP_INTEN_PT2 Mask */
 
-#define MXC_F_PTG_INTEN_PT3_POS                        3 /**< INTEN_PT3 Position */
-#define MXC_F_PTG_INTEN_PT3                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT3_POS)) /**< INTEN_PT3 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT3_POS                   3 /**< STOP_INTEN_PT3 Position */
+#define MXC_F_PTG_STOP_INTEN_PT3                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT3_POS)) /**< STOP_INTEN_PT3 Mask */
 
-#define MXC_F_PTG_INTEN_PT4_POS                        4 /**< INTEN_PT4 Position */
-#define MXC_F_PTG_INTEN_PT4                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT4_POS)) /**< INTEN_PT4 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT4_POS                   4 /**< STOP_INTEN_PT4 Position */
+#define MXC_F_PTG_STOP_INTEN_PT4                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT4_POS)) /**< STOP_INTEN_PT4 Mask */
 
-#define MXC_F_PTG_INTEN_PT5_POS                        5 /**< INTEN_PT5 Position */
-#define MXC_F_PTG_INTEN_PT5                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT5_POS)) /**< INTEN_PT5 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT5_POS                   5 /**< STOP_INTEN_PT5 Position */
+#define MXC_F_PTG_STOP_INTEN_PT5                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT5_POS)) /**< STOP_INTEN_PT5 Mask */
 
-#define MXC_F_PTG_INTEN_PT6_POS                        6 /**< INTEN_PT6 Position */
-#define MXC_F_PTG_INTEN_PT6                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT6_POS)) /**< INTEN_PT6 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT6_POS                   6 /**< STOP_INTEN_PT6 Position */
+#define MXC_F_PTG_STOP_INTEN_PT6                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT6_POS)) /**< STOP_INTEN_PT6 Mask */
 
-#define MXC_F_PTG_INTEN_PT7_POS                        7 /**< INTEN_PT7 Position */
-#define MXC_F_PTG_INTEN_PT7                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT7_POS)) /**< INTEN_PT7 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT7_POS                   7 /**< STOP_INTEN_PT7 Position */
+#define MXC_F_PTG_STOP_INTEN_PT7                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT7_POS)) /**< STOP_INTEN_PT7 Mask */
 
-/**@} end of group PTG_INTEN_Register */
+/**@} end of group PTG_STOP_INTEN_Register */
 
 /**
  * @ingroup  ptg_registers

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.svd
@@ -867,7 +867,7 @@
   </peripheral>
 <!--ADC Inter-Integrated Circuit.-->
   <peripheral>
-   <name>AES_KEY</name>
+   <name>AESKEYS</name>
    <description>AES Key Registers.</description>
    <baseAddress>0x40205000</baseAddress>
    <addressBlock>
@@ -877,56 +877,56 @@
    </addressBlock>
    <registers>
     <register>
-     <name>AES_KEY0</name>
+     <name>KEY0</name>
      <description>AES Key 0.</description>
      <addressOffset>0x00</addressOffset>
      <size>32</size>
     </register>
     <register>
-     <name>AES_KEY1</name>
+     <name>KEY1</name>
      <description>AES Key 1.</description>
      <addressOffset>0x04</addressOffset>
      <size>32</size>
     </register>
     <register>
-     <name>AES_KEY2</name>
+     <name>KEY2</name>
      <description>AES Key 2.</description>
      <addressOffset>0x08</addressOffset>
      <size>32</size>
     </register>
     <register>
-     <name>AES_KEY3</name>
+     <name>KEY3</name>
      <description>AES Key 3.</description>
      <addressOffset>0x0C</addressOffset>
      <size>32</size>
     </register>
     <register>
-     <name>AES_KEY4</name>
+     <name>KEY4</name>
      <description>AES Key 4.</description>
      <addressOffset>0x10</addressOffset>
      <size>32</size>
     </register>
     <register>
-     <name>AES_KEY5</name>
+     <name>KEY5</name>
      <description>AES Key 5.</description>
      <addressOffset>0x14</addressOffset>
      <size>32</size>
     </register>
     <register>
-     <name>AES_KEY6</name>
+     <name>KEY6</name>
      <description>AES Key 6.</description>
      <addressOffset>0x18</addressOffset>
      <size>32</size>
     </register>
     <register>
-     <name>AES_KEY7</name>
+     <name>KEY7</name>
      <description>AES Key 7.</description>
      <addressOffset>0x1C</addressOffset>
      <size>32</size>
     </register>
    </registers>
   </peripheral>
-<!--AES_KEY AES Key Registers.-->
+<!--AESKEYS AES Key Registers.-->
   <peripheral>
    <name>AES</name>
    <description>AES Keys.</description>
@@ -8117,19 +8117,19 @@ control comes from GPIO control module</description>
   <peripheral derivedFrom="PT">
    <name>PT1</name>
    <description>Pulse Train 1</description>
-   <baseAddress>0x4003C040</baseAddress>
+   <baseAddress>0x4003C030</baseAddress>
   </peripheral>
 <!--PT1 Pulse Train 1-->
   <peripheral derivedFrom="PT">
    <name>PT2</name>
    <description>Pulse Train 2</description>
-   <baseAddress>0x4003C060</baseAddress>
+   <baseAddress>0x4003C040</baseAddress>
   </peripheral>
 <!--PT2 Pulse Train 2-->
   <peripheral derivedFrom="PT">
    <name>PT3</name>
    <description>Pulse Train 3</description>
-   <baseAddress>0x4003C080</baseAddress>
+   <baseAddress>0x4003C050</baseAddress>
   </peripheral>
 <!--PT3 Pulse Train 3-->
   <peripheral>
@@ -8223,8 +8223,8 @@ control comes from GPIO control module</description>
      </fields>
     </register>
     <register>
-     <name>INTFL</name>
-     <description>Pulse Train Interrupt Flags</description>
+     <name>STOP_INTFL</name>
+     <description>Pulse Train Stop Interrupt Flags</description>
      <addressOffset>0x0008</addressOffset>
      <access>read-write</access>
      <fields>
@@ -8259,8 +8259,8 @@ control comes from GPIO control module</description>
      </fields>
     </register>
     <register>
-     <name>INTEN</name>
-     <description>Pulse Train Interrupt Enable/Disable</description>
+     <name>STOP_INTEN</name>
+     <description>Pulse Train Stop Interrupt Enable/Disable</description>
      <addressOffset>0x000C</addressOffset>
      <access>read-write</access>
      <fields>
@@ -8355,6 +8355,78 @@ control comes from GPIO control module</description>
        <bitOffset>3</bitOffset>
        <bitWidth>1</bitWidth>
        <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTFL</name>
+     <description>Pulse Train Ready Interrupt Flags</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTEN</name>
+     <description>Pulse Train Ready Interrupt Enable/Disable</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
       </field>
      </fields>
     </register>

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/pt_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/pt_regs.h
@@ -5,7 +5,7 @@
  */
 
 /******************************************************************************
- * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/ptg_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/ptg_regs.h
@@ -5,7 +5,7 @@
  */
 
 /******************************************************************************
- * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -88,10 +88,12 @@ extern "C" {
 typedef struct {
     __IO uint32_t enable;               /**< <tt>\b 0x0000:</tt> PTG ENABLE Register */
     __IO uint32_t resync;               /**< <tt>\b 0x0004:</tt> PTG RESYNC Register */
-    __IO uint32_t intfl;                /**< <tt>\b 0x0008:</tt> PTG INTFL Register */
-    __IO uint32_t inten;                /**< <tt>\b 0x000C:</tt> PTG INTEN Register */
+    __IO uint32_t stop_intfl;           /**< <tt>\b 0x0008:</tt> PTG STOP_INTFL Register */
+    __IO uint32_t stop_inten;           /**< <tt>\b 0x000C:</tt> PTG STOP_INTEN Register */
     __O  uint32_t safe_en;              /**< <tt>\b 0x0010:</tt> PTG SAFE_EN Register */
     __O  uint32_t safe_dis;             /**< <tt>\b 0x0014:</tt> PTG SAFE_DIS Register */
+    __IO uint32_t ready_intfl;          /**< <tt>\b 0x0018:</tt> PTG READY_INTFL Register */
+    __IO uint32_t ready_inten;          /**< <tt>\b 0x001C:</tt> PTG READY_INTEN Register */
 } mxc_ptg_regs_t;
 
 /* Register offsets for module PTG */
@@ -103,10 +105,12 @@ typedef struct {
  */
 #define MXC_R_PTG_ENABLE                   ((uint32_t)0x00000000UL) /**< Offset from PTG Base Address: <tt> 0x0000</tt> */
 #define MXC_R_PTG_RESYNC                   ((uint32_t)0x00000004UL) /**< Offset from PTG Base Address: <tt> 0x0004</tt> */
-#define MXC_R_PTG_INTFL                    ((uint32_t)0x00000008UL) /**< Offset from PTG Base Address: <tt> 0x0008</tt> */
-#define MXC_R_PTG_INTEN                    ((uint32_t)0x0000000CUL) /**< Offset from PTG Base Address: <tt> 0x000C</tt> */
+#define MXC_R_PTG_STOP_INTFL               ((uint32_t)0x00000008UL) /**< Offset from PTG Base Address: <tt> 0x0008</tt> */
+#define MXC_R_PTG_STOP_INTEN               ((uint32_t)0x0000000CUL) /**< Offset from PTG Base Address: <tt> 0x000C</tt> */
 #define MXC_R_PTG_SAFE_EN                  ((uint32_t)0x00000010UL) /**< Offset from PTG Base Address: <tt> 0x0010</tt> */
 #define MXC_R_PTG_SAFE_DIS                 ((uint32_t)0x00000014UL) /**< Offset from PTG Base Address: <tt> 0x0014</tt> */
+#define MXC_R_PTG_READY_INTFL              ((uint32_t)0x00000018UL) /**< Offset from PTG Base Address: <tt> 0x0018</tt> */
+#define MXC_R_PTG_READY_INTEN              ((uint32_t)0x0000001CUL) /**< Offset from PTG Base Address: <tt> 0x001C</tt> */
 /**@} end of group ptg_registers */
 
 /**
@@ -151,43 +155,43 @@ typedef struct {
 
 /**
  * @ingroup  ptg_registers
- * @defgroup PTG_INTFL PTG_INTFL
- * @brief    Pulse Train Interrupt Flags
+ * @defgroup PTG_STOP_INTFL PTG_STOP_INTFL
+ * @brief    Pulse Train Stop Interrupt Flags
  * @{
  */
-#define MXC_F_PTG_INTFL_PT0_POS                        0 /**< INTFL_PT0 Position */
-#define MXC_F_PTG_INTFL_PT0                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT0_POS)) /**< INTFL_PT0 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT0_POS                   0 /**< STOP_INTFL_PT0 Position */
+#define MXC_F_PTG_STOP_INTFL_PT0                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT0_POS)) /**< STOP_INTFL_PT0 Mask */
 
-#define MXC_F_PTG_INTFL_PT1_POS                        1 /**< INTFL_PT1 Position */
-#define MXC_F_PTG_INTFL_PT1                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT1_POS)) /**< INTFL_PT1 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT1_POS                   1 /**< STOP_INTFL_PT1 Position */
+#define MXC_F_PTG_STOP_INTFL_PT1                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT1_POS)) /**< STOP_INTFL_PT1 Mask */
 
-#define MXC_F_PTG_INTFL_PT2_POS                        2 /**< INTFL_PT2 Position */
-#define MXC_F_PTG_INTFL_PT2                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT2_POS)) /**< INTFL_PT2 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT2_POS                   2 /**< STOP_INTFL_PT2 Position */
+#define MXC_F_PTG_STOP_INTFL_PT2                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT2_POS)) /**< STOP_INTFL_PT2 Mask */
 
-#define MXC_F_PTG_INTFL_PT3_POS                        3 /**< INTFL_PT3 Position */
-#define MXC_F_PTG_INTFL_PT3                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT3_POS)) /**< INTFL_PT3 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT3_POS                   3 /**< STOP_INTFL_PT3 Position */
+#define MXC_F_PTG_STOP_INTFL_PT3                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT3_POS)) /**< STOP_INTFL_PT3 Mask */
 
-/**@} end of group PTG_INTFL_Register */
+/**@} end of group PTG_STOP_INTFL_Register */
 
 /**
  * @ingroup  ptg_registers
- * @defgroup PTG_INTEN PTG_INTEN
- * @brief    Pulse Train Interrupt Enable/Disable
+ * @defgroup PTG_STOP_INTEN PTG_STOP_INTEN
+ * @brief    Pulse Train Stop Interrupt Enable/Disable
  * @{
  */
-#define MXC_F_PTG_INTEN_PT0_POS                        0 /**< INTEN_PT0 Position */
-#define MXC_F_PTG_INTEN_PT0                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT0_POS)) /**< INTEN_PT0 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT0_POS                   0 /**< STOP_INTEN_PT0 Position */
+#define MXC_F_PTG_STOP_INTEN_PT0                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT0_POS)) /**< STOP_INTEN_PT0 Mask */
 
-#define MXC_F_PTG_INTEN_PT1_POS                        1 /**< INTEN_PT1 Position */
-#define MXC_F_PTG_INTEN_PT1                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT1_POS)) /**< INTEN_PT1 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT1_POS                   1 /**< STOP_INTEN_PT1 Position */
+#define MXC_F_PTG_STOP_INTEN_PT1                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT1_POS)) /**< STOP_INTEN_PT1 Mask */
 
-#define MXC_F_PTG_INTEN_PT2_POS                        2 /**< INTEN_PT2 Position */
-#define MXC_F_PTG_INTEN_PT2                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT2_POS)) /**< INTEN_PT2 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT2_POS                   2 /**< STOP_INTEN_PT2 Position */
+#define MXC_F_PTG_STOP_INTEN_PT2                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT2_POS)) /**< STOP_INTEN_PT2 Mask */
 
-#define MXC_F_PTG_INTEN_PT3_POS                        3 /**< INTEN_PT3 Position */
-#define MXC_F_PTG_INTEN_PT3                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT3_POS)) /**< INTEN_PT3 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT3_POS                   3 /**< STOP_INTEN_PT3 Position */
+#define MXC_F_PTG_STOP_INTEN_PT3                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT3_POS)) /**< STOP_INTEN_PT3 Mask */
 
-/**@} end of group PTG_INTEN_Register */
+/**@} end of group PTG_STOP_INTEN_Register */
 
 /**
  * @ingroup  ptg_registers
@@ -228,6 +232,46 @@ typedef struct {
 #define MXC_F_PTG_SAFE_DIS_PT3                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT3_POS)) /**< SAFE_DIS_PT3 Mask */
 
 /**@} end of group PTG_SAFE_DIS_Register */
+
+/**
+ * @ingroup  ptg_registers
+ * @defgroup PTG_READY_INTFL PTG_READY_INTFL
+ * @brief    Pulse Train Ready Interrupt Flags
+ * @{
+ */
+#define MXC_F_PTG_READY_INTFL_PT0_POS                  0 /**< READY_INTFL_PT0 Position */
+#define MXC_F_PTG_READY_INTFL_PT0                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT0_POS)) /**< READY_INTFL_PT0 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT1_POS                  1 /**< READY_INTFL_PT1 Position */
+#define MXC_F_PTG_READY_INTFL_PT1                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT1_POS)) /**< READY_INTFL_PT1 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT2_POS                  2 /**< READY_INTFL_PT2 Position */
+#define MXC_F_PTG_READY_INTFL_PT2                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT2_POS)) /**< READY_INTFL_PT2 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT3_POS                  3 /**< READY_INTFL_PT3 Position */
+#define MXC_F_PTG_READY_INTFL_PT3                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT3_POS)) /**< READY_INTFL_PT3 Mask */
+
+/**@} end of group PTG_READY_INTFL_Register */
+
+/**
+ * @ingroup  ptg_registers
+ * @defgroup PTG_READY_INTEN PTG_READY_INTEN
+ * @brief    Pulse Train Ready Interrupt Enable/Disable
+ * @{
+ */
+#define MXC_F_PTG_READY_INTEN_PT0_POS                  0 /**< READY_INTEN_PT0 Position */
+#define MXC_F_PTG_READY_INTEN_PT0                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT0_POS)) /**< READY_INTEN_PT0 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT1_POS                  1 /**< READY_INTEN_PT1 Position */
+#define MXC_F_PTG_READY_INTEN_PT1                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT1_POS)) /**< READY_INTEN_PT1 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT2_POS                  2 /**< READY_INTEN_PT2 Position */
+#define MXC_F_PTG_READY_INTEN_PT2                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT2_POS)) /**< READY_INTEN_PT2 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT3_POS                  3 /**< READY_INTEN_PT3 Position */
+#define MXC_F_PTG_READY_INTEN_PT3                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT3_POS)) /**< READY_INTEN_PT3 Mask */
+
+/**@} end of group PTG_READY_INTEN_Register */
 
 #ifdef __cplusplus
 }

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
@@ -867,7 +867,7 @@
   </peripheral>
 <!--ADC Inter-Integrated Circuit.-->
   <peripheral>
-   <name>AES_KEY</name>
+   <name>AESKEYS</name>
    <description>AES Key Registers.</description>
    <baseAddress>0x40005000</baseAddress>
    <addressBlock>
@@ -877,56 +877,32 @@
    </addressBlock>
    <registers>
     <register>
-     <name>AES_KEY0</name>
+     <name>KEY0</name>
      <description>AES Key 0.</description>
-     <addressOffset>0x00</addressOffset>
-     <size>32</size>
+     <addressOffset>0x000</addressOffset>
+     <size>128</size>
     </register>
     <register>
-     <name>AES_KEY1</name>
+     <name>KEY1</name>
      <description>AES Key 1.</description>
-     <addressOffset>0x04</addressOffset>
-     <size>32</size>
+     <addressOffset>0x010</addressOffset>
+     <size>128</size>
     </register>
     <register>
-     <name>AES_KEY2</name>
-     <description>AES Key 2.</description>
-     <addressOffset>0x08</addressOffset>
-     <size>32</size>
+     <name>PUF_KEY1</name>
+     <description>PUF Key 1.</description>
+     <addressOffset>0x020</addressOffset>
+     <size>256</size>
     </register>
     <register>
-     <name>AES_KEY3</name>
-     <description>AES Key 3.</description>
-     <addressOffset>0x0C</addressOffset>
-     <size>32</size>
-    </register>
-    <register>
-     <name>AES_KEY4</name>
-     <description>AES Key 4.</description>
-     <addressOffset>0x10</addressOffset>
-     <size>32</size>
-    </register>
-    <register>
-     <name>AES_KEY5</name>
-     <description>AES Key 5.</description>
-     <addressOffset>0x14</addressOffset>
-     <size>32</size>
-    </register>
-    <register>
-     <name>AES_KEY6</name>
-     <description>AES Key 6.</description>
-     <addressOffset>0x18</addressOffset>
-     <size>32</size>
-    </register>
-    <register>
-     <name>AES_KEY7</name>
-     <description>AES Key 7.</description>
-     <addressOffset>0x1C</addressOffset>
-     <size>32</size>
+     <name>PUF_KEY2</name>
+     <description>PUF Key 2.</description>
+     <addressOffset>0x040</addressOffset>
+     <size>256</size>
     </register>
    </registers>
   </peripheral>
-<!--AES_KEY AES Key Registers.-->
+<!--AESKEYS AES Key Registers.-->
   <peripheral>
    <name>CAN0</name>
    <description>Controller Area Network Registers</description>
@@ -10064,6 +10040,181 @@ memory.
   </peripheral>
 <!--I2S Inter-IC Sound Interface.-->
   <peripheral>
+   <name>ICC0</name>
+   <description>Instruction Cache Controller Registers</description>
+   <baseAddress>0x4002A000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x800</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <registers>
+    <register>
+     <name>INFO</name>
+     <description>Cache ID Register.</description>
+     <addressOffset>0x0000</addressOffset>
+     <access>read-only</access>
+     <fields>
+      <field>
+       <name>RELNUM</name>
+       <description>Release Number. Identifies the RTL release version.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+      <field>
+       <name>PARTNUM</name>
+       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>4</bitWidth>
+      </field>
+      <field>
+       <name>ID</name>
+       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>6</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SZ</name>
+     <description>Memory Configuration Register.</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-only</access>
+     <resetValue>0x00080008</resetValue>
+     <fields>
+      <field>
+       <name>CCH</name>
+       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+      <field>
+       <name>MEM</name>
+       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>16</bitWidth>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>CTRL</name>
+     <description>Cache Control and Status Register.</description>
+     <addressOffset>0x0100</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>dis</name>
+         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>en</name>
+         <description>Cache Enabled.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+      <field>
+       <name>RDY</name>
+       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
+       <bitOffset>16</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-only</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>notReady</name>
+         <description>Not Ready.</description>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>ready</name>
+         <description>Ready.</description>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>INVALIDATE</name>
+     <description>Invalidate All Registers.</description>
+     <addressOffset>0x0700</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>INVALID</name>
+       <description>Invalidate.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--ICC0 Instruction Cache Controller Registers-->
+  <peripheral>
+   <name>LPCMP</name>
+   <description>Low Power Comparator</description>
+   <baseAddress>0x40088000</baseAddress>
+   <addressBlock>
+    <offset>0x00</offset>
+    <size>0x400</size>
+    <usage>registers</usage>
+   </addressBlock>
+   <interrupt>
+    <name>LPCMP</name>
+    <description>Low Power Comparato</description>
+    <value>103</value>
+   </interrupt>
+   <registers>
+    <register>
+     <dim>3</dim>
+     <dimIncrement>4</dimIncrement>
+     <name>CTRL[%s]</name>
+     <description>Comparator Control Register.</description>
+     <addressOffset>0x00</addressOffset>
+     <fields>
+      <field>
+       <name>EN</name>
+       <description>Comparator Enable.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>POL</name>
+       <description>Polarity Select</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_EN</name>
+       <description>IRQ Enable.</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>OUT</name>
+       <description>Raw Compartor Input.</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+      <field>
+       <name>INT_FL</name>
+       <description>IRQ Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+      </field>
+     </fields>
+    </register>
+   </registers>
+  </peripheral>
+<!--LPCMP Low Power Comparator-->
+  <peripheral>
    <name>LPGCR</name>
    <description>Low Power Global Control.</description>
    <baseAddress>0x40080000</baseAddress>
@@ -10933,372 +11084,6 @@ memory.
   </peripheral>
 <!--OWM 1-Wire Master Interface.-->
   <peripheral>
-   <name>PUF</name>
-   <description>PUF Registers</description>
-   <baseAddress>0x40007000</baseAddress>
-   <addressBlock>
-    <offset>0x00</offset>
-    <size>0x400</size>
-    <usage>registers</usage>
-   </addressBlock>
-   <registers>
-    <register>
-     <name>CTRL</name>
-     <description>PUF Control Register.</description>
-     <addressOffset>0x0000</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>PUF_EN</name>
-       <description>PUF Controller Enable.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY_CLR_EN</name>
-       <description>Key Clear Enable or PUFSEC Disable</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY0_GEN_EN</name>
-       <description>PUF Key0 Generation Enable.</description>
-       <bitOffset>8</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY1_GEN_EN</name>
-       <description>PUF Key1 Generation Enable.</description>
-       <bitOffset>9</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEYGEN_ERR_IE</name>
-       <description>Key Generation Error Interrupt Enable.</description>
-       <bitOffset>16</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY0_DN_IE</name>
-       <description>Key0 Done Interrupt Enable.</description>
-       <bitOffset>24</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY1_DN_IE</name>
-       <description>Key1 Done Interrupt Enable </description>
-       <bitOffset>25</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>STAT</name>
-     <description>PUF Status Register.</description>
-     <addressOffset>0x0004</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>BUSY</name>
-       <description>PUF Controller Busy.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>MAGIC_ERR</name>
-       <description>PUF Magic Word Error.</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEYGEN_EN_ERR</name>
-       <description>PUF Magic Word Error.</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEYGEN_ERR</name>
-       <description>PUF Magic Word Error.</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>ADC_FREQ_FL</name>
-       <description>ADC Frequency Flag</description>
-       <bitOffset>7</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY0_INIT_ERR</name>
-       <description>PUF Key0 Initialization Error.</description>
-       <bitOffset>8</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY0_CNST_ERR</name>
-       <description> PUF Key0 Constant Key Mismatch Error</description>
-       <bitOffset>9</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY1_INIT_ERR</name>
-       <description>PUF Key1 Initialization Error.</description>
-       <bitOffset>16</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY1_CNST_ERR</name>
-       <description> PUF Key1 Constant Key Mismatch Error</description>
-       <bitOffset>17</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY0_DN</name>
-       <description>Key0 Done.</description>
-       <bitOffset>24</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>KEY1_DN</name>
-       <description>Key1 Done.</description>
-       <bitOffset>25</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-     </fields>
-    </register>
-   </registers>
-  </peripheral>
-<!--PUF PUF Registers-->
-  <peripheral>
-   <name>PTG</name>
-   <description>Pulse Train Generation</description>
-   <groupName>Pulse_Train</groupName>
-   <baseAddress>0x4003C000</baseAddress>
-   <size>32</size>
-   <access>read-write</access>
-   <addressBlock>
-    <offset>0</offset>
-    <size>0x0018</size>
-    <usage>registers</usage>
-   </addressBlock>
-   <interrupt>
-    <name>PT</name>
-    <description>Pulse Train IRQ</description>
-    <value>59</value>
-   </interrupt>
-   <registers>
-    <register>
-     <name>ENABLE</name>
-     <description>Global Enable/Disable Controls for All Pulse Trains</description>
-     <addressOffset>0x0000</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Enable/Disable control for PT0</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Enable/Disable control for PT1</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Enable/Disable control for PT2</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Enable/Disable control for PT3</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>RESYNC</name>
-     <description>Global Resync (All Pulse Trains) Control</description>
-     <addressOffset>0x0004</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Resync control for PT0</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Resync control for PT1</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Resync control for PT2</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Resync control for PT3</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>INTFL</name>
-     <description>Pulse Train Interrupt Flags</description>
-     <addressOffset>0x0008</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Pulse Train 0 Stopped Interrupt Flag</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Pulse Train 1 Stopped Interrupt Flag</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Pulse Train 2 Stopped Interrupt Flag</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Pulse Train 3 Stopped Interrupt Flag</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>INTEN</name>
-     <description>Pulse Train Interrupt Enable/Disable</description>
-     <addressOffset>0x000C</addressOffset>
-     <access>read-write</access>
-     <fields>
-      <field>
-       <name>pt0</name>
-       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt1</name>
-       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt2</name>
-       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-      <field>
-       <name>pt3</name>
-       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-write</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>SAFE_EN</name>
-     <description>Pulse Train Global Safe Enable.</description>
-     <addressOffset>0x0010</addressOffset>
-     <access>write-only</access>
-     <fields>
-      <field>
-       <name>PT0</name>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT1</name>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT2</name>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT3</name>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>SAFE_DIS</name>
-     <description>Pulse Train Global Safe Disable.</description>
-     <addressOffset>0x0014</addressOffset>
-     <access>write-only</access>
-     <fields>
-      <field>
-       <name>PT0</name>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT1</name>
-       <bitOffset>1</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT2</name>
-       <bitOffset>2</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-      <field>
-       <name>PT3</name>
-       <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>write-only</access>
-      </field>
-     </fields>
-    </register>
-   </registers>
-  </peripheral>
-<!--PTG Pulse Train Generation-->
-  <peripheral>
    <name>PT</name>
    <description>Pulse Train</description>
    <groupName>Pulse_Train</groupName>
@@ -11565,139 +11350,1042 @@ memory.
   <peripheral derivedFrom="PT">
    <name>PT1</name>
    <description>Pulse Train 1</description>
-   <baseAddress>0x4003C040</baseAddress>
+   <baseAddress>0x4003C030</baseAddress>
   </peripheral>
 <!--PT1 Pulse Train 1-->
   <peripheral derivedFrom="PT">
    <name>PT2</name>
    <description>Pulse Train 2</description>
-   <baseAddress>0x4003C060</baseAddress>
+   <baseAddress>0x4003C040</baseAddress>
   </peripheral>
 <!--PT2 Pulse Train 2-->
   <peripheral derivedFrom="PT">
    <name>PT3</name>
    <description>Pulse Train 3</description>
-   <baseAddress>0x4003C080</baseAddress>
+   <baseAddress>0x4003C050</baseAddress>
   </peripheral>
 <!--PT3 Pulse Train 3-->
+  <peripheral derivedFrom="PT">
+   <name>PT4</name>
+   <description>Pulse Train 4</description>
+   <baseAddress>0x4003C060</baseAddress>
+  </peripheral>
+<!--PT4 Pulse Train 4-->
+  <peripheral derivedFrom="PT">
+   <name>PT5</name>
+   <description>Pulse Train 5</description>
+   <baseAddress>0x4003C070</baseAddress>
+  </peripheral>
+<!--PT5 Pulse Train 5-->
+  <peripheral derivedFrom="PT">
+   <name>PT6</name>
+   <description>Pulse Train 6</description>
+   <baseAddress>0x4003C080</baseAddress>
+  </peripheral>
+<!--PT6 Pulse Train 6-->
+  <peripheral derivedFrom="PT">
+   <name>PT7</name>
+   <description>Pulse Train 7</description>
+   <baseAddress>0x4003C090</baseAddress>
+  </peripheral>
+<!--PT7 Pulse Train 7-->
+  <peripheral derivedFrom="PT">
+   <name>PT8</name>
+   <description>Pulse Train 8</description>
+   <baseAddress>0x4003C0A0</baseAddress>
+  </peripheral>
+<!--PT8 Pulse Train 8-->
+  <peripheral derivedFrom="PT">
+   <name>PT9</name>
+   <description>Pulse Train 9</description>
+   <baseAddress>0x4003C0B0</baseAddress>
+  </peripheral>
+<!--PT9 Pulse Train 9-->
+  <peripheral derivedFrom="PT">
+   <name>PT10</name>
+   <description>Pulse Train 10</description>
+   <baseAddress>0x4003C0C0</baseAddress>
+  </peripheral>
+<!--PT10 Pulse Train 10-->
+  <peripheral derivedFrom="PT">
+   <name>PT11</name>
+   <description>Pulse Train 11</description>
+   <baseAddress>0x4003C0D0</baseAddress>
+  </peripheral>
+<!--PT11 Pulse Train 11-->
+  <peripheral derivedFrom="PT">
+   <name>PT12</name>
+   <description>Pulse Train 12</description>
+   <baseAddress>0x4003C0E0</baseAddress>
+  </peripheral>
+<!--PT12 Pulse Train 12-->
+  <peripheral derivedFrom="PT">
+   <name>PT13</name>
+   <description>Pulse Train 13</description>
+   <baseAddress>0x4003C0F0</baseAddress>
+  </peripheral>
+<!--PT13 Pulse Train 13-->
+  <peripheral derivedFrom="PT">
+   <name>PT14</name>
+   <description>Pulse Train 14</description>
+   <baseAddress>0x4003C100</baseAddress>
+  </peripheral>
+<!--PT14 Pulse Train 14-->
+  <peripheral derivedFrom="PT">
+   <name>PT15</name>
+   <description>Pulse Train 15</description>
+   <baseAddress>0x4003C110</baseAddress>
+  </peripheral>
+<!--PT15 Pulse Train 15-->
   <peripheral>
-   <name>ICC0</name>
-   <description>Instruction Cache Controller Registers</description>
-   <baseAddress>0x4002A000</baseAddress>
+   <name>PTG</name>
+   <description>Pulse Train Generation</description>
+   <groupName>Pulse_Train</groupName>
+   <baseAddress>0x4003C000</baseAddress>
+   <size>32</size>
+   <access>read-write</access>
    <addressBlock>
-    <offset>0x00</offset>
-    <size>0x800</size>
+    <offset>0</offset>
+    <size>0x0020</size>
     <usage>registers</usage>
    </addressBlock>
+   <interrupt>
+    <name>PT</name>
+    <description>Pulse Train IRQ</description>
+    <value>59</value>
+   </interrupt>
    <registers>
     <register>
-     <name>INFO</name>
-     <description>Cache ID Register.</description>
+     <name>ENABLE</name>
+     <description>Global Enable/Disable Controls for All Pulse Trains</description>
      <addressOffset>0x0000</addressOffset>
-     <access>read-only</access>
-     <fields>
-      <field>
-       <name>RELNUM</name>
-       <description>Release Number. Identifies the RTL release version.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>6</bitWidth>
-      </field>
-      <field>
-       <name>PARTNUM</name>
-       <description>Part Number. This field reflects the value of C_ID_PART_NUMBER configuration parameter.</description>
-       <bitOffset>6</bitOffset>
-       <bitWidth>4</bitWidth>
-      </field>
-      <field>
-       <name>ID</name>
-       <description>Cache ID. This field reflects the value of the C_ID_CACHEID configuration parameter.</description>
-       <bitOffset>10</bitOffset>
-       <bitWidth>6</bitWidth>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>SZ</name>
-     <description>Memory Configuration Register.</description>
-     <addressOffset>0x0004</addressOffset>
-     <access>read-only</access>
-     <resetValue>0x00080008</resetValue>
-     <fields>
-      <field>
-       <name>CCH</name>
-       <description>Cache Size. Indicates total size in Kbytes of cache.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>16</bitWidth>
-      </field>
-      <field>
-       <name>MEM</name>
-       <description>Main Memory Size. Indicates the total size, in units of 128 Kbytes, of code memory accessible to the cache controller.</description>
-       <bitOffset>16</bitOffset>
-       <bitWidth>16</bitWidth>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>CTRL</name>
-     <description>Cache Control and Status Register.</description>
-     <addressOffset>0x0100</addressOffset>
-     <fields>
-      <field>
-       <name>EN</name>
-       <description>Cache Enable. Controls whether the cache is bypassed or is in use. Changing the state of this bit will cause the instruction cache to be flushed and its contents invalidated.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-       <enumeratedValues>
-        <enumeratedValue>
-         <name>dis</name>
-         <description>Cache Bypassed. Instruction data is stored in the line fill buffer but is not written to main cache memory array.</description>
-         <value>0</value>
-        </enumeratedValue>
-        <enumeratedValue>
-         <name>en</name>
-         <description>Cache Enabled.</description>
-         <value>1</value>
-        </enumeratedValue>
-       </enumeratedValues>
-      </field>
-      <field>
-       <name>RDY</name>
-       <description>Cache Ready flag. Cleared by hardware when at any time the cache as a whole is invalidated (including a system reset). When this bit is 0, the cache is effectively in bypass mode (instruction fetches will come from main memory or from the line fill buffer). Set by hardware when the invalidate operation is complete and the cache is ready.</description>
-       <bitOffset>16</bitOffset>
-       <bitWidth>1</bitWidth>
-       <access>read-only</access>
-       <enumeratedValues>
-        <enumeratedValue>
-         <name>notReady</name>
-         <description>Not Ready.</description>
-         <value>0</value>
-        </enumeratedValue>
-        <enumeratedValue>
-         <name>ready</name>
-         <description>Ready.</description>
-         <value>1</value>
-        </enumeratedValue>
-       </enumeratedValues>
-      </field>
-     </fields>
-    </register>
-    <register>
-     <name>INVALIDATE</name>
-     <description>Invalidate All Registers.</description>
-     <addressOffset>0x0700</addressOffset>
      <access>read-write</access>
      <fields>
       <field>
-       <name>INVALID</name>
-       <description>Invalidate.</description>
+       <name>pt0</name>
+       <description>Enable/Disable control for PT0</description>
        <bitOffset>0</bitOffset>
-       <bitWidth>32</bitWidth>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Enable/Disable control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Enable/Disable control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Enable/Disable control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Enable/Disable control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Enable/Disable control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Enable/Disable control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Enable/Disable control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Enable/Disable control for PT8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Enable/Disable control for PT9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Enable/Disable control for PT10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Enable/Disable control for PT11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Enable/Disable control for PT12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Enable/Disable control for PT13</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Enable/Disable control for PT14</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Enable/Disable control for PT15</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>RESYNC</name>
+     <description>Global Resync (All Pulse Trains) Control</description>
+     <addressOffset>0x0004</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Resync control for PT0</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Resync control for PT1</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Resync control for PT2</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Resync control for PT3</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Resync control for PT4</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Resync control for PT5</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Resync control for PT6</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Resync control for PT7</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Resync control for PT8</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Resync control for PT9</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Resync control for PT10</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Resync control for PT11</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Resync control for PT12</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Resync control for PT13</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Resync control for PT14</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Resync control for PT15</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTFL</name>
+     <description>Pulse Train Interrupt Flags</description>
+     <addressOffset>0x0008</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Stopped Interrupt Flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Stopped Interrupt Flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Stopped Interrupt Flag</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Stopped Interrupt Flag</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Stopped Interrupt Flag</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Stopped Interrupt Flag</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Stopped Interrupt Flag</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Stopped Interrupt Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>STOP_INTEN</name>
+     <description>Pulse Train Interrupt Enable/Disable</description>
+     <addressOffset>0x000C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Stopped Interrupt Enable/Disable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_EN</name>
+     <description>Pulse Train Global Safe Enable.</description>
+     <addressOffset>0x0010</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>SAFE_DIS</name>
+     <description>Pulse Train Global Safe Disable.</description>
+     <addressOffset>0x0014</addressOffset>
+     <access>write-only</access>
+     <fields>
+      <field>
+       <name>PT0</name>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT1</name>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT2</name>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT3</name>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT4</name>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT5</name>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT6</name>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT7</name>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT8</name>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT9</name>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT10</name>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT11</name>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT12</name>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT13</name>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT14</name>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+      <field>
+       <name>PT15</name>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>write-only</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTFL</name>
+     <description>Pulse Train Ready Interrupt Flags</description>
+     <addressOffset>0x0018</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Flag</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Flag</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Flag</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Flag</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Ready Interrupt Flag</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Ready Interrupt Flag</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Ready Interrupt Flag</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Ready Interrupt Flag</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Ready Interrupt Flag</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Ready Interrupt Flag</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Ready Interrupt Flag</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Ready Interrupt Flag</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Ready Interrupt Flag</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Ready Interrupt Flag</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Ready Interrupt Flag</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Ready Interrupt Flag</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+     </fields>
+    </register>
+    <register>
+     <name>READY_INTEN</name>
+     <description>Pulse Train Ready Interrupt Enable/Disable</description>
+     <addressOffset>0x001C</addressOffset>
+     <access>read-write</access>
+     <fields>
+      <field>
+       <name>pt0</name>
+       <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt1</name>
+       <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+       <bitOffset>1</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt2</name>
+       <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+       <bitOffset>2</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt3</name>
+       <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+       <bitOffset>3</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt4</name>
+       <description>Pulse Train 4 Ready Interrupt Enable/Disable</description>
+       <bitOffset>4</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt5</name>
+       <description>Pulse Train 5 Ready Interrupt Enable/Disable</description>
+       <bitOffset>5</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt6</name>
+       <description>Pulse Train 6 Ready Interrupt Enable/Disable</description>
+       <bitOffset>6</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt7</name>
+       <description>Pulse Train 7 Ready Interrupt Enable/Disable</description>
+       <bitOffset>7</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt8</name>
+       <description>Pulse Train 8 Ready Interrupt Enable/Disable</description>
+       <bitOffset>8</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt9</name>
+       <description>Pulse Train 9 Ready Interrupt Enable/Disable</description>
+       <bitOffset>9</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt10</name>
+       <description>Pulse Train 10 Ready Interrupt Enable/Disable</description>
+       <bitOffset>10</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt11</name>
+       <description>Pulse Train 11 Ready Interrupt Enable/Disable</description>
+       <bitOffset>11</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt12</name>
+       <description>Pulse Train 12 Ready Interrupt Enable/Disable</description>
+       <bitOffset>12</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt13</name>
+       <description>Pulse Train 13 Ready Interrupt Enable/Disable</description>
+       <bitOffset>13</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt14</name>
+       <description>Pulse Train 14 Ready Interrupt Enable/Disable</description>
+       <bitOffset>14</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
+      </field>
+      <field>
+       <name>pt15</name>
+       <description>Pulse Train 15 Ready Interrupt Enable/Disable</description>
+       <bitOffset>15</bitOffset>
+       <bitWidth>1</bitWidth>
+       <access>read-write</access>
       </field>
      </fields>
     </register>
    </registers>
   </peripheral>
-<!--ICC0 Instruction Cache Controller Registers-->
+<!--PTG Pulse Train Generation-->
   <peripheral>
    <name>PWRSEQ</name>
    <description>Power Sequencer / Low Power Control Register.</description>
@@ -12233,63 +12921,6 @@ signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is se
    </registers>
   </peripheral>
 <!--PWRSEQ Power Sequencer / Low Power Control Register.-->
-  <peripheral>
-   <name>LPCMP</name>
-   <description>Low Power Comparator</description>
-   <baseAddress>0x40088000</baseAddress>
-   <addressBlock>
-    <offset>0x00</offset>
-    <size>0x400</size>
-    <usage>registers</usage>
-   </addressBlock>
-   <interrupt>
-    <name>LPCMP</name>
-    <description>Low Power Comparato</description>
-    <value>103</value>
-   </interrupt>
-   <registers>
-    <register>
-     <dim>3</dim>
-     <dimIncrement>4</dimIncrement>
-     <name>CTRL[%s]</name>
-     <description>Comparator Control Register.</description>
-     <addressOffset>0x00</addressOffset>
-     <fields>
-      <field>
-       <name>EN</name>
-       <description>Comparator Enable.</description>
-       <bitOffset>0</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>POL</name>
-       <description>Polarity Select</description>
-       <bitOffset>5</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>INT_EN</name>
-       <description>IRQ Enable.</description>
-       <bitOffset>6</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>OUT</name>
-       <description>Raw Compartor Input.</description>
-       <bitOffset>14</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>INT_FL</name>
-       <description>IRQ Flag</description>
-       <bitOffset>15</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-     </fields>
-    </register>
-   </registers>
-  </peripheral>
-<!--LPCMP Low Power Comparator-->
   <peripheral>
    <name>RTC</name>
    <description>Real Time Clock and Alarm.</description>

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/owm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/owm_regs.h
@@ -5,7 +5,7 @@
  */
 
 /******************************************************************************
- * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/pt_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/pt_regs.h
@@ -5,7 +5,7 @@
  */
 
 /******************************************************************************
- * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/ptg_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/ptg_regs.h
@@ -5,7 +5,7 @@
  */
 
 /******************************************************************************
- * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -88,10 +88,12 @@ extern "C" {
 typedef struct {
     __IO uint32_t enable;               /**< <tt>\b 0x0000:</tt> PTG ENABLE Register */
     __IO uint32_t resync;               /**< <tt>\b 0x0004:</tt> PTG RESYNC Register */
-    __IO uint32_t intfl;                /**< <tt>\b 0x0008:</tt> PTG INTFL Register */
-    __IO uint32_t inten;                /**< <tt>\b 0x000C:</tt> PTG INTEN Register */
+    __IO uint32_t stop_intfl;           /**< <tt>\b 0x0008:</tt> PTG STOP_INTFL Register */
+    __IO uint32_t stop_inten;           /**< <tt>\b 0x000C:</tt> PTG STOP_INTEN Register */
     __O  uint32_t safe_en;              /**< <tt>\b 0x0010:</tt> PTG SAFE_EN Register */
     __O  uint32_t safe_dis;             /**< <tt>\b 0x0014:</tt> PTG SAFE_DIS Register */
+    __IO uint32_t ready_intfl;          /**< <tt>\b 0x0018:</tt> PTG READY_INTFL Register */
+    __IO uint32_t ready_inten;          /**< <tt>\b 0x001C:</tt> PTG READY_INTEN Register */
 } mxc_ptg_regs_t;
 
 /* Register offsets for module PTG */
@@ -103,10 +105,12 @@ typedef struct {
  */
 #define MXC_R_PTG_ENABLE                   ((uint32_t)0x00000000UL) /**< Offset from PTG Base Address: <tt> 0x0000</tt> */
 #define MXC_R_PTG_RESYNC                   ((uint32_t)0x00000004UL) /**< Offset from PTG Base Address: <tt> 0x0004</tt> */
-#define MXC_R_PTG_INTFL                    ((uint32_t)0x00000008UL) /**< Offset from PTG Base Address: <tt> 0x0008</tt> */
-#define MXC_R_PTG_INTEN                    ((uint32_t)0x0000000CUL) /**< Offset from PTG Base Address: <tt> 0x000C</tt> */
+#define MXC_R_PTG_STOP_INTFL               ((uint32_t)0x00000008UL) /**< Offset from PTG Base Address: <tt> 0x0008</tt> */
+#define MXC_R_PTG_STOP_INTEN               ((uint32_t)0x0000000CUL) /**< Offset from PTG Base Address: <tt> 0x000C</tt> */
 #define MXC_R_PTG_SAFE_EN                  ((uint32_t)0x00000010UL) /**< Offset from PTG Base Address: <tt> 0x0010</tt> */
 #define MXC_R_PTG_SAFE_DIS                 ((uint32_t)0x00000014UL) /**< Offset from PTG Base Address: <tt> 0x0014</tt> */
+#define MXC_R_PTG_READY_INTFL              ((uint32_t)0x00000018UL) /**< Offset from PTG Base Address: <tt> 0x0018</tt> */
+#define MXC_R_PTG_READY_INTEN              ((uint32_t)0x0000001CUL) /**< Offset from PTG Base Address: <tt> 0x001C</tt> */
 /**@} end of group ptg_registers */
 
 /**
@@ -126,6 +130,42 @@ typedef struct {
 
 #define MXC_F_PTG_ENABLE_PT3_POS                       3 /**< ENABLE_PT3 Position */
 #define MXC_F_PTG_ENABLE_PT3                           ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT3_POS)) /**< ENABLE_PT3 Mask */
+
+#define MXC_F_PTG_ENABLE_PT4_POS                       4 /**< ENABLE_PT4 Position */
+#define MXC_F_PTG_ENABLE_PT4                           ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT4_POS)) /**< ENABLE_PT4 Mask */
+
+#define MXC_F_PTG_ENABLE_PT5_POS                       5 /**< ENABLE_PT5 Position */
+#define MXC_F_PTG_ENABLE_PT5                           ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT5_POS)) /**< ENABLE_PT5 Mask */
+
+#define MXC_F_PTG_ENABLE_PT6_POS                       6 /**< ENABLE_PT6 Position */
+#define MXC_F_PTG_ENABLE_PT6                           ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT6_POS)) /**< ENABLE_PT6 Mask */
+
+#define MXC_F_PTG_ENABLE_PT7_POS                       7 /**< ENABLE_PT7 Position */
+#define MXC_F_PTG_ENABLE_PT7                           ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT7_POS)) /**< ENABLE_PT7 Mask */
+
+#define MXC_F_PTG_ENABLE_PT8_POS                       8 /**< ENABLE_PT8 Position */
+#define MXC_F_PTG_ENABLE_PT8                           ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT8_POS)) /**< ENABLE_PT8 Mask */
+
+#define MXC_F_PTG_ENABLE_PT9_POS                       9 /**< ENABLE_PT9 Position */
+#define MXC_F_PTG_ENABLE_PT9                           ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT9_POS)) /**< ENABLE_PT9 Mask */
+
+#define MXC_F_PTG_ENABLE_PT10_POS                      10 /**< ENABLE_PT10 Position */
+#define MXC_F_PTG_ENABLE_PT10                          ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT10_POS)) /**< ENABLE_PT10 Mask */
+
+#define MXC_F_PTG_ENABLE_PT11_POS                      11 /**< ENABLE_PT11 Position */
+#define MXC_F_PTG_ENABLE_PT11                          ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT11_POS)) /**< ENABLE_PT11 Mask */
+
+#define MXC_F_PTG_ENABLE_PT12_POS                      12 /**< ENABLE_PT12 Position */
+#define MXC_F_PTG_ENABLE_PT12                          ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT12_POS)) /**< ENABLE_PT12 Mask */
+
+#define MXC_F_PTG_ENABLE_PT13_POS                      13 /**< ENABLE_PT13 Position */
+#define MXC_F_PTG_ENABLE_PT13                          ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT13_POS)) /**< ENABLE_PT13 Mask */
+
+#define MXC_F_PTG_ENABLE_PT14_POS                      14 /**< ENABLE_PT14 Position */
+#define MXC_F_PTG_ENABLE_PT14                          ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT14_POS)) /**< ENABLE_PT14 Mask */
+
+#define MXC_F_PTG_ENABLE_PT15_POS                      15 /**< ENABLE_PT15 Position */
+#define MXC_F_PTG_ENABLE_PT15                          ((uint32_t)(0x1UL << MXC_F_PTG_ENABLE_PT15_POS)) /**< ENABLE_PT15 Mask */
 
 /**@} end of group PTG_ENABLE_Register */
 
@@ -147,47 +187,155 @@ typedef struct {
 #define MXC_F_PTG_RESYNC_PT3_POS                       3 /**< RESYNC_PT3 Position */
 #define MXC_F_PTG_RESYNC_PT3                           ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT3_POS)) /**< RESYNC_PT3 Mask */
 
+#define MXC_F_PTG_RESYNC_PT4_POS                       4 /**< RESYNC_PT4 Position */
+#define MXC_F_PTG_RESYNC_PT4                           ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT4_POS)) /**< RESYNC_PT4 Mask */
+
+#define MXC_F_PTG_RESYNC_PT5_POS                       5 /**< RESYNC_PT5 Position */
+#define MXC_F_PTG_RESYNC_PT5                           ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT5_POS)) /**< RESYNC_PT5 Mask */
+
+#define MXC_F_PTG_RESYNC_PT6_POS                       6 /**< RESYNC_PT6 Position */
+#define MXC_F_PTG_RESYNC_PT6                           ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT6_POS)) /**< RESYNC_PT6 Mask */
+
+#define MXC_F_PTG_RESYNC_PT7_POS                       7 /**< RESYNC_PT7 Position */
+#define MXC_F_PTG_RESYNC_PT7                           ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT7_POS)) /**< RESYNC_PT7 Mask */
+
+#define MXC_F_PTG_RESYNC_PT8_POS                       8 /**< RESYNC_PT8 Position */
+#define MXC_F_PTG_RESYNC_PT8                           ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT8_POS)) /**< RESYNC_PT8 Mask */
+
+#define MXC_F_PTG_RESYNC_PT9_POS                       9 /**< RESYNC_PT9 Position */
+#define MXC_F_PTG_RESYNC_PT9                           ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT9_POS)) /**< RESYNC_PT9 Mask */
+
+#define MXC_F_PTG_RESYNC_PT10_POS                      10 /**< RESYNC_PT10 Position */
+#define MXC_F_PTG_RESYNC_PT10                          ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT10_POS)) /**< RESYNC_PT10 Mask */
+
+#define MXC_F_PTG_RESYNC_PT11_POS                      11 /**< RESYNC_PT11 Position */
+#define MXC_F_PTG_RESYNC_PT11                          ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT11_POS)) /**< RESYNC_PT11 Mask */
+
+#define MXC_F_PTG_RESYNC_PT12_POS                      12 /**< RESYNC_PT12 Position */
+#define MXC_F_PTG_RESYNC_PT12                          ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT12_POS)) /**< RESYNC_PT12 Mask */
+
+#define MXC_F_PTG_RESYNC_PT13_POS                      13 /**< RESYNC_PT13 Position */
+#define MXC_F_PTG_RESYNC_PT13                          ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT13_POS)) /**< RESYNC_PT13 Mask */
+
+#define MXC_F_PTG_RESYNC_PT14_POS                      14 /**< RESYNC_PT14 Position */
+#define MXC_F_PTG_RESYNC_PT14                          ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT14_POS)) /**< RESYNC_PT14 Mask */
+
+#define MXC_F_PTG_RESYNC_PT15_POS                      15 /**< RESYNC_PT15 Position */
+#define MXC_F_PTG_RESYNC_PT15                          ((uint32_t)(0x1UL << MXC_F_PTG_RESYNC_PT15_POS)) /**< RESYNC_PT15 Mask */
+
 /**@} end of group PTG_RESYNC_Register */
 
 /**
  * @ingroup  ptg_registers
- * @defgroup PTG_INTFL PTG_INTFL
+ * @defgroup PTG_STOP_INTFL PTG_STOP_INTFL
  * @brief    Pulse Train Interrupt Flags
  * @{
  */
-#define MXC_F_PTG_INTFL_PT0_POS                        0 /**< INTFL_PT0 Position */
-#define MXC_F_PTG_INTFL_PT0                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT0_POS)) /**< INTFL_PT0 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT0_POS                   0 /**< STOP_INTFL_PT0 Position */
+#define MXC_F_PTG_STOP_INTFL_PT0                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT0_POS)) /**< STOP_INTFL_PT0 Mask */
 
-#define MXC_F_PTG_INTFL_PT1_POS                        1 /**< INTFL_PT1 Position */
-#define MXC_F_PTG_INTFL_PT1                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT1_POS)) /**< INTFL_PT1 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT1_POS                   1 /**< STOP_INTFL_PT1 Position */
+#define MXC_F_PTG_STOP_INTFL_PT1                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT1_POS)) /**< STOP_INTFL_PT1 Mask */
 
-#define MXC_F_PTG_INTFL_PT2_POS                        2 /**< INTFL_PT2 Position */
-#define MXC_F_PTG_INTFL_PT2                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT2_POS)) /**< INTFL_PT2 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT2_POS                   2 /**< STOP_INTFL_PT2 Position */
+#define MXC_F_PTG_STOP_INTFL_PT2                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT2_POS)) /**< STOP_INTFL_PT2 Mask */
 
-#define MXC_F_PTG_INTFL_PT3_POS                        3 /**< INTFL_PT3 Position */
-#define MXC_F_PTG_INTFL_PT3                            ((uint32_t)(0x1UL << MXC_F_PTG_INTFL_PT3_POS)) /**< INTFL_PT3 Mask */
+#define MXC_F_PTG_STOP_INTFL_PT3_POS                   3 /**< STOP_INTFL_PT3 Position */
+#define MXC_F_PTG_STOP_INTFL_PT3                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT3_POS)) /**< STOP_INTFL_PT3 Mask */
 
-/**@} end of group PTG_INTFL_Register */
+#define MXC_F_PTG_STOP_INTFL_PT4_POS                   4 /**< STOP_INTFL_PT4 Position */
+#define MXC_F_PTG_STOP_INTFL_PT4                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT4_POS)) /**< STOP_INTFL_PT4 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT5_POS                   5 /**< STOP_INTFL_PT5 Position */
+#define MXC_F_PTG_STOP_INTFL_PT5                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT5_POS)) /**< STOP_INTFL_PT5 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT6_POS                   6 /**< STOP_INTFL_PT6 Position */
+#define MXC_F_PTG_STOP_INTFL_PT6                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT6_POS)) /**< STOP_INTFL_PT6 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT7_POS                   7 /**< STOP_INTFL_PT7 Position */
+#define MXC_F_PTG_STOP_INTFL_PT7                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT7_POS)) /**< STOP_INTFL_PT7 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT8_POS                   8 /**< STOP_INTFL_PT8 Position */
+#define MXC_F_PTG_STOP_INTFL_PT8                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT8_POS)) /**< STOP_INTFL_PT8 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT9_POS                   9 /**< STOP_INTFL_PT9 Position */
+#define MXC_F_PTG_STOP_INTFL_PT9                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT9_POS)) /**< STOP_INTFL_PT9 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT10_POS                  10 /**< STOP_INTFL_PT10 Position */
+#define MXC_F_PTG_STOP_INTFL_PT10                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT10_POS)) /**< STOP_INTFL_PT10 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT11_POS                  11 /**< STOP_INTFL_PT11 Position */
+#define MXC_F_PTG_STOP_INTFL_PT11                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT11_POS)) /**< STOP_INTFL_PT11 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT12_POS                  12 /**< STOP_INTFL_PT12 Position */
+#define MXC_F_PTG_STOP_INTFL_PT12                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT12_POS)) /**< STOP_INTFL_PT12 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT13_POS                  13 /**< STOP_INTFL_PT13 Position */
+#define MXC_F_PTG_STOP_INTFL_PT13                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT13_POS)) /**< STOP_INTFL_PT13 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT14_POS                  14 /**< STOP_INTFL_PT14 Position */
+#define MXC_F_PTG_STOP_INTFL_PT14                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT14_POS)) /**< STOP_INTFL_PT14 Mask */
+
+#define MXC_F_PTG_STOP_INTFL_PT15_POS                  15 /**< STOP_INTFL_PT15 Position */
+#define MXC_F_PTG_STOP_INTFL_PT15                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTFL_PT15_POS)) /**< STOP_INTFL_PT15 Mask */
+
+/**@} end of group PTG_STOP_INTFL_Register */
 
 /**
  * @ingroup  ptg_registers
- * @defgroup PTG_INTEN PTG_INTEN
+ * @defgroup PTG_STOP_INTEN PTG_STOP_INTEN
  * @brief    Pulse Train Interrupt Enable/Disable
  * @{
  */
-#define MXC_F_PTG_INTEN_PT0_POS                        0 /**< INTEN_PT0 Position */
-#define MXC_F_PTG_INTEN_PT0                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT0_POS)) /**< INTEN_PT0 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT0_POS                   0 /**< STOP_INTEN_PT0 Position */
+#define MXC_F_PTG_STOP_INTEN_PT0                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT0_POS)) /**< STOP_INTEN_PT0 Mask */
 
-#define MXC_F_PTG_INTEN_PT1_POS                        1 /**< INTEN_PT1 Position */
-#define MXC_F_PTG_INTEN_PT1                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT1_POS)) /**< INTEN_PT1 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT1_POS                   1 /**< STOP_INTEN_PT1 Position */
+#define MXC_F_PTG_STOP_INTEN_PT1                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT1_POS)) /**< STOP_INTEN_PT1 Mask */
 
-#define MXC_F_PTG_INTEN_PT2_POS                        2 /**< INTEN_PT2 Position */
-#define MXC_F_PTG_INTEN_PT2                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT2_POS)) /**< INTEN_PT2 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT2_POS                   2 /**< STOP_INTEN_PT2 Position */
+#define MXC_F_PTG_STOP_INTEN_PT2                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT2_POS)) /**< STOP_INTEN_PT2 Mask */
 
-#define MXC_F_PTG_INTEN_PT3_POS                        3 /**< INTEN_PT3 Position */
-#define MXC_F_PTG_INTEN_PT3                            ((uint32_t)(0x1UL << MXC_F_PTG_INTEN_PT3_POS)) /**< INTEN_PT3 Mask */
+#define MXC_F_PTG_STOP_INTEN_PT3_POS                   3 /**< STOP_INTEN_PT3 Position */
+#define MXC_F_PTG_STOP_INTEN_PT3                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT3_POS)) /**< STOP_INTEN_PT3 Mask */
 
-/**@} end of group PTG_INTEN_Register */
+#define MXC_F_PTG_STOP_INTEN_PT4_POS                   4 /**< STOP_INTEN_PT4 Position */
+#define MXC_F_PTG_STOP_INTEN_PT4                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT4_POS)) /**< STOP_INTEN_PT4 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT5_POS                   5 /**< STOP_INTEN_PT5 Position */
+#define MXC_F_PTG_STOP_INTEN_PT5                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT5_POS)) /**< STOP_INTEN_PT5 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT6_POS                   6 /**< STOP_INTEN_PT6 Position */
+#define MXC_F_PTG_STOP_INTEN_PT6                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT6_POS)) /**< STOP_INTEN_PT6 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT7_POS                   7 /**< STOP_INTEN_PT7 Position */
+#define MXC_F_PTG_STOP_INTEN_PT7                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT7_POS)) /**< STOP_INTEN_PT7 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT8_POS                   8 /**< STOP_INTEN_PT8 Position */
+#define MXC_F_PTG_STOP_INTEN_PT8                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT8_POS)) /**< STOP_INTEN_PT8 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT9_POS                   9 /**< STOP_INTEN_PT9 Position */
+#define MXC_F_PTG_STOP_INTEN_PT9                       ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT9_POS)) /**< STOP_INTEN_PT9 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT10_POS                  10 /**< STOP_INTEN_PT10 Position */
+#define MXC_F_PTG_STOP_INTEN_PT10                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT10_POS)) /**< STOP_INTEN_PT10 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT11_POS                  11 /**< STOP_INTEN_PT11 Position */
+#define MXC_F_PTG_STOP_INTEN_PT11                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT11_POS)) /**< STOP_INTEN_PT11 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT12_POS                  12 /**< STOP_INTEN_PT12 Position */
+#define MXC_F_PTG_STOP_INTEN_PT12                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT12_POS)) /**< STOP_INTEN_PT12 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT13_POS                  13 /**< STOP_INTEN_PT13 Position */
+#define MXC_F_PTG_STOP_INTEN_PT13                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT13_POS)) /**< STOP_INTEN_PT13 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT14_POS                  14 /**< STOP_INTEN_PT14 Position */
+#define MXC_F_PTG_STOP_INTEN_PT14                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT14_POS)) /**< STOP_INTEN_PT14 Mask */
+
+#define MXC_F_PTG_STOP_INTEN_PT15_POS                  15 /**< STOP_INTEN_PT15 Position */
+#define MXC_F_PTG_STOP_INTEN_PT15                      ((uint32_t)(0x1UL << MXC_F_PTG_STOP_INTEN_PT15_POS)) /**< STOP_INTEN_PT15 Mask */
+
+/**@} end of group PTG_STOP_INTEN_Register */
 
 /**
  * @ingroup  ptg_registers
@@ -206,6 +354,42 @@ typedef struct {
 
 #define MXC_F_PTG_SAFE_EN_PT3_POS                      3 /**< SAFE_EN_PT3 Position */
 #define MXC_F_PTG_SAFE_EN_PT3                          ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT3_POS)) /**< SAFE_EN_PT3 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT4_POS                      4 /**< SAFE_EN_PT4 Position */
+#define MXC_F_PTG_SAFE_EN_PT4                          ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT4_POS)) /**< SAFE_EN_PT4 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT5_POS                      5 /**< SAFE_EN_PT5 Position */
+#define MXC_F_PTG_SAFE_EN_PT5                          ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT5_POS)) /**< SAFE_EN_PT5 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT6_POS                      6 /**< SAFE_EN_PT6 Position */
+#define MXC_F_PTG_SAFE_EN_PT6                          ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT6_POS)) /**< SAFE_EN_PT6 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT7_POS                      7 /**< SAFE_EN_PT7 Position */
+#define MXC_F_PTG_SAFE_EN_PT7                          ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT7_POS)) /**< SAFE_EN_PT7 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT8_POS                      8 /**< SAFE_EN_PT8 Position */
+#define MXC_F_PTG_SAFE_EN_PT8                          ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT8_POS)) /**< SAFE_EN_PT8 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT9_POS                      9 /**< SAFE_EN_PT9 Position */
+#define MXC_F_PTG_SAFE_EN_PT9                          ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT9_POS)) /**< SAFE_EN_PT9 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT10_POS                     10 /**< SAFE_EN_PT10 Position */
+#define MXC_F_PTG_SAFE_EN_PT10                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT10_POS)) /**< SAFE_EN_PT10 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT11_POS                     11 /**< SAFE_EN_PT11 Position */
+#define MXC_F_PTG_SAFE_EN_PT11                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT11_POS)) /**< SAFE_EN_PT11 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT12_POS                     12 /**< SAFE_EN_PT12 Position */
+#define MXC_F_PTG_SAFE_EN_PT12                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT12_POS)) /**< SAFE_EN_PT12 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT13_POS                     13 /**< SAFE_EN_PT13 Position */
+#define MXC_F_PTG_SAFE_EN_PT13                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT13_POS)) /**< SAFE_EN_PT13 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT14_POS                     14 /**< SAFE_EN_PT14 Position */
+#define MXC_F_PTG_SAFE_EN_PT14                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT14_POS)) /**< SAFE_EN_PT14 Mask */
+
+#define MXC_F_PTG_SAFE_EN_PT15_POS                     15 /**< SAFE_EN_PT15 Position */
+#define MXC_F_PTG_SAFE_EN_PT15                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_EN_PT15_POS)) /**< SAFE_EN_PT15 Mask */
 
 /**@} end of group PTG_SAFE_EN_Register */
 
@@ -227,7 +411,155 @@ typedef struct {
 #define MXC_F_PTG_SAFE_DIS_PT3_POS                     3 /**< SAFE_DIS_PT3 Position */
 #define MXC_F_PTG_SAFE_DIS_PT3                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT3_POS)) /**< SAFE_DIS_PT3 Mask */
 
+#define MXC_F_PTG_SAFE_DIS_PT4_POS                     4 /**< SAFE_DIS_PT4 Position */
+#define MXC_F_PTG_SAFE_DIS_PT4                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT4_POS)) /**< SAFE_DIS_PT4 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT5_POS                     5 /**< SAFE_DIS_PT5 Position */
+#define MXC_F_PTG_SAFE_DIS_PT5                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT5_POS)) /**< SAFE_DIS_PT5 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT6_POS                     6 /**< SAFE_DIS_PT6 Position */
+#define MXC_F_PTG_SAFE_DIS_PT6                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT6_POS)) /**< SAFE_DIS_PT6 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT7_POS                     7 /**< SAFE_DIS_PT7 Position */
+#define MXC_F_PTG_SAFE_DIS_PT7                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT7_POS)) /**< SAFE_DIS_PT7 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT8_POS                     8 /**< SAFE_DIS_PT8 Position */
+#define MXC_F_PTG_SAFE_DIS_PT8                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT8_POS)) /**< SAFE_DIS_PT8 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT9_POS                     9 /**< SAFE_DIS_PT9 Position */
+#define MXC_F_PTG_SAFE_DIS_PT9                         ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT9_POS)) /**< SAFE_DIS_PT9 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT10_POS                    10 /**< SAFE_DIS_PT10 Position */
+#define MXC_F_PTG_SAFE_DIS_PT10                        ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT10_POS)) /**< SAFE_DIS_PT10 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT11_POS                    11 /**< SAFE_DIS_PT11 Position */
+#define MXC_F_PTG_SAFE_DIS_PT11                        ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT11_POS)) /**< SAFE_DIS_PT11 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT12_POS                    12 /**< SAFE_DIS_PT12 Position */
+#define MXC_F_PTG_SAFE_DIS_PT12                        ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT12_POS)) /**< SAFE_DIS_PT12 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT13_POS                    13 /**< SAFE_DIS_PT13 Position */
+#define MXC_F_PTG_SAFE_DIS_PT13                        ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT13_POS)) /**< SAFE_DIS_PT13 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT14_POS                    14 /**< SAFE_DIS_PT14 Position */
+#define MXC_F_PTG_SAFE_DIS_PT14                        ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT14_POS)) /**< SAFE_DIS_PT14 Mask */
+
+#define MXC_F_PTG_SAFE_DIS_PT15_POS                    15 /**< SAFE_DIS_PT15 Position */
+#define MXC_F_PTG_SAFE_DIS_PT15                        ((uint32_t)(0x1UL << MXC_F_PTG_SAFE_DIS_PT15_POS)) /**< SAFE_DIS_PT15 Mask */
+
 /**@} end of group PTG_SAFE_DIS_Register */
+
+/**
+ * @ingroup  ptg_registers
+ * @defgroup PTG_READY_INTFL PTG_READY_INTFL
+ * @brief    Pulse Train Ready Interrupt Flags
+ * @{
+ */
+#define MXC_F_PTG_READY_INTFL_PT0_POS                  0 /**< READY_INTFL_PT0 Position */
+#define MXC_F_PTG_READY_INTFL_PT0                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT0_POS)) /**< READY_INTFL_PT0 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT1_POS                  1 /**< READY_INTFL_PT1 Position */
+#define MXC_F_PTG_READY_INTFL_PT1                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT1_POS)) /**< READY_INTFL_PT1 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT2_POS                  2 /**< READY_INTFL_PT2 Position */
+#define MXC_F_PTG_READY_INTFL_PT2                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT2_POS)) /**< READY_INTFL_PT2 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT3_POS                  3 /**< READY_INTFL_PT3 Position */
+#define MXC_F_PTG_READY_INTFL_PT3                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT3_POS)) /**< READY_INTFL_PT3 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT4_POS                  4 /**< READY_INTFL_PT4 Position */
+#define MXC_F_PTG_READY_INTFL_PT4                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT4_POS)) /**< READY_INTFL_PT4 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT5_POS                  5 /**< READY_INTFL_PT5 Position */
+#define MXC_F_PTG_READY_INTFL_PT5                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT5_POS)) /**< READY_INTFL_PT5 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT6_POS                  6 /**< READY_INTFL_PT6 Position */
+#define MXC_F_PTG_READY_INTFL_PT6                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT6_POS)) /**< READY_INTFL_PT6 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT7_POS                  7 /**< READY_INTFL_PT7 Position */
+#define MXC_F_PTG_READY_INTFL_PT7                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT7_POS)) /**< READY_INTFL_PT7 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT8_POS                  8 /**< READY_INTFL_PT8 Position */
+#define MXC_F_PTG_READY_INTFL_PT8                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT8_POS)) /**< READY_INTFL_PT8 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT9_POS                  9 /**< READY_INTFL_PT9 Position */
+#define MXC_F_PTG_READY_INTFL_PT9                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT9_POS)) /**< READY_INTFL_PT9 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT10_POS                 10 /**< READY_INTFL_PT10 Position */
+#define MXC_F_PTG_READY_INTFL_PT10                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT10_POS)) /**< READY_INTFL_PT10 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT11_POS                 11 /**< READY_INTFL_PT11 Position */
+#define MXC_F_PTG_READY_INTFL_PT11                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT11_POS)) /**< READY_INTFL_PT11 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT12_POS                 12 /**< READY_INTFL_PT12 Position */
+#define MXC_F_PTG_READY_INTFL_PT12                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT12_POS)) /**< READY_INTFL_PT12 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT13_POS                 13 /**< READY_INTFL_PT13 Position */
+#define MXC_F_PTG_READY_INTFL_PT13                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT13_POS)) /**< READY_INTFL_PT13 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT14_POS                 14 /**< READY_INTFL_PT14 Position */
+#define MXC_F_PTG_READY_INTFL_PT14                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT14_POS)) /**< READY_INTFL_PT14 Mask */
+
+#define MXC_F_PTG_READY_INTFL_PT15_POS                 15 /**< READY_INTFL_PT15 Position */
+#define MXC_F_PTG_READY_INTFL_PT15                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTFL_PT15_POS)) /**< READY_INTFL_PT15 Mask */
+
+/**@} end of group PTG_READY_INTFL_Register */
+
+/**
+ * @ingroup  ptg_registers
+ * @defgroup PTG_READY_INTEN PTG_READY_INTEN
+ * @brief    Pulse Train Ready Interrupt Enable/Disable
+ * @{
+ */
+#define MXC_F_PTG_READY_INTEN_PT0_POS                  0 /**< READY_INTEN_PT0 Position */
+#define MXC_F_PTG_READY_INTEN_PT0                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT0_POS)) /**< READY_INTEN_PT0 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT1_POS                  1 /**< READY_INTEN_PT1 Position */
+#define MXC_F_PTG_READY_INTEN_PT1                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT1_POS)) /**< READY_INTEN_PT1 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT2_POS                  2 /**< READY_INTEN_PT2 Position */
+#define MXC_F_PTG_READY_INTEN_PT2                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT2_POS)) /**< READY_INTEN_PT2 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT3_POS                  3 /**< READY_INTEN_PT3 Position */
+#define MXC_F_PTG_READY_INTEN_PT3                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT3_POS)) /**< READY_INTEN_PT3 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT4_POS                  4 /**< READY_INTEN_PT4 Position */
+#define MXC_F_PTG_READY_INTEN_PT4                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT4_POS)) /**< READY_INTEN_PT4 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT5_POS                  5 /**< READY_INTEN_PT5 Position */
+#define MXC_F_PTG_READY_INTEN_PT5                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT5_POS)) /**< READY_INTEN_PT5 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT6_POS                  6 /**< READY_INTEN_PT6 Position */
+#define MXC_F_PTG_READY_INTEN_PT6                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT6_POS)) /**< READY_INTEN_PT6 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT7_POS                  7 /**< READY_INTEN_PT7 Position */
+#define MXC_F_PTG_READY_INTEN_PT7                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT7_POS)) /**< READY_INTEN_PT7 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT8_POS                  8 /**< READY_INTEN_PT8 Position */
+#define MXC_F_PTG_READY_INTEN_PT8                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT8_POS)) /**< READY_INTEN_PT8 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT9_POS                  9 /**< READY_INTEN_PT9 Position */
+#define MXC_F_PTG_READY_INTEN_PT9                      ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT9_POS)) /**< READY_INTEN_PT9 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT10_POS                 10 /**< READY_INTEN_PT10 Position */
+#define MXC_F_PTG_READY_INTEN_PT10                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT10_POS)) /**< READY_INTEN_PT10 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT11_POS                 11 /**< READY_INTEN_PT11 Position */
+#define MXC_F_PTG_READY_INTEN_PT11                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT11_POS)) /**< READY_INTEN_PT11 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT12_POS                 12 /**< READY_INTEN_PT12 Position */
+#define MXC_F_PTG_READY_INTEN_PT12                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT12_POS)) /**< READY_INTEN_PT12 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT13_POS                 13 /**< READY_INTEN_PT13 Position */
+#define MXC_F_PTG_READY_INTEN_PT13                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT13_POS)) /**< READY_INTEN_PT13 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT14_POS                 14 /**< READY_INTEN_PT14 Position */
+#define MXC_F_PTG_READY_INTEN_PT14                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT14_POS)) /**< READY_INTEN_PT14 Mask */
+
+#define MXC_F_PTG_READY_INTEN_PT15_POS                 15 /**< READY_INTEN_PT15 Position */
+#define MXC_F_PTG_READY_INTEN_PT15                     ((uint32_t)(0x1UL << MXC_F_PTG_READY_INTEN_PT15_POS)) /**< READY_INTEN_PT15 Mask */
+
+/**@} end of group PTG_READY_INTEN_Register */
 
 #ifdef __cplusplus
 }

--- a/Libraries/PeriphDrivers/Include/MAX32572/pt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/pt.h
@@ -172,39 +172,47 @@ uint32_t MXC_PT_IsActive(uint32_t pts);
 void MXC_PT_SetPattern(unsigned pts, uint32_t pattern);
 
 /**
- * @brief      Enable interrupts for the pulse trains selected.
+ * @brief      Enable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This is just an explicit version of MXC_PT_EnableInt()
  *
  * @param      pts   Bit mask of which pulse trains to enable. Set the bit
  *                   position of each pulse train to enable it. Bit0-\>pt0,
  *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-void MXC_PT_EnableInt(uint32_t pts);
+void MXC_PT_EnableStopInt(uint32_t pts);
 
 /**
- * @brief      Disable interrupts for the pulse trains selected.
+ * @brief      Disable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This is an explicit version of MXC_PT_DisableInt()
  *
  * @param      pts   Bit mask of what pulse trains to disable. Set the bit
  *                   position of each pulse train to disable it. Bit0-\>pt0,
  *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-void MXC_PT_DisableInt(uint32_t pts);
+void MXC_PT_DisableStopInt(uint32_t pts);
 
 /**
- * @brief      Gets the pulse trains's interrupt flags.
+ * @brief      Gets the pulse trains's Stop interrupt flags.
+ * 
+ * @note       This is an explicit version of MXC_PT_GetStopFlags()
  *
- * @return     The Pulse Train Interrupt Flags, \ref PTG_INTFL Register
+ * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_STOP_INTFL_Register Register
  *             for details.
  */
-uint32_t MXC_PT_GetFlags(void);
+uint32_t MXC_PT_GetStopFlags(void);
 
 /**
- * @brief      Clears the pulse train's interrupt flag.
+ * @brief      Clears the pulse train's Stop interrupt flag.
+ * 
+ * @note       This is an explicit version of MXC_PT_ClearStopFlags()
  *
- * @param      flags  bits to clear, see \ref PTG_INTFL Register for details.
+ * @param      flags  bits to clear, see \ref MXC_PT_STOP_INTFL_Register Register for details.
  */
-void MXC_PT_ClearFlags(uint32_t flags);
+void MXC_PT_ClearStopFlags(uint32_t flags);
 
 /**
  * @brief      Setup and enables a pulse train to restart after another pulse
@@ -233,6 +241,42 @@ void MXC_PT_DisableRestart(unsigned channel, uint8_t restartIndex);
  *                        number. Bit0-\>pt0, Bit1-\>pt1... etc.
  */
 void MXC_PT_Resync(uint32_t pts);
+
+/**
+ * @brief      Enable Ready interrupts for the pulse trains selected.
+ *
+ * @param      pts   Bit mask of which pulse trains to enable. Set the bit
+ *                   position of each pulse train to enable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+void MXC_PT_EnableReadyInt(uint32_t pts);
+
+/**
+ * @brief      Disable Ready interrupts for the pulse trains selected.
+ *
+ * @param      pts   Bit mask of what pulse trains to disable. Set the bit
+ *                   position of each pulse train to disable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+void MXC_PT_DisableReadyInt(uint32_t pts);
+
+/**
+ * @brief      Gets the pulse trains's Ready interrupt flags.
+ *
+ * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_READY_INTFL_Register Register
+ *             for details.
+ */
+uint32_t MXC_PT_GetReadyFlags(void);
+
+/**
+ * @brief      Clears the pulse train's Ready interrupt flag.
+ *
+ * @param      flags  bits to clear, see \ref MXC_PT_READY_INTFL_Register Register for details.
+ */
+void MXC_PT_ClearReadyFlags(uint32_t flags);
+
 /**@} end of group pt*/
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32662/pt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/pt.h
@@ -223,7 +223,9 @@ void MXC_PT_ClearStopFlags(uint32_t flags);
  *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-inline __attribute__((deprecated("Use MXC_PT_EnableStopInt instead.  See pt.h for more details."))) void MXC_PT_EnableInt(uint32_t pts) 
+inline
+    __attribute__((deprecated("Use MXC_PT_EnableStopInt instead.  See pt.h for more details."))) void
+    MXC_PT_EnableInt(uint32_t pts)
 {
     MXC_PT_EnableStopInt(pts);
 }
@@ -239,7 +241,9 @@ inline __attribute__((deprecated("Use MXC_PT_EnableStopInt instead.  See pt.h fo
  *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-inline __attribute__((deprecated("Use MXC_PT_DisableStopInt instead.  See pt.h for more details."))) void MXC_PT_DisableInt(uint32_t pts)
+inline __attribute__((
+    deprecated("Use MXC_PT_DisableStopInt instead.  See pt.h for more details."))) void
+MXC_PT_DisableInt(uint32_t pts)
 {
     MXC_PT_DisableStopInt(pts);
 }
@@ -253,7 +257,9 @@ inline __attribute__((deprecated("Use MXC_PT_DisableStopInt instead.  See pt.h f
  * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_STOP_INTFL_Register Register
  *             for details.
  */
-inline __attribute__((deprecated("Use MXC_PT_GetStopFlags instead.  See pt.h for more details."))) uint32_t MXC_PT_GetFlags(void)
+inline __attribute__((deprecated("Use MXC_PT_GetStopFlags instead.  See pt.h for more details.")))
+uint32_t
+MXC_PT_GetFlags(void)
 {
     return MXC_PT_GetStopFlags();
 }
@@ -266,7 +272,9 @@ inline __attribute__((deprecated("Use MXC_PT_GetStopFlags instead.  See pt.h for
  *
  * @param      flags  bits to clear, see \ref MXC_PT_STOP_INTFL_Register Register for details.
  */
-inline __attribute__((deprecated("Use MXC_PT_ClearStopFlags instead.  See pt.h for more details."))) void MXC_PT_ClearFlags(uint32_t flags)
+inline __attribute__((
+    deprecated("Use MXC_PT_ClearStopFlags instead.  See pt.h for more details."))) void
+MXC_PT_ClearFlags(uint32_t flags)
 {
     MXC_PT_ClearStopFlags(flags);
 }

--- a/Libraries/PeriphDrivers/Include/MAX32662/pt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/pt.h
@@ -169,39 +169,108 @@ uint32_t MXC_PT_IsActive(uint32_t pts);
 void MXC_PT_SetPattern(unsigned pts, uint32_t pattern);
 
 /**
- * @brief      Enable interrupts for the pulse trains selected.
+ * @brief      Enable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This is just an explicit version of MXC_PT_EnableInt()
  *
  * @param      pts   Bit mask of which pulse trains to enable. Set the bit
  *                   position of each pulse train to enable it. Bit0-\>pt0,
  *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-void MXC_PT_EnableInt(uint32_t pts);
+void MXC_PT_EnableStopInt(uint32_t pts);
 
 /**
- * @brief      Disable interrupts for the pulse trains selected.
+ * @brief      Disable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This is an explicit version of MXC_PT_DisableInt()
  *
  * @param      pts   Bit mask of what pulse trains to disable. Set the bit
  *                   position of each pulse train to disable it. Bit0-\>pt0,
  *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-void MXC_PT_DisableInt(uint32_t pts);
+void MXC_PT_DisableStopInt(uint32_t pts);
 
 /**
- * @brief      Gets the pulse trains's interrupt flags.
+ * @brief      Gets the pulse trains's Stop interrupt flags.
+ * 
+ * @note       This is an explicit version of MXC_PT_GetStopFlags()
  *
- * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_INTFL_Register Register
+ * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_STOP_INTFL_Register Register
  *             for details.
  */
-uint32_t MXC_PT_GetFlags(void);
+uint32_t MXC_PT_GetStopFlags(void);
 
 /**
- * @brief      Clears the pulse train's interrupt flag.
+ * @brief      Clears the pulse train's Stop interrupt flag.
+ * 
+ * @note       This is an explicit version of MXC_PT_ClearStopFlags()
  *
- * @param      flags  bits to clear, see \ref MXC_PT_INTFL_Register Register for details.
+ * @param      flags  bits to clear, see \ref MXC_PT_STOP_INTFL_Register Register for details.
  */
-void MXC_PT_ClearFlags(uint32_t flags);
+void MXC_PT_ClearStopFlags(uint32_t flags);
+
+#if defined(__GNUC__)
+/**
+ * @brief      Enable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This function is deprecated. Use MXC_PT_EnableStopInt instead to
+ *             differentiate between the STOP and READY interrupts.
+ *
+ * @param      pts   Bit mask of which pulse trains to enable. Set the bit
+ *                   position of each pulse train to enable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+inline __attribute__((deprecated("Use MXC_PT_EnableStopInt instead.  See pt.h for more details."))) void MXC_PT_EnableInt(uint32_t pts) 
+{
+    MXC_PT_EnableStopInt(pts);
+}
+
+/**
+ * @brief      Disable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This function is deprecated. Use MXC_PT_DisableStopInt instead to
+ *             differentiate between the STOP and READY interrupts.
+ *
+ * @param      pts   Bit mask of what pulse trains to disable. Set the bit
+ *                   position of each pulse train to disable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+inline __attribute__((deprecated("Use MXC_PT_DisableStopInt instead.  See pt.h for more details."))) void MXC_PT_DisableInt(uint32_t pts)
+{
+    MXC_PT_DisableStopInt(pts);
+}
+
+/**
+ * @brief      Gets the pulse trains's Stop interrupt flags.
+ * 
+ * @note       This function is deprecated. Use MXC_PT_GetStopFlags instead to
+ *             differentiate between the STOP and READY interrupts.
+ *
+ * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_STOP_INTFL_Register Register
+ *             for details.
+ */
+inline __attribute__((deprecated("Use MXC_PT_GetStopFlags instead.  See pt.h for more details."))) uint32_t MXC_PT_GetFlags(void)
+{
+    return MXC_PT_GetStopFlags();
+}
+
+/**
+ * @brief      Clears the pulse train's Stop interrupt flag.
+ * 
+ * @note       This function is deprecated. Use MXC_PT_ClearStopFlags instead to
+ *             differentiate between the STOP and READY interrupts.
+ *
+ * @param      flags  bits to clear, see \ref MXC_PT_STOP_INTFL_Register Register for details.
+ */
+inline __attribute__((deprecated("Use MXC_PT_ClearStopFlags instead.  See pt.h for more details."))) void MXC_PT_ClearFlags(uint32_t flags)
+{
+    MXC_PT_ClearStopFlags(flags);
+}
+#endif
 
 /**
  * @brief      Setup and enables a pulse train to restart after another pulse
@@ -230,6 +299,42 @@ void MXC_PT_DisableRestart(unsigned channel, uint8_t restartIndex);
  *                        number. Bit0-\>pt0, Bit1-\>pt1... etc.
  */
 void MXC_PT_Resync(uint32_t pts);
+
+/**
+ * @brief      Enable Ready interrupts for the pulse trains selected.
+ *
+ * @param      pts   Bit mask of which pulse trains to enable. Set the bit
+ *                   position of each pulse train to enable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+void MXC_PT_EnableReadyInt(uint32_t pts);
+
+/**
+ * @brief      Disable Ready interrupts for the pulse trains selected.
+ *
+ * @param      pts   Bit mask of what pulse trains to disable. Set the bit
+ *                   position of each pulse train to disable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+void MXC_PT_DisableReadyInt(uint32_t pts);
+
+/**
+ * @brief      Gets the pulse trains's Ready interrupt flags.
+ *
+ * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_READY_INTFL_Register Register
+ *             for details.
+ */
+uint32_t MXC_PT_GetReadyFlags(void);
+
+/**
+ * @brief      Clears the pulse train's Ready interrupt flag.
+ *
+ * @param      flags  bits to clear, see \ref MXC_PT_READY_INTFL_Register Register for details.
+ */
+void MXC_PT_ClearReadyFlags(uint32_t flags);
+
 /**@} end of group pulsetrains*/
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32690/pt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/pt.h
@@ -226,7 +226,9 @@ void MXC_PT_ClearStopFlags(uint32_t flags);
  *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-inline __attribute__((deprecated("Use MXC_PT_EnableStopInt instead.  See pt.h for more details."))) void MXC_PT_EnableInt(uint32_t pts) 
+inline
+    __attribute__((deprecated("Use MXC_PT_EnableStopInt instead.  See pt.h for more details."))) void
+    MXC_PT_EnableInt(uint32_t pts)
 {
     MXC_PT_EnableStopInt(pts);
 }
@@ -242,7 +244,9 @@ inline __attribute__((deprecated("Use MXC_PT_EnableStopInt instead.  See pt.h fo
  *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-inline __attribute__((deprecated("Use MXC_PT_DisableStopInt instead.  See pt.h for more details."))) void MXC_PT_DisableInt(uint32_t pts)
+inline __attribute__((
+    deprecated("Use MXC_PT_DisableStopInt instead.  See pt.h for more details."))) void
+MXC_PT_DisableInt(uint32_t pts)
 {
     MXC_PT_DisableStopInt(pts);
 }
@@ -256,7 +260,9 @@ inline __attribute__((deprecated("Use MXC_PT_DisableStopInt instead.  See pt.h f
  * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_STOP_INTFL_Register Register
  *             for details.
  */
-inline __attribute__((deprecated("Use MXC_PT_GetStopFlags instead.  See pt.h for more details."))) uint32_t MXC_PT_GetFlags(void)
+inline __attribute__((deprecated("Use MXC_PT_GetStopFlags instead.  See pt.h for more details.")))
+uint32_t
+MXC_PT_GetFlags(void)
 {
     return MXC_PT_GetStopFlags();
 }
@@ -269,7 +275,9 @@ inline __attribute__((deprecated("Use MXC_PT_GetStopFlags instead.  See pt.h for
  *
  * @param      flags  bits to clear, see \ref MXC_PT_STOP_INTFL_Register Register for details.
  */
-inline __attribute__((deprecated("Use MXC_PT_ClearStopFlags instead.  See pt.h for more details."))) void MXC_PT_ClearFlags(uint32_t flags)
+inline __attribute__((
+    deprecated("Use MXC_PT_ClearStopFlags instead.  See pt.h for more details."))) void
+MXC_PT_ClearFlags(uint32_t flags)
 {
     MXC_PT_ClearStopFlags(flags);
 }

--- a/Libraries/PeriphDrivers/Include/MAX32690/pt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/pt.h
@@ -172,39 +172,108 @@ uint32_t MXC_PT_IsActive(uint32_t pts);
 void MXC_PT_SetPattern(unsigned pts, uint32_t pattern);
 
 /**
- * @brief      Enable interrupts for the pulse trains selected.
+ * @brief      Enable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This is just an explicit version of MXC_PT_EnableInt()
  *
  * @param      pts   Bit mask of which pulse trains to enable. Set the bit
  *                   position of each pulse train to enable it. Bit0-\>pt0,
  *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-void MXC_PT_EnableInt(uint32_t pts);
+void MXC_PT_EnableStopInt(uint32_t pts);
 
 /**
- * @brief      Disable interrupts for the pulse trains selected.
+ * @brief      Disable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This is an explicit version of MXC_PT_DisableInt()
  *
  * @param      pts   Bit mask of what pulse trains to disable. Set the bit
  *                   position of each pulse train to disable it. Bit0-\>pt0,
  *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
  *                   a PT channel in its current state.
  */
-void MXC_PT_DisableInt(uint32_t pts);
+void MXC_PT_DisableStopInt(uint32_t pts);
 
 /**
- * @brief      Gets the pulse trains's interrupt flags.
+ * @brief      Gets the pulse trains's Stop interrupt flags.
+ * 
+ * @note       This is an explicit version of MXC_PT_GetStopFlags()
  *
- * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_INTFL_Register Register
+ * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_STOP_INTFL_Register Register
  *             for details.
  */
-uint32_t MXC_PT_GetFlags(void);
+uint32_t MXC_PT_GetStopFlags(void);
 
 /**
- * @brief      Clears the pulse train's interrupt flag.
+ * @brief      Clears the pulse train's Stop interrupt flag.
+ * 
+ * @note       This is an explicit version of MXC_PT_ClearStopFlags()
  *
- * @param      flags  bits to clear, see \ref MXC_PT_INTFL_Register Register for details.
+ * @param      flags  bits to clear, see \ref MXC_PT_STOP_INTFL_Register Register for details.
  */
-void MXC_PT_ClearFlags(uint32_t flags);
+void MXC_PT_ClearStopFlags(uint32_t flags);
+
+#if defined(__GNUC__)
+/**
+ * @brief      Enable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This function is deprecated. Use MXC_PT_EnableStopInt instead to
+ *             differentiate between the STOP and READY interrupts.
+ *
+ * @param      pts   Bit mask of which pulse trains to enable. Set the bit
+ *                   position of each pulse train to enable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+inline __attribute__((deprecated("Use MXC_PT_EnableStopInt instead.  See pt.h for more details."))) void MXC_PT_EnableInt(uint32_t pts) 
+{
+    MXC_PT_EnableStopInt(pts);
+}
+
+/**
+ * @brief      Disable Stop interrupts for the pulse trains selected.
+ * 
+ * @note       This function is deprecated. Use MXC_PT_DisableStopInt instead to
+ *             differentiate between the STOP and READY interrupts.
+ *
+ * @param      pts   Bit mask of what pulse trains to disable. Set the bit
+ *                   position of each pulse train to disable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+inline __attribute__((deprecated("Use MXC_PT_DisableStopInt instead.  See pt.h for more details."))) void MXC_PT_DisableInt(uint32_t pts)
+{
+    MXC_PT_DisableStopInt(pts);
+}
+
+/**
+ * @brief      Gets the pulse trains's Stop interrupt flags.
+ * 
+ * @note       This function is deprecated. Use MXC_PT_GetStopFlags instead to
+ *             differentiate between the STOP and READY interrupts.
+ *
+ * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_STOP_INTFL_Register Register
+ *             for details.
+ */
+inline __attribute__((deprecated("Use MXC_PT_GetStopFlags instead.  See pt.h for more details."))) uint32_t MXC_PT_GetFlags(void)
+{
+    return MXC_PT_GetStopFlags();
+}
+
+/**
+ * @brief      Clears the pulse train's Stop interrupt flag.
+ * 
+ * @note       This function is deprecated. Use MXC_PT_ClearStopFlags instead to
+ *             differentiate between the STOP and READY interrupts.
+ *
+ * @param      flags  bits to clear, see \ref MXC_PT_STOP_INTFL_Register Register for details.
+ */
+inline __attribute__((deprecated("Use MXC_PT_ClearStopFlags instead.  See pt.h for more details."))) void MXC_PT_ClearFlags(uint32_t flags)
+{
+    MXC_PT_ClearStopFlags(flags);
+}
+#endif
 
 /**
  * @brief      Setup and enables a pulse train to restart after another pulse
@@ -233,6 +302,42 @@ void MXC_PT_DisableRestart(unsigned channel, uint8_t restartIndex);
  *                        number. Bit0-\>pt0, Bit1-\>pt1... etc.
  */
 void MXC_PT_Resync(uint32_t pts);
+
+/**
+ * @brief      Enable Ready interrupts for the pulse trains selected.
+ *
+ * @param      pts   Bit mask of which pulse trains to enable. Set the bit
+ *                   position of each pulse train to enable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will enable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+void MXC_PT_EnableReadyInt(uint32_t pts);
+
+/**
+ * @brief      Disable Ready interrupts for the pulse trains selected.
+ *
+ * @param      pts   Bit mask of what pulse trains to disable. Set the bit
+ *                   position of each pulse train to disable it. Bit0-\>pt0,
+ *                   Bit1-\>pt1... etc, 1 will disable the interrupt, 0 to leave
+ *                   a PT channel in its current state.
+ */
+void MXC_PT_DisableReadyInt(uint32_t pts);
+
+/**
+ * @brief      Gets the pulse trains's Ready interrupt flags.
+ *
+ * @return     The Pulse Train Interrupt Flags, \ref MXC_PT_READY_INTFL_Register Register
+ *             for details.
+ */
+uint32_t MXC_PT_GetReadyFlags(void);
+
+/**
+ * @brief      Clears the pulse train's Ready interrupt flag.
+ *
+ * @param      flags  bits to clear, see \ref MXC_PT_READY_INTFL_Register Register for details.
+ */
+void MXC_PT_ClearReadyFlags(uint32_t flags);
+
 /**@} end of group pulsetrains*/
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Source/PT/pt_me12.c
+++ b/Libraries/PeriphDrivers/Source/PT/pt_me12.c
@@ -153,24 +153,24 @@ void MXC_PT_SetPattern(unsigned pts, uint32_t pattern)
     MXC_PT_RevA_SetPattern(pts, pattern);
 }
 
-void MXC_PT_EnableInt(uint32_t pts)
+void MXC_PT_EnableStopInt(uint32_t pts)
 {
-    MXC_PT_RevA_EnableInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+    MXC_PT_RevA_EnableStopInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
 }
 
-void MXC_PT_DisableInt(uint32_t pts)
+void MXC_PT_DisableStopInt(uint32_t pts)
 {
-    MXC_PT_RevA_DisableInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+    MXC_PT_RevA_DisableStopInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
 }
 
-uint32_t MXC_PT_GetFlags(void)
+uint32_t MXC_PT_GetStopFlags(void)
 {
-    return MXC_PT_RevA_GetFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
+    return MXC_PT_RevA_GetStopFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
 }
 
-void MXC_PT_ClearFlags(uint32_t flags)
+void MXC_PT_ClearStopFlags(uint32_t flags)
 {
-    MXC_PT_RevA_ClearFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
+    MXC_PT_RevA_ClearStopFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
 }
 
 void MXC_PT_EnableRestart(unsigned start, unsigned stop, uint8_t restartIndex)
@@ -186,4 +186,24 @@ void MXC_PT_DisableRestart(unsigned channel, uint8_t restartIndex)
 void MXC_PT_Resync(uint32_t pts)
 {
     MXC_PT_RevA_Resync((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+void MXC_PT_EnableReadyInt(uint32_t pts)
+{
+    MXC_PT_RevA_EnableReadyInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+void MXC_PT_DisableReadyInt(uint32_t pts)
+{
+    MXC_PT_RevA_DisableReadyInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+uint32_t MXC_PT_GetReadyFlags(void)
+{
+    return MXC_PT_RevA_GetReadyFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
+}
+
+void MXC_PT_ClearReadyFlags(uint32_t flags)
+{
+    MXC_PT_RevA_ClearReadyFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
 }

--- a/Libraries/PeriphDrivers/Source/PT/pt_me18.c
+++ b/Libraries/PeriphDrivers/Source/PT/pt_me18.c
@@ -151,24 +151,24 @@ void MXC_PT_SetPattern(unsigned pts, uint32_t pattern)
     MXC_PT_RevA_SetPattern(pts, pattern);
 }
 
-void MXC_PT_EnableInt(uint32_t pts)
+void MXC_PT_EnableStopInt(uint32_t pts)
 {
-    MXC_PT_RevA_EnableInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+    MXC_PT_RevA_EnableStopInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
 }
 
-void MXC_PT_DisableInt(uint32_t pts)
+void MXC_PT_DisableStopInt(uint32_t pts)
 {
-    MXC_PT_RevA_DisableInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+    MXC_PT_RevA_DisableStopInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
 }
 
-uint32_t MXC_PT_GetFlags(void)
+uint32_t MXC_PT_GetStopFlags(void)
 {
-    return MXC_PT_RevA_GetFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
+    return MXC_PT_RevA_GetStopFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
 }
 
-void MXC_PT_ClearFlags(uint32_t flags)
+void MXC_PT_ClearStopFlags(uint32_t flags)
 {
-    MXC_PT_RevA_ClearFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
+    MXC_PT_RevA_ClearStopFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
 }
 
 void MXC_PT_EnableRestart(unsigned start, unsigned stop, uint8_t restartIndex)
@@ -184,4 +184,24 @@ void MXC_PT_DisableRestart(unsigned channel, uint8_t restartIndex)
 void MXC_PT_Resync(uint32_t pts)
 {
     MXC_PT_RevA_Resync((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+void MXC_PT_EnableReadyInt(uint32_t pts)
+{
+    MXC_PT_RevA_EnableReadyInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+void MXC_PT_DisableReadyInt(uint32_t pts)
+{
+    MXC_PT_RevA_DisableReadyInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+uint32_t MXC_PT_GetReadyFlags(void)
+{
+    return MXC_PT_RevA_GetReadyFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
+}
+
+void MXC_PT_ClearReadyFlags(uint32_t flags)
+{
+    MXC_PT_RevA_ClearReadyFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
 }

--- a/Libraries/PeriphDrivers/Source/PT/pt_me55.c
+++ b/Libraries/PeriphDrivers/Source/PT/pt_me55.c
@@ -165,24 +165,24 @@ void MXC_PT_SetPattern(unsigned pts, uint32_t pattern)
     MXC_PT_RevA_SetPattern(pts, pattern);
 }
 
-void MXC_PT_EnableInt(uint32_t pts)
+void MXC_PT_EnableStopInt(uint32_t pts)
 {
-    MXC_PT_RevA_EnableInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+    MXC_PT_RevA_EnableStopInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
 }
 
-void MXC_PT_DisableInt(uint32_t pts)
+void MXC_PT_DisableStopInt(uint32_t pts)
 {
-    MXC_PT_RevA_DisableInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+    MXC_PT_RevA_DisableStopInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
 }
 
-uint32_t MXC_PT_GetFlags(void)
+uint32_t MXC_PT_GetStopFlags(void)
 {
-    return MXC_PT_RevA_GetFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
+    return MXC_PT_RevA_GetStopFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
 }
 
-void MXC_PT_ClearFlags(uint32_t flags)
+void MXC_PT_ClearStopFlags(uint32_t flags)
 {
-    MXC_PT_RevA_ClearFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
+    MXC_PT_RevA_ClearStopFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
 }
 
 void MXC_PT_EnableRestart(unsigned start, unsigned stop, uint8_t restartIndex)
@@ -198,4 +198,24 @@ void MXC_PT_DisableRestart(unsigned channel, uint8_t restartIndex)
 void MXC_PT_Resync(uint32_t pts)
 {
     MXC_PT_RevA_Resync((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+void MXC_PT_EnableReadyInt(uint32_t pts)
+{
+    MXC_PT_RevA_EnableReadyInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+void MXC_PT_DisableReadyInt(uint32_t pts)
+{
+    MXC_PT_RevA_DisableReadyInt((mxc_ptg_reva_regs_t *)MXC_PTG, pts);
+}
+
+uint32_t MXC_PT_GetReadyFlags(void)
+{
+    return MXC_PT_RevA_GetReadyFlags((mxc_ptg_reva_regs_t *)MXC_PTG);
+}
+
+void MXC_PT_ClearReadyFlags(uint32_t flags)
+{
+    MXC_PT_RevA_ClearReadyFlags((mxc_ptg_reva_regs_t *)MXC_PTG, flags);
 }

--- a/Libraries/PeriphDrivers/Source/PT/pt_reva.c
+++ b/Libraries/PeriphDrivers/Source/PT/pt_reva.c
@@ -43,7 +43,8 @@ void MXC_PT_RevA_Init(mxc_ptg_reva_regs_t *ptg, mxc_clk_scale_t clk_scale)
     ptg->enable = 0;
 
     //clear all interrupts
-    ptg->intfl = ptg->intfl;
+    ptg->stop_intfl = ptg->stop_intfl;
+    ptg->ready_intfl = ptg->ready_intfl;
 }
 
 int MXC_PT_RevA_Shutdown(mxc_ptg_reva_regs_t *ptg, uint32_t pts)
@@ -148,22 +149,62 @@ void MXC_PT_RevA_SetPattern(unsigned pts, uint32_t pattern)
 
 void MXC_PT_RevA_EnableInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts)
 {
-    ptg->inten |= pts;
+    MXC_PT_RevA_EnableStopInt(ptg, pts);
 }
 
 void MXC_PT_RevA_DisableInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts)
 {
-    ptg->inten &= ~pts;
+    MXC_PT_RevA_DisableStopInt(ptg, pts);
 }
 
 uint32_t MXC_PT_RevA_GetFlags(mxc_ptg_reva_regs_t *ptg)
 {
-    return ptg->intfl;
+    return MXC_PT_RevA_GetStopFlags(ptg);
 }
 
 void MXC_PT_RevA_ClearFlags(mxc_ptg_reva_regs_t *ptg, uint32_t flags)
 {
-    ptg->intfl = flags;
+    MXC_PT_RevA_ClearStopFlags(ptg, flags);
+}
+
+void MXC_PT_RevA_EnableStopInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts)
+{
+    ptg->stop_inten |= pts;
+}
+
+void MXC_PT_RevA_DisableStopInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts)
+{
+    ptg->stop_inten &= ~pts;
+}
+
+uint32_t MXC_PT_RevA_GetStopFlags(mxc_ptg_reva_regs_t *ptg)
+{
+    return ptg->stop_intfl;
+}
+
+void MXC_PT_RevA_ClearStopFlags(mxc_ptg_reva_regs_t *ptg, uint32_t flags)
+{
+    ptg->stop_intfl = flags;
+}
+
+void MXC_PT_RevA_EnableReadyInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts)
+{
+    ptg->ready_inten |= pts;
+}
+
+void MXC_PT_RevA_DisableReadyInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts)
+{
+    ptg->ready_inten &= ~pts;
+}
+
+uint32_t MXC_PT_RevA_GetReadyFlags(mxc_ptg_reva_regs_t *ptg)
+{
+    return ptg->ready_intfl;
+}
+
+void MXC_PT_RevA_ClearReadyFlags(mxc_ptg_reva_regs_t *ptg, uint32_t flags)
+{
+    ptg->ready_intfl = flags;
 }
 
 void MXC_PT_RevA_EnableRestart(unsigned start, unsigned stop, uint8_t restartIndex)

--- a/Libraries/PeriphDrivers/Source/PT/pt_reva.h
+++ b/Libraries/PeriphDrivers/Source/PT/pt_reva.h
@@ -57,8 +57,16 @@ void MXC_PT_RevA_EnableInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts);
 void MXC_PT_RevA_DisableInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts);
 uint32_t MXC_PT_RevA_GetFlags(mxc_ptg_reva_regs_t *ptg);
 void MXC_PT_RevA_ClearFlags(mxc_ptg_reva_regs_t *ptg, uint32_t flags);
+void MXC_PT_RevA_EnableStopInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts);
+void MXC_PT_RevA_DisableStopInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts);
+uint32_t MXC_PT_RevA_GetStopFlags(mxc_ptg_reva_regs_t *ptg);
+void MXC_PT_RevA_ClearStopFlags(mxc_ptg_reva_regs_t *ptg, uint32_t flags);
 void MXC_PT_RevA_EnableRestart(unsigned start, unsigned stop, uint8_t restartIndex);
 void MXC_PT_RevA_DisableRestart(unsigned channel, uint8_t restartIndex);
 void MXC_PT_RevA_Resync(mxc_ptg_reva_regs_t *ptg, uint32_t pts);
+void MXC_PT_RevA_EnableReadyInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts);
+void MXC_PT_RevA_DisableReadyInt(mxc_ptg_reva_regs_t *ptg, uint32_t pts);
+uint32_t MXC_PT_RevA_GetReadyFlags(mxc_ptg_reva_regs_t *ptg);
+void MXC_PT_RevA_ClearReadyFlags(mxc_ptg_reva_regs_t *ptg, uint32_t flags);
 
 #endif // LIBRARIES_PERIPHDRIVERS_SOURCE_PT_PT_REVA_H_

--- a/Libraries/PeriphDrivers/Source/PT/ptg_reva1_16pt.svd
+++ b/Libraries/PeriphDrivers/Source/PT/ptg_reva1_16pt.svd
@@ -9,7 +9,7 @@
     <access>read-write</access>
     <addressBlock>
       <offset>0</offset>
-      <size>0x0020</size>
+      <size>0x0018</size>
       <usage>registers</usage>
     </addressBlock>
     <interrupt>
@@ -81,10 +81,65 @@
             <bitWidth>1</bitWidth>
             <access>read-write</access>
           </field>
+          <field>
+            <name>pt8</name>
+            <description>Enable/Disable control for PT8</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Enable/Disable control for PT9</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Enable/Disable control for PT10</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Enable/Disable control for PT11</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Enable/Disable control for PT12</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Enable/Disable control for PT13</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Enable/Disable control for PT14</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Enable/Disable control for PT15</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
         </fields>
       </register>
-      <!-- RESYNC:
-                                                                                                         Global Resync (All Pulse Trains) Control -->
+      <!-- RESYNC: Global Resync (All Pulse Trains) Control -->
       <register>
         <name>RESYNC</name>
         <description>Global Resync (All Pulse Trains) Control</description>
@@ -147,10 +202,65 @@
             <bitWidth>1</bitWidth>
             <access>read-write</access>
           </field>
+          <field>
+            <name>pt8</name>
+            <description>Resync control for PT8</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Resync control for PT9</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Resync control for PT10</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Resync control for PT11</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Resync control for PT12</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Resync control for PT13</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Resync control for PT14</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Resync control for PT15</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
         </fields>
       </register>
-      <!-- INTFL:
-                                                                                                                                                                         Pulse Train Interrupt Flags -->
+      <!-- INTFL: Pulse Train Interrupt Flags -->
       <register>
         <name>INTFL</name>
         <description>Pulse Train Interrupt Flags</description>
@@ -213,10 +323,65 @@
             <bitWidth>1</bitWidth>
             <access>read-write</access>
           </field>
+          <field>
+            <name>pt8</name>
+            <description>Pulse Train 8 Stopped Interrupt Flag</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Pulse Train 9 Stopped Interrupt Flag</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Pulse Train 10 Stopped Interrupt Flag</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Pulse Train 11 Stopped Interrupt Flag</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Pulse Train 12 Stopped Interrupt Flag</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Pulse Train 13 Stopped Interrupt Flag</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Pulse Train 14 Stopped Interrupt Flag</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Pulse Train 15 Stopped Interrupt Flag</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
         </fields>
       </register>
-      <!-- INTEN:
-                                                                                                                                                                         Pulse Train Interrupt Enable/Disable -->
+      <!-- INTEN: Pulse Train Interrupt Enable/Disable -->
       <register>
         <name>INTEN</name>
         <description>Pulse Train Interrupt Enable/Disable</description>
@@ -279,8 +444,65 @@
             <bitWidth>1</bitWidth>
             <access>read-write</access>
           </field>
+          <field>
+            <name>pt8</name>
+            <description>Pulse Train 8 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Pulse Train 9 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Pulse Train 10 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Pulse Train 11 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Pulse Train 12 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Pulse Train 13 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Pulse Train 14 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Pulse Train 15 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
         </fields>
       </register>
+      <!--SAFE_EN: Pulse Train Global Safe Enable -->
       <register>
         <name>SAFE_EN</name>
         <description>Pulse Train Global Safe Enable.</description>
@@ -335,8 +557,57 @@
             <bitWidth>1</bitWidth>
             <access>write-only</access>
           </field>
+          <field>
+            <name>PT8</name>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT9</name>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT10</name>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT11</name>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT12</name>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT13</name>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT14</name>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT15</name>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
         </fields>
       </register>
+      <!--SAFE_DIS: Pulse Train Global Safe Disable-->
       <register>
         <name>SAFE_DIS</name>
         <description>Pulse Train Global Safe Disable.</description>
@@ -391,133 +662,53 @@
             <bitWidth>1</bitWidth>
             <access>write-only</access>
           </field>
-        </fields>
-      </register>
-      <register>
-        <name>READY_INTFL</name>
-        <description>Pulse Train Ready Interrupt Flags</description>
-        <addressOffset>0x0018</addressOffset>
-        <access>read-write</access>
-        <fields>
           <field>
-            <name>pt0</name>
-            <description>Pulse Train 0 Stopped Interrupt Flag</description>
-            <bitOffset>0</bitOffset>
+            <name>PT8</name>
+            <bitOffset>8</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>read-write</access>
+            <access>write-only</access>
           </field>
           <field>
-            <name>pt1</name>
-            <description>Pulse Train 1 Stopped Interrupt Flag</description>
-            <bitOffset>1</bitOffset>
+            <name>PT9</name>
+            <bitOffset>9</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>read-write</access>
+            <access>write-only</access>
           </field>
           <field>
-            <name>pt2</name>
-            <description>Pulse Train 2 Stopped Interrupt Flag</description>
-            <bitOffset>2</bitOffset>
+            <name>PT10</name>
+            <bitOffset>10</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>read-write</access>
+            <access>write-only</access>
           </field>
           <field>
-            <name>pt3</name>
-            <description>Pulse Train 3 Stopped Interrupt Flag</description>
-            <bitOffset>3</bitOffset>
+            <name>PT11</name>
+            <bitOffset>11</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>read-write</access>
+            <access>write-only</access>
           </field>
           <field>
-            <name>pt4</name>
-            <description>Pulse Train 4 Stopped Interrupt Flag</description>
-            <bitOffset>4</bitOffset>
+            <name>PT12</name>
+            <bitOffset>12</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>read-write</access>
+            <access>write-only</access>
           </field>
           <field>
-            <name>pt5</name>
-            <description>Pulse Train 5 Stopped Interrupt Flag</description>
-            <bitOffset>5</bitOffset>
+            <name>PT13</name>
+            <bitOffset>13</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>read-write</access>
+            <access>write-only</access>
           </field>
           <field>
-            <name>pt6</name>
-            <description>Pulse Train 6 Stopped Interrupt Flag</description>
-            <bitOffset>6</bitOffset>
+            <name>PT14</name>
+            <bitOffset>14</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>read-write</access>
+            <access>write-only</access>
           </field>
           <field>
-            <name>pt7</name>
-            <description>Pulse Train 7 Stopped Interrupt Flag</description>
-            <bitOffset>7</bitOffset>
+            <name>PT15</name>
+            <bitOffset>15</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-        </fields>
-      </register>
-      <register>
-        <name>READY_INTEN</name>
-        <description>Pulse Train Ready Interrupt Enable/Disable</description>
-        <addressOffset>0x001C</addressOffset>
-        <access>read-write</access>
-        <fields>
-          <field>
-            <name>pt0</name>
-            <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>0</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt1</name>
-            <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>1</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt2</name>
-            <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>2</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt3</name>
-            <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>3</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt4</name>
-            <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>4</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt5</name>
-            <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>5</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt6</name>
-            <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>6</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt7</name>
-            <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>7</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
+            <access>write-only</access>
           </field>
         </fields>
       </register>

--- a/Libraries/PeriphDrivers/Source/PT/ptg_reva1_4pt.svd
+++ b/Libraries/PeriphDrivers/Source/PT/ptg_reva1_4pt.svd
@@ -1,0 +1,237 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <peripheral>
+    <name>PTG</name>
+    <description>Pulse Train Generation</description>
+    <groupName>Pulse_Train</groupName>
+    <baseAddress>0x4003C000</baseAddress>
+    <size>32</size>
+    <access>read-write</access>
+    <addressBlock>
+      <offset>0</offset>
+      <size>0x0020</size>
+      <usage>registers</usage>
+    </addressBlock>
+    <interrupt>
+      <name>PT</name>
+      <description>Pulse Train IRQ</description>
+      <value>59</value>
+    </interrupt>
+    <registers>
+      <!-- ENABLE: Global Enable/Disable Controls for All Pulse Trains -->
+      <register>
+        <name>ENABLE</name>
+        <description>Global Enable/Disable Controls for All Pulse Trains</description>
+        <addressOffset>0x0000</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Enable/Disable control for PT0</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Enable/Disable control for PT1</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Enable/Disable control for PT2</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Enable/Disable control for PT3</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- RESYNC: Global Resync (All Pulse Trains) Control -->
+      <register>
+        <name>RESYNC</name>
+        <description>Global Resync (All Pulse Trains) Control</description>
+        <addressOffset>0x0004</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Resync control for PT0</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Resync control for PT1</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Resync control for PT2</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Resync control for PT3</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- INTFL: Pulse Train Interrupt Flags -->
+      <register>
+        <name>INTFL</name>
+        <description>Pulse Train Interrupt Flags</description>
+        <addressOffset>0x0008</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Stopped Interrupt Flag</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Stopped Interrupt Flag</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Stopped Interrupt Flag</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Stopped Interrupt Flag</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- INTEN: Pulse Train Interrupt Enable/Disable -->
+      <register>
+        <name>INTEN</name>
+        <description>Pulse Train Interrupt Enable/Disable</description>
+        <addressOffset>0x000C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!--SAFE_EN: Pulse Train Global Safe Enable -->
+      <register>
+        <name>SAFE_EN</name>
+        <description>Pulse Train Global Safe Enable.</description>
+        <addressOffset>0x0010</addressOffset>
+        <access>write-only</access>
+        <fields>
+          <field>
+            <name>PT0</name>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT1</name>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT2</name>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT3</name>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+        </fields>
+      </register>
+      <!--SAFE_DIS: Pulse Train Global Safe Disable-->
+      <register>
+        <name>SAFE_DIS</name>
+        <description>Pulse Train Global Safe Disable.</description>
+        <addressOffset>0x0014</addressOffset>
+        <access>write-only</access>
+        <fields>
+          <field>
+            <name>PT0</name>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT1</name>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT2</name>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT3</name>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+        </fields>
+      </register>
+    </registers>
+  </peripheral>
+</device>

--- a/Libraries/PeriphDrivers/Source/PT/ptg_reva1_8pt.svd
+++ b/Libraries/PeriphDrivers/Source/PT/ptg_reva1_8pt.svd
@@ -1,0 +1,397 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <peripheral>
+    <name>PTG</name>
+    <description>Pulse Train Generation</description>
+    <groupName>Pulse_Train</groupName>
+    <baseAddress>0x4003C000</baseAddress>
+    <size>32</size>
+    <access>read-write</access>
+    <addressBlock>
+      <offset>0</offset>
+      <size>0x0020</size>
+      <usage>registers</usage>
+    </addressBlock>
+    <interrupt>
+      <name>PT</name>
+      <description>Pulse Train IRQ</description>
+      <value>59</value>
+    </interrupt>
+    <registers>
+      <!-- ENABLE: Global Enable/Disable Controls for All Pulse Trains -->
+      <register>
+        <name>ENABLE</name>
+        <description>Global Enable/Disable Controls for All Pulse Trains</description>
+        <addressOffset>0x0000</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Enable/Disable control for PT0</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Enable/Disable control for PT1</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Enable/Disable control for PT2</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Enable/Disable control for PT3</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Enable/Disable control for PT4</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Enable/Disable control for PT5</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Enable/Disable control for PT6</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Enable/Disable control for PT7</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- RESYNC: Global Resync (All Pulse Trains) Control -->
+      <register>
+        <name>RESYNC</name>
+        <description>Global Resync (All Pulse Trains) Control</description>
+        <addressOffset>0x0004</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Resync control for PT0</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Resync control for PT1</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Resync control for PT2</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Resync control for PT3</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Resync control for PT4</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Resync control for PT5</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Resync control for PT6</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Resync control for PT7</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- INTFL: Pulse Train Interrupt Flags -->
+      <register>
+        <name>INTFL</name>
+        <description>Pulse Train Interrupt Flags</description>
+        <addressOffset>0x0008</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Stopped Interrupt Flag</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Stopped Interrupt Flag</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Stopped Interrupt Flag</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Stopped Interrupt Flag</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Pulse Train 4 Stopped Interrupt Flag</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Pulse Train 5 Stopped Interrupt Flag</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Pulse Train 6 Stopped Interrupt Flag</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Pulse Train 7 Stopped Interrupt Flag</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- INTEN: Pulse Train Interrupt Enable/Disable -->
+      <register>
+        <name>INTEN</name>
+        <description>Pulse Train Interrupt Enable/Disable</description>
+        <addressOffset>0x000C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!--SAFE_EN: Pulse Train Global Safe Enable -->
+      <register>
+        <name>SAFE_EN</name>
+        <description>Pulse Train Global Safe Enable.</description>
+        <addressOffset>0x0010</addressOffset>
+        <access>write-only</access>
+        <fields>
+          <field>
+            <name>PT0</name>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT1</name>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT2</name>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT3</name>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT4</name>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT5</name>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT6</name>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT7</name>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+        </fields>
+      </register>
+      <!--SAFE_DIS: Pulse Train Global Safe Disable-->
+      <register>
+        <name>SAFE_DIS</name>
+        <description>Pulse Train Global Safe Disable.</description>
+        <addressOffset>0x0014</addressOffset>
+        <access>write-only</access>
+        <fields>
+          <field>
+            <name>PT0</name>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT1</name>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT2</name>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT3</name>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT4</name>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT5</name>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT6</name>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT7</name>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+        </fields>
+      </register>
+    </registers>
+  </peripheral>
+</device>

--- a/Libraries/PeriphDrivers/Source/PT/ptg_reva2_16pt.svd
+++ b/Libraries/PeriphDrivers/Source/PT/ptg_reva2_16pt.svd
@@ -1,0 +1,959 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <peripheral>
+    <name>PTG</name>
+    <description>Pulse Train Generation</description>
+    <groupName>Pulse_Train</groupName>
+    <baseAddress>0x4003C000</baseAddress>
+    <size>32</size>
+    <access>read-write</access>
+    <addressBlock>
+      <offset>0</offset>
+      <size>0x0020</size>
+      <usage>registers</usage>
+    </addressBlock>
+    <interrupt>
+      <name>PT</name>
+      <description>Pulse Train IRQ</description>
+      <value>59</value>
+    </interrupt>
+    <registers>
+      <!-- ENABLE: Global Enable/Disable Controls for All Pulse Trains -->
+      <register>
+        <name>ENABLE</name>
+        <description>Global Enable/Disable Controls for All Pulse Trains</description>
+        <addressOffset>0x0000</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Enable/Disable control for PT0</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Enable/Disable control for PT1</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Enable/Disable control for PT2</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Enable/Disable control for PT3</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Enable/Disable control for PT4</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Enable/Disable control for PT5</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Enable/Disable control for PT6</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Enable/Disable control for PT7</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt8</name>
+            <description>Enable/Disable control for PT8</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Enable/Disable control for PT9</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Enable/Disable control for PT10</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Enable/Disable control for PT11</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Enable/Disable control for PT12</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Enable/Disable control for PT13</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Enable/Disable control for PT14</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Enable/Disable control for PT15</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- RESYNC: Global Resync (All Pulse Trains) Control -->
+      <register>
+        <name>RESYNC</name>
+        <description>Global Resync (All Pulse Trains) Control</description>
+        <addressOffset>0x0004</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Resync control for PT0</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Resync control for PT1</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Resync control for PT2</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Resync control for PT3</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Resync control for PT4</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Resync control for PT5</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Resync control for PT6</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Resync control for PT7</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt8</name>
+            <description>Resync control for PT8</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Resync control for PT9</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Resync control for PT10</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Resync control for PT11</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Resync control for PT12</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Resync control for PT13</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Resync control for PT14</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Resync control for PT15</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- STOP_INTFL: Pulse Train Stopped Interrupt Flags -->
+      <register>
+        <name>STOP_INTFL</name>
+        <description>Pulse Train Interrupt Flags</description>
+        <addressOffset>0x0008</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Stopped Interrupt Flag</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Stopped Interrupt Flag</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Stopped Interrupt Flag</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Stopped Interrupt Flag</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Pulse Train 4 Stopped Interrupt Flag</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Pulse Train 5 Stopped Interrupt Flag</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Pulse Train 6 Stopped Interrupt Flag</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Pulse Train 7 Stopped Interrupt Flag</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt8</name>
+            <description>Pulse Train 8 Stopped Interrupt Flag</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Pulse Train 9 Stopped Interrupt Flag</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Pulse Train 10 Stopped Interrupt Flag</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Pulse Train 11 Stopped Interrupt Flag</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Pulse Train 12 Stopped Interrupt Flag</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Pulse Train 13 Stopped Interrupt Flag</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Pulse Train 14 Stopped Interrupt Flag</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Pulse Train 15 Stopped Interrupt Flag</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!-- STOP_INTEN: Pulse Train Stopped Interrupt Enable/Disable -->
+      <register>
+        <name>STOP_INTEN</name>
+        <description>Pulse Train Interrupt Enable/Disable</description>
+        <addressOffset>0x000C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Pulse Train 4 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Pulse Train 5 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Pulse Train 6 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Pulse Train 7 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt8</name>
+            <description>Pulse Train 8 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Pulse Train 9 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Pulse Train 10 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Pulse Train 11 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Pulse Train 12 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Pulse Train 13 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Pulse Train 14 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Pulse Train 15 Stopped Interrupt Enable/Disable</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!--SAFE_EN: Pulse Train Global Safe Enable -->
+      <register>
+        <name>SAFE_EN</name>
+        <description>Pulse Train Global Safe Enable.</description>
+        <addressOffset>0x0010</addressOffset>
+        <access>write-only</access>
+        <fields>
+          <field>
+            <name>PT0</name>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT1</name>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT2</name>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT3</name>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT4</name>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT5</name>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT6</name>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT7</name>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT8</name>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT9</name>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT10</name>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT11</name>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT12</name>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT13</name>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT14</name>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT15</name>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+        </fields>
+      </register>
+      <!--SAFE_DIS: Pulse Train Global Safe Disable-->
+      <register>
+        <name>SAFE_DIS</name>
+        <description>Pulse Train Global Safe Disable.</description>
+        <addressOffset>0x0014</addressOffset>
+        <access>write-only</access>
+        <fields>
+          <field>
+            <name>PT0</name>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT1</name>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT2</name>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT3</name>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT4</name>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT5</name>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT6</name>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT7</name>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT8</name>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT9</name>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT10</name>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT11</name>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT12</name>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT13</name>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT14</name>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+          <field>
+            <name>PT15</name>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>write-only</access>
+          </field>
+        </fields>
+      </register>
+      <!--READY_INTFL: Pulse Train Ready Interrupt Flags -->
+      <register>
+        <name>READY_INTFL</name>
+        <description>Pulse Train Ready Interrupt Flags</description>
+        <addressOffset>0x0018</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Ready Interrupt Flag</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Ready Interrupt Flag</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Ready Interrupt Flag</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Ready Interrupt Flag</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Pulse Train 4 Ready Interrupt Flag</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Pulse Train 5 Ready Interrupt Flag</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Pulse Train 6 Ready Interrupt Flag</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Pulse Train 7 Ready Interrupt Flag</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt8</name>
+            <description>Pulse Train 8 Ready Interrupt Flag</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Pulse Train 9 Ready Interrupt Flag</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Pulse Train 10 Ready Interrupt Flag</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Pulse Train 11 Ready Interrupt Flag</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Pulse Train 12 Ready Interrupt Flag</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Pulse Train 13 Ready Interrupt Flag</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Pulse Train 14 Ready Interrupt Flag</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Pulse Train 15 Ready Interrupt Flag</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!--READY_INTEN: Pulse Train Ready Interrupt Enable/Disable -->
+      <register>
+        <name>READY_INTEN</name>
+        <description>Pulse Train Ready Interrupt Enable/Disable</description>
+        <addressOffset>0x001C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Pulse Train 4 Ready Interrupt Enable/Disable</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Pulse Train 5 Ready Interrupt Enable/Disable</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Pulse Train 6 Ready Interrupt Enable/Disable</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Pulse Train 7 Ready Interrupt Enable/Disable</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt8</name>
+            <description>Pulse Train 8 Ready Interrupt Enable/Disable</description>
+            <bitOffset>8</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt9</name>
+            <description>Pulse Train 9 Ready Interrupt Enable/Disable</description>
+            <bitOffset>9</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt10</name>
+            <description>Pulse Train 10 Ready Interrupt Enable/Disable</description>
+            <bitOffset>10</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt11</name>
+            <description>Pulse Train 11 Ready Interrupt Enable/Disable</description>
+            <bitOffset>11</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt12</name>
+            <description>Pulse Train 12 Ready Interrupt Enable/Disable</description>
+            <bitOffset>12</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt13</name>
+            <description>Pulse Train 13 Ready Interrupt Enable/Disable</description>
+            <bitOffset>13</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt14</name>
+            <description>Pulse Train 14 Ready Interrupt Enable/Disable</description>
+            <bitOffset>14</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt15</name>
+            <description>Pulse Train 15 Ready Interrupt Enable/Disable</description>
+            <bitOffset>15</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+    </registers>
+  </peripheral>
+</device>

--- a/Libraries/PeriphDrivers/Source/PT/ptg_reva2_4pt.svd
+++ b/Libraries/PeriphDrivers/Source/PT/ptg_reva2_4pt.svd
@@ -55,8 +55,7 @@
           </field>
         </fields>
       </register>
-      <!-- RESYNC:
-                                                                                                         Global Resync (All Pulse Trains) Control -->
+      <!-- RESYNC: Global Resync (All Pulse Trains) Control -->
       <register>
         <name>RESYNC</name>
         <description>Global Resync (All Pulse Trains) Control</description>
@@ -93,11 +92,10 @@
           </field>
         </fields>
       </register>
-      <!-- INTFL:
-                                                                                                                                                                         Pulse Train Interrupt Flags -->
+      <!-- STOP_INTFL: Pulse Train Stopped Interrupt Flags -->
       <register>
-        <name>INTFL</name>
-        <description>Pulse Train Interrupt Flags</description>
+        <name>STOP_INTFL</name>
+        <description>Pulse Train Stop Interrupt Flags</description>
         <addressOffset>0x0008</addressOffset>
         <access>read-write</access>
         <fields>
@@ -131,11 +129,10 @@
           </field>
         </fields>
       </register>
-      <!-- INTEN:
-                                                                                                                                                                         Pulse Train Interrupt Enable/Disable -->
+      <!-- STOP_INTEN: Pulse Train Stopped Interrupt Enable/Disable -->
       <register>
-        <name>INTEN</name>
-        <description>Pulse Train Interrupt Enable/Disable</description>
+        <name>STOP_INTEN</name>
+        <description>Pulse Train Stop Interrupt Enable/Disable</description>
         <addressOffset>0x000C</addressOffset>
         <access>read-write</access>
         <fields>
@@ -169,6 +166,7 @@
           </field>
         </fields>
       </register>
+      <!--SAFE_EN: Pulse Train Global Safe Enable -->
       <register>
         <name>SAFE_EN</name>
         <description>Pulse Train Global Safe Enable.</description>
@@ -201,6 +199,7 @@
           </field>
         </fields>
       </register>
+      <!--SAFE_DIS: Pulse Train Global Safe Disable-->
       <register>
         <name>SAFE_DIS</name>
         <description>Pulse Train Global Safe Disable.</description>
@@ -230,6 +229,80 @@
             <bitOffset>3</bitOffset>
             <bitWidth>1</bitWidth>
             <access>write-only</access>
+          </field>
+        </fields>
+      </register>
+      <!--READY_INTFL: Pulse Train Ready Interrupt Flags -->
+      <register>
+        <name>READY_INTFL</name>
+        <description>Pulse Train Ready Interrupt Flags</description>
+        <addressOffset>0x0018</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Ready Interrupt Flag</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Ready Interrupt Flag</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Ready Interrupt Flag</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Ready Interrupt Flag</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!--READY_INTEN: Pulse Train Ready Interrupt Enable/Disable -->
+      <register>
+        <name>READY_INTEN</name>
+        <description>Pulse Train Ready Interrupt Enable/Disable</description>
+        <addressOffset>0x001C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
           </field>
         </fields>
       </register>

--- a/Libraries/PeriphDrivers/Source/PT/ptg_reva2_8pt.svd
+++ b/Libraries/PeriphDrivers/Source/PT/ptg_reva2_8pt.svd
@@ -9,7 +9,7 @@
     <access>read-write</access>
     <addressBlock>
       <offset>0</offset>
-      <size>0x0018</size>
+      <size>0x0020</size>
       <usage>registers</usage>
     </addressBlock>
     <interrupt>
@@ -81,62 +81,6 @@
             <bitWidth>1</bitWidth>
             <access>read-write</access>
           </field>
-          <field>
-            <name>pt8</name>
-            <description>Enable/Disable control for PT8</description>
-            <bitOffset>8</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt9</name>
-            <description>Enable/Disable control for PT9</description>
-            <bitOffset>9</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt10</name>
-            <description>Enable/Disable control for PT10</description>
-            <bitOffset>10</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt11</name>
-            <description>Enable/Disable control for PT11</description>
-            <bitOffset>11</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt12</name>
-            <description>Enable/Disable control for PT12</description>
-            <bitOffset>12</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt13</name>
-            <description>Enable/Disable control for PT13</description>
-            <bitOffset>13</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt14</name>
-            <description>Enable/Disable control for PT14</description>
-            <bitOffset>14</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt15</name>
-            <description>Enable/Disable control for PT15</description>
-            <bitOffset>15</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
         </fields>
       </register>
       <!-- RESYNC: Global Resync (All Pulse Trains) Control -->
@@ -202,68 +146,12 @@
             <bitWidth>1</bitWidth>
             <access>read-write</access>
           </field>
-          <field>
-            <name>pt8</name>
-            <description>Resync control for PT8</description>
-            <bitOffset>8</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt9</name>
-            <description>Resync control for PT9</description>
-            <bitOffset>9</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt10</name>
-            <description>Resync control for PT10</description>
-            <bitOffset>10</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt11</name>
-            <description>Resync control for PT11</description>
-            <bitOffset>11</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt12</name>
-            <description>Resync control for PT12</description>
-            <bitOffset>12</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt13</name>
-            <description>Resync control for PT13</description>
-            <bitOffset>13</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt14</name>
-            <description>Resync control for PT14</description>
-            <bitOffset>14</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt15</name>
-            <description>Resync control for PT15</description>
-            <bitOffset>15</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
         </fields>
       </register>
-      <!-- INTFL: Pulse Train Interrupt Flags -->
+      <!-- STOP_INTFL: Pulse Train Stopped Interrupt Flags -->
       <register>
-        <name>INTFL</name>
-        <description>Pulse Train Interrupt Flags</description>
+        <name>STOP_INTFL</name>
+        <description>Pulse Train Stop Interrupt Flags</description>
         <addressOffset>0x0008</addressOffset>
         <access>read-write</access>
         <fields>
@@ -323,68 +211,12 @@
             <bitWidth>1</bitWidth>
             <access>read-write</access>
           </field>
-          <field>
-            <name>pt8</name>
-            <description>Pulse Train 8 Stopped Interrupt Flag</description>
-            <bitOffset>8</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt9</name>
-            <description>Pulse Train 9 Stopped Interrupt Flag</description>
-            <bitOffset>9</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt10</name>
-            <description>Pulse Train 10 Stopped Interrupt Flag</description>
-            <bitOffset>10</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt11</name>
-            <description>Pulse Train 11 Stopped Interrupt Flag</description>
-            <bitOffset>11</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt12</name>
-            <description>Pulse Train 12 Stopped Interrupt Flag</description>
-            <bitOffset>12</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt13</name>
-            <description>Pulse Train 13 Stopped Interrupt Flag</description>
-            <bitOffset>13</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt14</name>
-            <description>Pulse Train 14 Stopped Interrupt Flag</description>
-            <bitOffset>14</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt15</name>
-            <description>Pulse Train 15 Stopped Interrupt Flag</description>
-            <bitOffset>15</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
         </fields>
       </register>
-      <!-- INTEN: Pulse Train Interrupt Enable/Disable -->
+      <!-- STOP_INTEN: Pulse Train Stopped Interrupt Enable/Disable -->
       <register>
-        <name>INTEN</name>
-        <description>Pulse Train Interrupt Enable/Disable</description>
+        <name>STOP_INTEN</name>
+        <description>Pulse Train Stop Interrupt Enable/Disable</description>
         <addressOffset>0x000C</addressOffset>
         <access>read-write</access>
         <fields>
@@ -444,64 +276,9 @@
             <bitWidth>1</bitWidth>
             <access>read-write</access>
           </field>
-          <field>
-            <name>pt8</name>
-            <description>Pulse Train 8 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>8</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt9</name>
-            <description>Pulse Train 9 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>9</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt10</name>
-            <description>Pulse Train 10 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>10</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt11</name>
-            <description>Pulse Train 11 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>11</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt12</name>
-            <description>Pulse Train 12 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>12</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt13</name>
-            <description>Pulse Train 13 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>13</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt14</name>
-            <description>Pulse Train 14 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>14</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
-          <field>
-            <name>pt15</name>
-            <description>Pulse Train 15 Stopped Interrupt Enable/Disable</description>
-            <bitOffset>15</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>read-write</access>
-          </field>
         </fields>
       </register>
+      <!--SAFE_EN: Pulse Train Global Safe Enable -->
       <register>
         <name>SAFE_EN</name>
         <description>Pulse Train Global Safe Enable.</description>
@@ -556,56 +333,9 @@
             <bitWidth>1</bitWidth>
             <access>write-only</access>
           </field>
-          <field>
-            <name>PT8</name>
-            <bitOffset>8</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>write-only</access>
-          </field>
-          <field>
-            <name>PT9</name>
-            <bitOffset>9</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>write-only</access>
-          </field>
-          <field>
-            <name>PT10</name>
-            <bitOffset>10</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>write-only</access>
-          </field>
-          <field>
-            <name>PT11</name>
-            <bitOffset>11</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>write-only</access>
-          </field>
-          <field>
-            <name>PT12</name>
-            <bitOffset>12</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>write-only</access>
-          </field>
-          <field>
-            <name>PT13</name>
-            <bitOffset>13</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>write-only</access>
-          </field>
-          <field>
-            <name>PT14</name>
-            <bitOffset>14</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>write-only</access>
-          </field>
-          <field>
-            <name>PT15</name>
-            <bitOffset>15</bitOffset>
-            <bitWidth>1</bitWidth>
-            <access>write-only</access>
-          </field>
         </fields>
       </register>
+      <!--SAFE_DIS: Pulse Train Global Safe Disable-->
       <register>
         <name>SAFE_DIS</name>
         <description>Pulse Train Global Safe Disable.</description>
@@ -660,53 +390,135 @@
             <bitWidth>1</bitWidth>
             <access>write-only</access>
           </field>
+        </fields>
+      </register>
+      <!--READY_INTFL: Pulse Train Ready Interrupt Flags -->
+      <register>
+        <name>READY_INTFL</name>
+        <description>Pulse Train Ready Interrupt Flags</description>
+        <addressOffset>0x0018</addressOffset>
+        <access>read-write</access>
+        <fields>
           <field>
-            <name>PT8</name>
-            <bitOffset>8</bitOffset>
+            <name>pt0</name>
+            <description>Pulse Train 0 Ready Interrupt Flag</description>
+            <bitOffset>0</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>write-only</access>
+            <access>read-write</access>
           </field>
           <field>
-            <name>PT9</name>
-            <bitOffset>9</bitOffset>
+            <name>pt1</name>
+            <description>Pulse Train 1 Ready Interrupt Flag</description>
+            <bitOffset>1</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>write-only</access>
+            <access>read-write</access>
           </field>
           <field>
-            <name>PT10</name>
-            <bitOffset>10</bitOffset>
+            <name>pt2</name>
+            <description>Pulse Train 2 Ready Interrupt Flag</description>
+            <bitOffset>2</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>write-only</access>
+            <access>read-write</access>
           </field>
           <field>
-            <name>PT11</name>
-            <bitOffset>11</bitOffset>
+            <name>pt3</name>
+            <description>Pulse Train 3 Ready Interrupt Flag</description>
+            <bitOffset>3</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>write-only</access>
+            <access>read-write</access>
           </field>
           <field>
-            <name>PT12</name>
-            <bitOffset>12</bitOffset>
+            <name>pt4</name>
+            <description>Pulse Train 4 Ready Interrupt Flag</description>
+            <bitOffset>4</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>write-only</access>
+            <access>read-write</access>
           </field>
           <field>
-            <name>PT13</name>
-            <bitOffset>13</bitOffset>
+            <name>pt5</name>
+            <description>Pulse Train 5 Ready Interrupt Flag</description>
+            <bitOffset>5</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>write-only</access>
+            <access>read-write</access>
           </field>
           <field>
-            <name>PT14</name>
-            <bitOffset>14</bitOffset>
+            <name>pt6</name>
+            <description>Pulse Train 6 Ready Interrupt Flag</description>
+            <bitOffset>6</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>write-only</access>
+            <access>read-write</access>
           </field>
           <field>
-            <name>PT15</name>
-            <bitOffset>15</bitOffset>
+            <name>pt7</name>
+            <description>Pulse Train 7 Ready Interrupt Flag</description>
+            <bitOffset>7</bitOffset>
             <bitWidth>1</bitWidth>
-            <access>write-only</access>
+            <access>read-write</access>
+          </field>
+        </fields>
+      </register>
+      <!--READY_INTEN: Pulse Train Ready Interrupt Enable/Disable -->
+      <register>
+        <name>READY_INTEN</name>
+        <description>Pulse Train Ready Interrupt Enable/Disable</description>
+        <addressOffset>0x001C</addressOffset>
+        <access>read-write</access>
+        <fields>
+          <field>
+            <name>pt0</name>
+            <description>Pulse Train 0 Ready Interrupt Enable/Disable</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt1</name>
+            <description>Pulse Train 1 Ready Interrupt Enable/Disable</description>
+            <bitOffset>1</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt2</name>
+            <description>Pulse Train 2 Ready Interrupt Enable/Disable</description>
+            <bitOffset>2</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt3</name>
+            <description>Pulse Train 3 Ready Interrupt Enable/Disable</description>
+            <bitOffset>3</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt4</name>
+            <description>Pulse Train 4 Ready Interrupt Enable/Disable</description>
+            <bitOffset>4</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt5</name>
+            <description>Pulse Train 5 Ready Interrupt Enable/Disable</description>
+            <bitOffset>5</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt6</name>
+            <description>Pulse Train 6 Ready Interrupt Enable/Disable</description>
+            <bitOffset>6</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
+          </field>
+          <field>
+            <name>pt7</name>
+            <description>Pulse Train 7 Ready Interrupt Enable/Disable</description>
+            <bitOffset>7</bitOffset>
+            <bitWidth>1</bitWidth>
+            <access>read-write</access>
           </field>
         </fields>
       </register>

--- a/Libraries/PeriphDrivers/Source/PT/ptg_reva_regs.h
+++ b/Libraries/PeriphDrivers/Source/PT/ptg_reva_regs.h
@@ -1,10 +1,11 @@
 /**
- * @file    ptg_regs.h
- * @brief   Registers, Bit Masks and Bit Positions for the PTG Peripheral Module.
+ * @file    ptg_reva_regs.h
+ * @brief   Registers, Bit Masks and Bit Positions for the PTG_REVA Peripheral Module.
+ * @note    This file is @generated.
  */
 
-/* ****************************************************************************
- * Copyright (C) 2016 Maxim Integrated Products, Inc., All Rights Reserved.
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -34,11 +35,10 @@
  * property whatsoever. Maxim Integrated Products, Inc. retains all
  * ownership rights.
  *
- *
- *************************************************************************** */
+ ******************************************************************************/
 
-#ifndef _PTG_REVA_REGS_H_
-#define _PTG_REVA_REGS_H_
+#ifndef LIBRARIES_PERIPHDRIVERS_SOURCE_PTG_PTG_REVA_REGS_H_
+#define LIBRARIES_PERIPHDRIVERS_SOURCE_PTG_PTG_REVA_REGS_H_
 
 /* **** Includes **** */
 #include <stdint.h>
@@ -46,11 +46,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
- 
+
 #if defined (__ICCARM__)
   #pragma system_include
 #endif
- 
+
 #if defined (__CC_ARM)
   #pragma anon_unions
 #endif
@@ -75,378 +75,494 @@ extern "C" {
 /* **** Definitions **** */
 
 /**
- * @ingroup     ptg
- * @defgroup    ptg_registers PTG_Registers
- * @brief       Registers, Bit Masks and Bit Positions for the PTG Peripheral Module.
- * @details Pulse Train Generation
+ * @ingroup     ptg_reva
+ * @defgroup    ptg_reva_registers PTG_REVA_Registers
+ * @brief       Registers, Bit Masks and Bit Positions for the PTG_REVA Peripheral Module.
+ * @details     Pulse Train Generation
  */
 
 /**
- * @ingroup ptg_registers
- * Structure type to access the PTG Registers.
+ * @ingroup ptg_reva_registers
+ * Structure type to access the PTG_REVA Registers.
  */
 typedef struct {
-    __IO uint32_t enable;               /**< <tt>\b 0x0000:</tt> PTG ENABLE Register */
-    __IO uint32_t resync;               /**< <tt>\b 0x0004:</tt> PTG RESYNC Register */
-    __IO uint32_t intfl;                /**< <tt>\b 0x0008:</tt> PTG INTFL Register */
-    __IO uint32_t inten;                /**< <tt>\b 0x000C:</tt> PTG INTEN Register */
-    __O  uint32_t safe_en;              /**< <tt>\b 0x10:</tt> PTG SAFE_EN Register */
-    __O  uint32_t safe_dis;             /**< <tt>\b 0x14:</tt> PTG SAFE_DIS Register */
+    __IO uint32_t enable;               /**< <tt>\b 0x0000:</tt> PTG_REVA ENABLE Register */
+    __IO uint32_t resync;               /**< <tt>\b 0x0004:</tt> PTG_REVA RESYNC Register */
+    __IO uint32_t stop_intfl;           /**< <tt>\b 0x0008:</tt> PTG_REVA STOP_INTFL Register */
+    __IO uint32_t stop_inten;           /**< <tt>\b 0x000C:</tt> PTG_REVA STOP_INTEN Register */
+    __O  uint32_t safe_en;              /**< <tt>\b 0x0010:</tt> PTG_REVA SAFE_EN Register */
+    __O  uint32_t safe_dis;             /**< <tt>\b 0x0014:</tt> PTG_REVA SAFE_DIS Register */
+    __IO uint32_t ready_intfl;          /**< <tt>\b 0x0018:</tt> PTG_REVA READY_INTFL Register */
+    __IO uint32_t ready_inten;          /**< <tt>\b 0x001C:</tt> PTG_REVA READY_INTEN Register */
 } mxc_ptg_reva_regs_t;
 
-/* Register offsets for module PTG */
+/* Register offsets for module PTG_REVA */
 /**
- * @ingroup    ptg_registers
- * @defgroup   PTG_Register_Offsets Register Offsets
- * @brief      PTG Peripheral Register Offsets from the PTG Base Peripheral Address. 
+ * @ingroup    ptg_reva_registers
+ * @defgroup   PTG_REVA_Register_Offsets Register Offsets
+ * @brief      PTG_REVA Peripheral Register Offsets from the PTG_REVA Base Peripheral Address.
  * @{
  */
- #define MXC_R_PTG_REVA_ENABLE                   ((uint32_t)0x00000000UL) /**< Offset from PTG Base Address: <tt> 0x0000</tt> */
- #define MXC_R_PTG_REVA_RESYNC                   ((uint32_t)0x00000004UL) /**< Offset from PTG Base Address: <tt> 0x0004</tt> */
- #define MXC_R_PTG_REVA_INTFL                    ((uint32_t)0x00000008UL) /**< Offset from PTG Base Address: <tt> 0x0008</tt> */
- #define MXC_R_PTG_REVA_INTEN                    ((uint32_t)0x0000000CUL) /**< Offset from PTG Base Address: <tt> 0x000C</tt> */
- #define MXC_R_PTG_REVA_SAFE_EN                  ((uint32_t)0x00000010UL) /**< Offset from PTG Base Address: <tt> 0x0010</tt> */
- #define MXC_R_PTG_REVA_SAFE_DIS                 ((uint32_t)0x00000014UL) /**< Offset from PTG Base Address: <tt> 0x0014</tt> */
-/**@} end of group ptg_registers */
+#define MXC_R_PTG_REVA_ENABLE              ((uint32_t)0x00000000UL) /**< Offset from PTG_REVA Base Address: <tt> 0x0000</tt> */
+#define MXC_R_PTG_REVA_RESYNC              ((uint32_t)0x00000004UL) /**< Offset from PTG_REVA Base Address: <tt> 0x0004</tt> */
+#define MXC_R_PTG_REVA_STOP_INTFL          ((uint32_t)0x00000008UL) /**< Offset from PTG_REVA Base Address: <tt> 0x0008</tt> */
+#define MXC_R_PTG_REVA_STOP_INTEN          ((uint32_t)0x0000000CUL) /**< Offset from PTG_REVA Base Address: <tt> 0x000C</tt> */
+#define MXC_R_PTG_REVA_SAFE_EN             ((uint32_t)0x00000010UL) /**< Offset from PTG_REVA Base Address: <tt> 0x0010</tt> */
+#define MXC_R_PTG_REVA_SAFE_DIS            ((uint32_t)0x00000014UL) /**< Offset from PTG_REVA Base Address: <tt> 0x0014</tt> */
+#define MXC_R_PTG_REVA_READY_INTFL         ((uint32_t)0x00000018UL) /**< Offset from PTG_REVA Base Address: <tt> 0x0018</tt> */
+#define MXC_R_PTG_REVA_READY_INTEN         ((uint32_t)0x0000001CUL) /**< Offset from PTG_REVA Base Address: <tt> 0x001C</tt> */
+/**@} end of group ptg_reva_registers */
 
 /**
- * @ingroup  ptg_registers
- * @defgroup PTG_ENABLE PTG_ENABLE
+ * @ingroup  ptg_reva_registers
+ * @defgroup PTG_REVA_ENABLE PTG_REVA_ENABLE
  * @brief    Global Enable/Disable Controls for All Pulse Trains
  * @{
  */
- #define MXC_F_PTG_REVA_ENABLE_PT0_POS                       0 /**< ENABLE_PT0 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT0                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT0_POS)) /**< ENABLE_PT0 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT0_POS                  0 /**< ENABLE_PT0 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT0                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT0_POS)) /**< ENABLE_PT0 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT1_POS                       1 /**< ENABLE_PT1 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT1                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT1_POS)) /**< ENABLE_PT1 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT1_POS                  1 /**< ENABLE_PT1 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT1                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT1_POS)) /**< ENABLE_PT1 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT2_POS                       2 /**< ENABLE_PT2 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT2                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT2_POS)) /**< ENABLE_PT2 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT2_POS                  2 /**< ENABLE_PT2 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT2                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT2_POS)) /**< ENABLE_PT2 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT3_POS                       3 /**< ENABLE_PT3 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT3                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT3_POS)) /**< ENABLE_PT3 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT3_POS                  3 /**< ENABLE_PT3 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT3                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT3_POS)) /**< ENABLE_PT3 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT4_POS                       4 /**< ENABLE_PT4 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT4                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT4_POS)) /**< ENABLE_PT4 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT4_POS                  4 /**< ENABLE_PT4 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT4                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT4_POS)) /**< ENABLE_PT4 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT5_POS                       5 /**< ENABLE_PT5 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT5                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT5_POS)) /**< ENABLE_PT5 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT5_POS                  5 /**< ENABLE_PT5 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT5                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT5_POS)) /**< ENABLE_PT5 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT6_POS                       6 /**< ENABLE_PT6 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT6                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT6_POS)) /**< ENABLE_PT6 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT6_POS                  6 /**< ENABLE_PT6 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT6                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT6_POS)) /**< ENABLE_PT6 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT7_POS                       7 /**< ENABLE_PT7 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT7                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT7_POS)) /**< ENABLE_PT7 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT7_POS                  7 /**< ENABLE_PT7 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT7                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT7_POS)) /**< ENABLE_PT7 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT8_POS                       8 /**< ENABLE_PT8 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT8                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT8_POS)) /**< ENABLE_PT8 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT8_POS                  8 /**< ENABLE_PT8 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT8                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT8_POS)) /**< ENABLE_PT8 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT9_POS                       9 /**< ENABLE_PT9 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT9                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT9_POS)) /**< ENABLE_PT9 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT9_POS                  9 /**< ENABLE_PT9 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT9                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT9_POS)) /**< ENABLE_PT9 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT10_POS                      10 /**< ENABLE_PT10 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT10                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT10_POS)) /**< ENABLE_PT10 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT10_POS                 10 /**< ENABLE_PT10 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT10                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT10_POS)) /**< ENABLE_PT10 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT11_POS                      11 /**< ENABLE_PT11 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT11                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT11_POS)) /**< ENABLE_PT11 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT11_POS                 11 /**< ENABLE_PT11 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT11                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT11_POS)) /**< ENABLE_PT11 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT12_POS                      12 /**< ENABLE_PT12 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT12                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT12_POS)) /**< ENABLE_PT12 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT12_POS                 12 /**< ENABLE_PT12 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT12                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT12_POS)) /**< ENABLE_PT12 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT13_POS                      13 /**< ENABLE_PT13 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT13                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT13_POS)) /**< ENABLE_PT13 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT13_POS                 13 /**< ENABLE_PT13 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT13                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT13_POS)) /**< ENABLE_PT13 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT14_POS                      14 /**< ENABLE_PT14 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT14                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT14_POS)) /**< ENABLE_PT14 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT14_POS                 14 /**< ENABLE_PT14 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT14                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT14_POS)) /**< ENABLE_PT14 Mask */
 
- #define MXC_F_PTG_REVA_ENABLE_PT15_POS                      15 /**< ENABLE_PT15 Position */
- #define MXC_F_PTG_REVA_ENABLE_PT15                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT15_POS)) /**< ENABLE_PT15 Mask */
+#define MXC_F_PTG_REVA_ENABLE_PT15_POS                 15 /**< ENABLE_PT15 Position */
+#define MXC_F_PTG_REVA_ENABLE_PT15                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_ENABLE_PT15_POS)) /**< ENABLE_PT15 Mask */
 
-/**@} end of group PTG_ENABLE_Register */
+/**@} end of group PTG_REVA_ENABLE_Register */
 
 /**
- * @ingroup  ptg_registers
- * @defgroup PTG_RESYNC PTG_RESYNC
+ * @ingroup  ptg_reva_registers
+ * @defgroup PTG_REVA_RESYNC PTG_REVA_RESYNC
  * @brief    Global Resync (All Pulse Trains) Control
  * @{
  */
- #define MXC_F_PTG_REVA_RESYNC_PT0_POS                       0 /**< RESYNC_PT0 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT0                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT0_POS)) /**< RESYNC_PT0 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT0_POS                  0 /**< RESYNC_PT0 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT0                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT0_POS)) /**< RESYNC_PT0 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT1_POS                       1 /**< RESYNC_PT1 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT1                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT1_POS)) /**< RESYNC_PT1 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT1_POS                  1 /**< RESYNC_PT1 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT1                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT1_POS)) /**< RESYNC_PT1 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT2_POS                       2 /**< RESYNC_PT2 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT2                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT2_POS)) /**< RESYNC_PT2 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT2_POS                  2 /**< RESYNC_PT2 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT2                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT2_POS)) /**< RESYNC_PT2 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT3_POS                       3 /**< RESYNC_PT3 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT3                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT3_POS)) /**< RESYNC_PT3 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT3_POS                  3 /**< RESYNC_PT3 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT3                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT3_POS)) /**< RESYNC_PT3 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT4_POS                       4 /**< RESYNC_PT4 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT4                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT4_POS)) /**< RESYNC_PT4 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT4_POS                  4 /**< RESYNC_PT4 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT4                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT4_POS)) /**< RESYNC_PT4 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT5_POS                       5 /**< RESYNC_PT5 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT5                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT5_POS)) /**< RESYNC_PT5 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT5_POS                  5 /**< RESYNC_PT5 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT5                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT5_POS)) /**< RESYNC_PT5 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT6_POS                       6 /**< RESYNC_PT6 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT6                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT6_POS)) /**< RESYNC_PT6 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT6_POS                  6 /**< RESYNC_PT6 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT6                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT6_POS)) /**< RESYNC_PT6 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT7_POS                       7 /**< RESYNC_PT7 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT7                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT7_POS)) /**< RESYNC_PT7 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT7_POS                  7 /**< RESYNC_PT7 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT7                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT7_POS)) /**< RESYNC_PT7 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT8_POS                       8 /**< RESYNC_PT8 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT8                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT8_POS)) /**< RESYNC_PT8 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT8_POS                  8 /**< RESYNC_PT8 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT8                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT8_POS)) /**< RESYNC_PT8 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT9_POS                       9 /**< RESYNC_PT9 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT9                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT9_POS)) /**< RESYNC_PT9 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT9_POS                  9 /**< RESYNC_PT9 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT9                      ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT9_POS)) /**< RESYNC_PT9 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT10_POS                      10 /**< RESYNC_PT10 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT10                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT10_POS)) /**< RESYNC_PT10 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT10_POS                 10 /**< RESYNC_PT10 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT10                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT10_POS)) /**< RESYNC_PT10 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT11_POS                      11 /**< RESYNC_PT11 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT11                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT11_POS)) /**< RESYNC_PT11 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT11_POS                 11 /**< RESYNC_PT11 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT11                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT11_POS)) /**< RESYNC_PT11 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT12_POS                      12 /**< RESYNC_PT12 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT12                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT12_POS)) /**< RESYNC_PT12 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT12_POS                 12 /**< RESYNC_PT12 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT12                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT12_POS)) /**< RESYNC_PT12 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT13_POS                      13 /**< RESYNC_PT13 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT13                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT13_POS)) /**< RESYNC_PT13 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT13_POS                 13 /**< RESYNC_PT13 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT13                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT13_POS)) /**< RESYNC_PT13 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT14_POS                      14 /**< RESYNC_PT14 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT14                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT14_POS)) /**< RESYNC_PT14 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT14_POS                 14 /**< RESYNC_PT14 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT14                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT14_POS)) /**< RESYNC_PT14 Mask */
 
- #define MXC_F_PTG_REVA_RESYNC_PT15_POS                      15 /**< RESYNC_PT15 Position */
- #define MXC_F_PTG_REVA_RESYNC_PT15                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT15_POS)) /**< RESYNC_PT15 Mask */
+#define MXC_F_PTG_REVA_RESYNC_PT15_POS                 15 /**< RESYNC_PT15 Position */
+#define MXC_F_PTG_REVA_RESYNC_PT15                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_RESYNC_PT15_POS)) /**< RESYNC_PT15 Mask */
 
-/**@} end of group PTG_RESYNC_Register */
+/**@} end of group PTG_REVA_RESYNC_Register */
 
 /**
- * @ingroup  ptg_registers
- * @defgroup PTG_INTFL PTG_INTFL
+ * @ingroup  ptg_reva_registers
+ * @defgroup PTG_REVA_STOP_INTFL PTG_REVA_STOP_INTFL
  * @brief    Pulse Train Interrupt Flags
  * @{
  */
- #define MXC_F_PTG_REVA_INTFL_PT0_POS                        0 /**< INTFL_PT0 Position */
- #define MXC_F_PTG_REVA_INTFL_PT0                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT0_POS)) /**< INTFL_PT0 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT0_POS              0 /**< STOP_INTFL_PT0 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT0                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT0_POS)) /**< STOP_INTFL_PT0 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT1_POS                        1 /**< INTFL_PT1 Position */
- #define MXC_F_PTG_REVA_INTFL_PT1                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT1_POS)) /**< INTFL_PT1 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT1_POS              1 /**< STOP_INTFL_PT1 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT1                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT1_POS)) /**< STOP_INTFL_PT1 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT2_POS                        2 /**< INTFL_PT2 Position */
- #define MXC_F_PTG_REVA_INTFL_PT2                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT2_POS)) /**< INTFL_PT2 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT2_POS              2 /**< STOP_INTFL_PT2 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT2                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT2_POS)) /**< STOP_INTFL_PT2 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT3_POS                        3 /**< INTFL_PT3 Position */
- #define MXC_F_PTG_REVA_INTFL_PT3                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT3_POS)) /**< INTFL_PT3 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT3_POS              3 /**< STOP_INTFL_PT3 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT3                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT3_POS)) /**< STOP_INTFL_PT3 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT4_POS                        4 /**< INTFL_PT4 Position */
- #define MXC_F_PTG_REVA_INTFL_PT4                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT4_POS)) /**< INTFL_PT4 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT4_POS              4 /**< STOP_INTFL_PT4 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT4                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT4_POS)) /**< STOP_INTFL_PT4 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT5_POS                        5 /**< INTFL_PT5 Position */
- #define MXC_F_PTG_REVA_INTFL_PT5                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT5_POS)) /**< INTFL_PT5 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT5_POS              5 /**< STOP_INTFL_PT5 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT5                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT5_POS)) /**< STOP_INTFL_PT5 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT6_POS                        6 /**< INTFL_PT6 Position */
- #define MXC_F_PTG_REVA_INTFL_PT6                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT6_POS)) /**< INTFL_PT6 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT6_POS              6 /**< STOP_INTFL_PT6 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT6                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT6_POS)) /**< STOP_INTFL_PT6 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT7_POS                        7 /**< INTFL_PT7 Position */
- #define MXC_F_PTG_REVA_INTFL_PT7                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT7_POS)) /**< INTFL_PT7 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT7_POS              7 /**< STOP_INTFL_PT7 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT7                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT7_POS)) /**< STOP_INTFL_PT7 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT8_POS                        8 /**< INTFL_PT8 Position */
- #define MXC_F_PTG_REVA_INTFL_PT8                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT8_POS)) /**< INTFL_PT8 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT8_POS              8 /**< STOP_INTFL_PT8 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT8                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT8_POS)) /**< STOP_INTFL_PT8 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT9_POS                        9 /**< INTFL_PT9 Position */
- #define MXC_F_PTG_REVA_INTFL_PT9                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT9_POS)) /**< INTFL_PT9 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT9_POS              9 /**< STOP_INTFL_PT9 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT9                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT9_POS)) /**< STOP_INTFL_PT9 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT10_POS                       10 /**< INTFL_PT10 Position */
- #define MXC_F_PTG_REVA_INTFL_PT10                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT10_POS)) /**< INTFL_PT10 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT10_POS             10 /**< STOP_INTFL_PT10 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT10                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT10_POS)) /**< STOP_INTFL_PT10 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT11_POS                       11 /**< INTFL_PT11 Position */
- #define MXC_F_PTG_REVA_INTFL_PT11                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT11_POS)) /**< INTFL_PT11 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT11_POS             11 /**< STOP_INTFL_PT11 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT11                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT11_POS)) /**< STOP_INTFL_PT11 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT12_POS                       12 /**< INTFL_PT12 Position */
- #define MXC_F_PTG_REVA_INTFL_PT12                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT12_POS)) /**< INTFL_PT12 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT12_POS             12 /**< STOP_INTFL_PT12 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT12                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT12_POS)) /**< STOP_INTFL_PT12 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT13_POS                       13 /**< INTFL_PT13 Position */
- #define MXC_F_PTG_REVA_INTFL_PT13                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT13_POS)) /**< INTFL_PT13 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT13_POS             13 /**< STOP_INTFL_PT13 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT13                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT13_POS)) /**< STOP_INTFL_PT13 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT14_POS                       14 /**< INTFL_PT14 Position */
- #define MXC_F_PTG_REVA_INTFL_PT14                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT14_POS)) /**< INTFL_PT14 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT14_POS             14 /**< STOP_INTFL_PT14 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT14                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT14_POS)) /**< STOP_INTFL_PT14 Mask */
 
- #define MXC_F_PTG_REVA_INTFL_PT15_POS                       15 /**< INTFL_PT15 Position */
- #define MXC_F_PTG_REVA_INTFL_PT15                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTFL_PT15_POS)) /**< INTFL_PT15 Mask */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT15_POS             15 /**< STOP_INTFL_PT15 Position */
+#define MXC_F_PTG_REVA_STOP_INTFL_PT15                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTFL_PT15_POS)) /**< STOP_INTFL_PT15 Mask */
 
-/**@} end of group PTG_INTFL_Register */
+/**@} end of group PTG_REVA_STOP_INTFL_Register */
 
 /**
- * @ingroup  ptg_registers
- * @defgroup PTG_INTEN PTG_INTEN
+ * @ingroup  ptg_reva_registers
+ * @defgroup PTG_REVA_STOP_INTEN PTG_REVA_STOP_INTEN
  * @brief    Pulse Train Interrupt Enable/Disable
  * @{
  */
- #define MXC_F_PTG_REVA_INTEN_PT0_POS                        0 /**< INTEN_PT0 Position */
- #define MXC_F_PTG_REVA_INTEN_PT0                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT0_POS)) /**< INTEN_PT0 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT0_POS              0 /**< STOP_INTEN_PT0 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT0                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT0_POS)) /**< STOP_INTEN_PT0 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT1_POS                        1 /**< INTEN_PT1 Position */
- #define MXC_F_PTG_REVA_INTEN_PT1                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT1_POS)) /**< INTEN_PT1 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT1_POS              1 /**< STOP_INTEN_PT1 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT1                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT1_POS)) /**< STOP_INTEN_PT1 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT2_POS                        2 /**< INTEN_PT2 Position */
- #define MXC_F_PTG_REVA_INTEN_PT2                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT2_POS)) /**< INTEN_PT2 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT2_POS              2 /**< STOP_INTEN_PT2 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT2                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT2_POS)) /**< STOP_INTEN_PT2 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT3_POS                        3 /**< INTEN_PT3 Position */
- #define MXC_F_PTG_REVA_INTEN_PT3                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT3_POS)) /**< INTEN_PT3 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT3_POS              3 /**< STOP_INTEN_PT3 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT3                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT3_POS)) /**< STOP_INTEN_PT3 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT4_POS                        4 /**< INTEN_PT4 Position */
- #define MXC_F_PTG_REVA_INTEN_PT4                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT4_POS)) /**< INTEN_PT4 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT4_POS              4 /**< STOP_INTEN_PT4 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT4                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT4_POS)) /**< STOP_INTEN_PT4 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT5_POS                        5 /**< INTEN_PT5 Position */
- #define MXC_F_PTG_REVA_INTEN_PT5                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT5_POS)) /**< INTEN_PT5 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT5_POS              5 /**< STOP_INTEN_PT5 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT5                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT5_POS)) /**< STOP_INTEN_PT5 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT6_POS                        6 /**< INTEN_PT6 Position */
- #define MXC_F_PTG_REVA_INTEN_PT6                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT6_POS)) /**< INTEN_PT6 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT6_POS              6 /**< STOP_INTEN_PT6 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT6                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT6_POS)) /**< STOP_INTEN_PT6 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT7_POS                        7 /**< INTEN_PT7 Position */
- #define MXC_F_PTG_REVA_INTEN_PT7                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT7_POS)) /**< INTEN_PT7 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT7_POS              7 /**< STOP_INTEN_PT7 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT7                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT7_POS)) /**< STOP_INTEN_PT7 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT8_POS                        8 /**< INTEN_PT8 Position */
- #define MXC_F_PTG_REVA_INTEN_PT8                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT8_POS)) /**< INTEN_PT8 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT8_POS              8 /**< STOP_INTEN_PT8 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT8                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT8_POS)) /**< STOP_INTEN_PT8 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT9_POS                        9 /**< INTEN_PT9 Position */
- #define MXC_F_PTG_REVA_INTEN_PT9                            ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT9_POS)) /**< INTEN_PT9 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT9_POS              9 /**< STOP_INTEN_PT9 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT9                  ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT9_POS)) /**< STOP_INTEN_PT9 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT10_POS                       10 /**< INTEN_PT10 Position */
- #define MXC_F_PTG_REVA_INTEN_PT10                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT10_POS)) /**< INTEN_PT10 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT10_POS             10 /**< STOP_INTEN_PT10 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT10                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT10_POS)) /**< STOP_INTEN_PT10 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT11_POS                       11 /**< INTEN_PT11 Position */
- #define MXC_F_PTG_REVA_INTEN_PT11                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT11_POS)) /**< INTEN_PT11 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT11_POS             11 /**< STOP_INTEN_PT11 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT11                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT11_POS)) /**< STOP_INTEN_PT11 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT12_POS                       12 /**< INTEN_PT12 Position */
- #define MXC_F_PTG_REVA_INTEN_PT12                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT12_POS)) /**< INTEN_PT12 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT12_POS             12 /**< STOP_INTEN_PT12 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT12                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT12_POS)) /**< STOP_INTEN_PT12 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT13_POS                       13 /**< INTEN_PT13 Position */
- #define MXC_F_PTG_REVA_INTEN_PT13                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT13_POS)) /**< INTEN_PT13 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT13_POS             13 /**< STOP_INTEN_PT13 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT13                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT13_POS)) /**< STOP_INTEN_PT13 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT14_POS                       14 /**< INTEN_PT14 Position */
- #define MXC_F_PTG_REVA_INTEN_PT14                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT14_POS)) /**< INTEN_PT14 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT14_POS             14 /**< STOP_INTEN_PT14 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT14                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT14_POS)) /**< STOP_INTEN_PT14 Mask */
 
- #define MXC_F_PTG_REVA_INTEN_PT15_POS                       15 /**< INTEN_PT15 Position */
- #define MXC_F_PTG_REVA_INTEN_PT15                           ((uint32_t)(0x1UL << MXC_F_PTG_REVA_INTEN_PT15_POS)) /**< INTEN_PT15 Mask */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT15_POS             15 /**< STOP_INTEN_PT15 Position */
+#define MXC_F_PTG_REVA_STOP_INTEN_PT15                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_STOP_INTEN_PT15_POS)) /**< STOP_INTEN_PT15 Mask */
 
-/**@} end of group PTG_INTEN_Register */
+/**@} end of group PTG_REVA_STOP_INTEN_Register */
 
 /**
- * @ingroup  ptg_registers
- * @defgroup PTG_SAFE_EN PTG_SAFE_EN
+ * @ingroup  ptg_reva_registers
+ * @defgroup PTG_REVA_SAFE_EN PTG_REVA_SAFE_EN
  * @brief    Pulse Train Global Safe Enable.
  * @{
  */
- #define MXC_F_PTG_REVA_SAFE_EN_PT0_POS                      0 /**< SAFE_EN_PT0 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT0                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT0_POS)) /**< SAFE_EN_PT0 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT0_POS                 0 /**< SAFE_EN_PT0 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT0                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT0_POS)) /**< SAFE_EN_PT0 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT1_POS                      1 /**< SAFE_EN_PT1 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT1                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT1_POS)) /**< SAFE_EN_PT1 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT1_POS                 1 /**< SAFE_EN_PT1 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT1                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT1_POS)) /**< SAFE_EN_PT1 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT2_POS                      2 /**< SAFE_EN_PT2 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT2                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT2_POS)) /**< SAFE_EN_PT2 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT2_POS                 2 /**< SAFE_EN_PT2 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT2                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT2_POS)) /**< SAFE_EN_PT2 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT3_POS                      3 /**< SAFE_EN_PT3 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT3                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT3_POS)) /**< SAFE_EN_PT3 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT3_POS                 3 /**< SAFE_EN_PT3 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT3                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT3_POS)) /**< SAFE_EN_PT3 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT4_POS                      4 /**< SAFE_EN_PT4 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT4                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT4_POS)) /**< SAFE_EN_PT4 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT4_POS                 4 /**< SAFE_EN_PT4 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT4                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT4_POS)) /**< SAFE_EN_PT4 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT5_POS                      5 /**< SAFE_EN_PT5 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT5                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT5_POS)) /**< SAFE_EN_PT5 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT5_POS                 5 /**< SAFE_EN_PT5 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT5                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT5_POS)) /**< SAFE_EN_PT5 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT6_POS                      6 /**< SAFE_EN_PT6 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT6                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT6_POS)) /**< SAFE_EN_PT6 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT6_POS                 6 /**< SAFE_EN_PT6 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT6                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT6_POS)) /**< SAFE_EN_PT6 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT7_POS                      7 /**< SAFE_EN_PT7 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT7                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT7_POS)) /**< SAFE_EN_PT7 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT7_POS                 7 /**< SAFE_EN_PT7 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT7                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT7_POS)) /**< SAFE_EN_PT7 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT8_POS                      8 /**< SAFE_EN_PT8 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT8                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT8_POS)) /**< SAFE_EN_PT8 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT8_POS                 8 /**< SAFE_EN_PT8 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT8                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT8_POS)) /**< SAFE_EN_PT8 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT9_POS                      9 /**< SAFE_EN_PT9 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT9                          ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT9_POS)) /**< SAFE_EN_PT9 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT9_POS                 9 /**< SAFE_EN_PT9 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT9                     ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT9_POS)) /**< SAFE_EN_PT9 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT10_POS                     10 /**< SAFE_EN_PT10 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT10                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT10_POS)) /**< SAFE_EN_PT10 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT10_POS                10 /**< SAFE_EN_PT10 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT10                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT10_POS)) /**< SAFE_EN_PT10 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT11_POS                     11 /**< SAFE_EN_PT11 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT11                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT11_POS)) /**< SAFE_EN_PT11 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT11_POS                11 /**< SAFE_EN_PT11 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT11                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT11_POS)) /**< SAFE_EN_PT11 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT12_POS                     12 /**< SAFE_EN_PT12 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT12                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT12_POS)) /**< SAFE_EN_PT12 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT12_POS                12 /**< SAFE_EN_PT12 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT12                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT12_POS)) /**< SAFE_EN_PT12 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT13_POS                     13 /**< SAFE_EN_PT13 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT13                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT13_POS)) /**< SAFE_EN_PT13 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT13_POS                13 /**< SAFE_EN_PT13 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT13                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT13_POS)) /**< SAFE_EN_PT13 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT14_POS                     14 /**< SAFE_EN_PT14 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT14                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT14_POS)) /**< SAFE_EN_PT14 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT14_POS                14 /**< SAFE_EN_PT14 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT14                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT14_POS)) /**< SAFE_EN_PT14 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_EN_PT15_POS                     15 /**< SAFE_EN_PT15 Position */
- #define MXC_F_PTG_REVA_SAFE_EN_PT15                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT15_POS)) /**< SAFE_EN_PT15 Mask */
+#define MXC_F_PTG_REVA_SAFE_EN_PT15_POS                15 /**< SAFE_EN_PT15 Position */
+#define MXC_F_PTG_REVA_SAFE_EN_PT15                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_EN_PT15_POS)) /**< SAFE_EN_PT15 Mask */
 
-/**@} end of group PTG_SAFE_EN_Register */
+/**@} end of group PTG_REVA_SAFE_EN_Register */
 
 /**
- * @ingroup  ptg_registers
- * @defgroup PTG_SAFE_DIS PTG_SAFE_DIS
+ * @ingroup  ptg_reva_registers
+ * @defgroup PTG_REVA_SAFE_DIS PTG_REVA_SAFE_DIS
  * @brief    Pulse Train Global Safe Disable.
  * @{
  */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT0_POS                     0 /**< SAFE_DIS_PT0 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT0                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT0_POS)) /**< SAFE_DIS_PT0 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT0_POS                0 /**< SAFE_DIS_PT0 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT0                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT0_POS)) /**< SAFE_DIS_PT0 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT1_POS                     1 /**< SAFE_DIS_PT1 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT1                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT1_POS)) /**< SAFE_DIS_PT1 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT1_POS                1 /**< SAFE_DIS_PT1 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT1                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT1_POS)) /**< SAFE_DIS_PT1 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT2_POS                     2 /**< SAFE_DIS_PT2 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT2                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT2_POS)) /**< SAFE_DIS_PT2 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT2_POS                2 /**< SAFE_DIS_PT2 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT2                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT2_POS)) /**< SAFE_DIS_PT2 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT3_POS                     3 /**< SAFE_DIS_PT3 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT3                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT3_POS)) /**< SAFE_DIS_PT3 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT3_POS                3 /**< SAFE_DIS_PT3 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT3                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT3_POS)) /**< SAFE_DIS_PT3 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT4_POS                     4 /**< SAFE_DIS_PT4 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT4                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT4_POS)) /**< SAFE_DIS_PT4 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT4_POS                4 /**< SAFE_DIS_PT4 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT4                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT4_POS)) /**< SAFE_DIS_PT4 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT5_POS                     5 /**< SAFE_DIS_PT5 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT5                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT5_POS)) /**< SAFE_DIS_PT5 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT5_POS                5 /**< SAFE_DIS_PT5 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT5                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT5_POS)) /**< SAFE_DIS_PT5 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT6_POS                     6 /**< SAFE_DIS_PT6 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT6                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT6_POS)) /**< SAFE_DIS_PT6 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT6_POS                6 /**< SAFE_DIS_PT6 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT6                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT6_POS)) /**< SAFE_DIS_PT6 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT7_POS                     7 /**< SAFE_DIS_PT7 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT7                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT7_POS)) /**< SAFE_DIS_PT7 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT7_POS                7 /**< SAFE_DIS_PT7 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT7                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT7_POS)) /**< SAFE_DIS_PT7 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT8_POS                     8 /**< SAFE_DIS_PT8 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT8                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT8_POS)) /**< SAFE_DIS_PT8 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT8_POS                8 /**< SAFE_DIS_PT8 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT8                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT8_POS)) /**< SAFE_DIS_PT8 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT9_POS                     9 /**< SAFE_DIS_PT9 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT9                         ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT9_POS)) /**< SAFE_DIS_PT9 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT9_POS                9 /**< SAFE_DIS_PT9 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT9                    ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT9_POS)) /**< SAFE_DIS_PT9 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT10_POS                    10 /**< SAFE_DIS_PT10 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT10                        ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT10_POS)) /**< SAFE_DIS_PT10 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT10_POS               10 /**< SAFE_DIS_PT10 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT10                   ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT10_POS)) /**< SAFE_DIS_PT10 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT11_POS                    11 /**< SAFE_DIS_PT11 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT11                        ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT11_POS)) /**< SAFE_DIS_PT11 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT11_POS               11 /**< SAFE_DIS_PT11 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT11                   ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT11_POS)) /**< SAFE_DIS_PT11 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT12_POS                    12 /**< SAFE_DIS_PT12 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT12                        ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT12_POS)) /**< SAFE_DIS_PT12 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT12_POS               12 /**< SAFE_DIS_PT12 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT12                   ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT12_POS)) /**< SAFE_DIS_PT12 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT13_POS                    13 /**< SAFE_DIS_PT13 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT13                        ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT13_POS)) /**< SAFE_DIS_PT13 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT13_POS               13 /**< SAFE_DIS_PT13 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT13                   ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT13_POS)) /**< SAFE_DIS_PT13 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT14_POS                    14 /**< SAFE_DIS_PT14 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT14                        ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT14_POS)) /**< SAFE_DIS_PT14 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT14_POS               14 /**< SAFE_DIS_PT14 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT14                   ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT14_POS)) /**< SAFE_DIS_PT14 Mask */
 
- #define MXC_F_PTG_REVA_SAFE_DIS_PT15_POS                    15 /**< SAFE_DIS_PT15 Position */
- #define MXC_F_PTG_REVA_SAFE_DIS_PT15                        ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT15_POS)) /**< SAFE_DIS_PT15 Mask */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT15_POS               15 /**< SAFE_DIS_PT15 Position */
+#define MXC_F_PTG_REVA_SAFE_DIS_PT15                   ((uint32_t)(0x1UL << MXC_F_PTG_REVA_SAFE_DIS_PT15_POS)) /**< SAFE_DIS_PT15 Mask */
 
-/**@} end of group PTG_SAFE_DIS_Register */
+/**@} end of group PTG_REVA_SAFE_DIS_Register */
+
+/**
+ * @ingroup  ptg_reva_registers
+ * @defgroup PTG_REVA_READY_INTFL PTG_REVA_READY_INTFL
+ * @brief    Pulse Train Ready Interrupt Flags
+ * @{
+ */
+#define MXC_F_PTG_REVA_READY_INTFL_PT0_POS             0 /**< READY_INTFL_PT0 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT0                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT0_POS)) /**< READY_INTFL_PT0 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT1_POS             1 /**< READY_INTFL_PT1 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT1                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT1_POS)) /**< READY_INTFL_PT1 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT2_POS             2 /**< READY_INTFL_PT2 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT2                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT2_POS)) /**< READY_INTFL_PT2 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT3_POS             3 /**< READY_INTFL_PT3 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT3                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT3_POS)) /**< READY_INTFL_PT3 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT4_POS             4 /**< READY_INTFL_PT4 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT4                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT4_POS)) /**< READY_INTFL_PT4 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT5_POS             5 /**< READY_INTFL_PT5 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT5                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT5_POS)) /**< READY_INTFL_PT5 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT6_POS             6 /**< READY_INTFL_PT6 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT6                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT6_POS)) /**< READY_INTFL_PT6 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT7_POS             7 /**< READY_INTFL_PT7 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT7                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT7_POS)) /**< READY_INTFL_PT7 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT8_POS             8 /**< READY_INTFL_PT8 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT8                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT8_POS)) /**< READY_INTFL_PT8 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT9_POS             9 /**< READY_INTFL_PT9 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT9                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT9_POS)) /**< READY_INTFL_PT9 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT10_POS            10 /**< READY_INTFL_PT10 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT10                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT10_POS)) /**< READY_INTFL_PT10 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT11_POS            11 /**< READY_INTFL_PT11 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT11                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT11_POS)) /**< READY_INTFL_PT11 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT12_POS            12 /**< READY_INTFL_PT12 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT12                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT12_POS)) /**< READY_INTFL_PT12 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT13_POS            13 /**< READY_INTFL_PT13 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT13                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT13_POS)) /**< READY_INTFL_PT13 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT14_POS            14 /**< READY_INTFL_PT14 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT14                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT14_POS)) /**< READY_INTFL_PT14 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTFL_PT15_POS            15 /**< READY_INTFL_PT15 Position */
+#define MXC_F_PTG_REVA_READY_INTFL_PT15                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTFL_PT15_POS)) /**< READY_INTFL_PT15 Mask */
+
+/**@} end of group PTG_REVA_READY_INTFL_Register */
+
+/**
+ * @ingroup  ptg_reva_registers
+ * @defgroup PTG_REVA_READY_INTEN PTG_REVA_READY_INTEN
+ * @brief    Pulse Train Ready Interrupt Enable/Disable
+ * @{
+ */
+#define MXC_F_PTG_REVA_READY_INTEN_PT0_POS             0 /**< READY_INTEN_PT0 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT0                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT0_POS)) /**< READY_INTEN_PT0 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT1_POS             1 /**< READY_INTEN_PT1 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT1                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT1_POS)) /**< READY_INTEN_PT1 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT2_POS             2 /**< READY_INTEN_PT2 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT2                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT2_POS)) /**< READY_INTEN_PT2 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT3_POS             3 /**< READY_INTEN_PT3 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT3                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT3_POS)) /**< READY_INTEN_PT3 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT4_POS             4 /**< READY_INTEN_PT4 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT4                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT4_POS)) /**< READY_INTEN_PT4 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT5_POS             5 /**< READY_INTEN_PT5 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT5                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT5_POS)) /**< READY_INTEN_PT5 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT6_POS             6 /**< READY_INTEN_PT6 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT6                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT6_POS)) /**< READY_INTEN_PT6 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT7_POS             7 /**< READY_INTEN_PT7 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT7                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT7_POS)) /**< READY_INTEN_PT7 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT8_POS             8 /**< READY_INTEN_PT8 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT8                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT8_POS)) /**< READY_INTEN_PT8 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT9_POS             9 /**< READY_INTEN_PT9 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT9                 ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT9_POS)) /**< READY_INTEN_PT9 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT10_POS            10 /**< READY_INTEN_PT10 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT10                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT10_POS)) /**< READY_INTEN_PT10 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT11_POS            11 /**< READY_INTEN_PT11 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT11                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT11_POS)) /**< READY_INTEN_PT11 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT12_POS            12 /**< READY_INTEN_PT12 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT12                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT12_POS)) /**< READY_INTEN_PT12 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT13_POS            13 /**< READY_INTEN_PT13 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT13                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT13_POS)) /**< READY_INTEN_PT13 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT14_POS            14 /**< READY_INTEN_PT14 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT14                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT14_POS)) /**< READY_INTEN_PT14 Mask */
+
+#define MXC_F_PTG_REVA_READY_INTEN_PT15_POS            15 /**< READY_INTEN_PT15 Position */
+#define MXC_F_PTG_REVA_READY_INTEN_PT15                ((uint32_t)(0x1UL << MXC_F_PTG_REVA_READY_INTEN_PT15_POS)) /**< READY_INTEN_PT15 Mask */
+
+/**@} end of group PTG_REVA_READY_INTEN_Register */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* _PTG_REVA_REGS_H_ */
+#endif // LIBRARIES_PERIPHDRIVERS_SOURCE_PTG_PTG_REVA_REGS_H_


### PR DESCRIPTION
The ME12, ME18, and ME55 will have two more interrupt registers: READY_INTFL (0x18) and READY_INTEN (0x1C). I've renamed the original two interrupt registers: INTFL -> STOP_INTFL (0x08) and INTEN -> STOP_INTEN (0x0C). The ME18 and ME55 are unreleased, and I got the go-ahead to update the ME12 PTG register names.