### PR TITLE
do not run pr if branch is draft

### DIFF
--- a/Examples/MAX32655/BLE_otas/wdxs_file_ext.c
+++ b/Examples/MAX32655/BLE_otas/wdxs_file_ext.c
@@ -267,6 +267,8 @@ static uint8_t wdxsFileWrite(const uint8_t *pBuf, uint8_t *pAddress, uint32_t si
     while (attempts) {
         err += Ext_Flash_Program_Page((uint32_t)pAddress, (uint8_t *)addressToBuf, size,
                                       Ext_Flash_DataLine_Quad);
+        if (err)
+            APP_TRACE_INFO0("failed at 0");
         err += Ext_Flash_Read((uint32_t)pAddress, tempBuff, size, Ext_Flash_DataLine_Quad);
         /* verify data was written correctly */
         if (memcmp(tempBuff, pBuf, size) != 0) {


### PR DESCRIPTION
Would be beneficial to not run BLE_test on branches that are in draft, because the constant commits cause the boards to be hogged up to the PR.
Author can make all their commits in draft mode, and when they are ready to merge they can get PR out of draft mode.
Alternatively they can take it out of draft mode at anytime to test their progress.