### PR TITLE
do not run hardware test if PR is draft

### DIFF
--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: [ self-hosted, btm-ci ]
+    if: github.event.pull_request.draft == false
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Would be beneficial to not run BLE_test on branches that are in draft, because the constant commits cause the boards to be hogged up to the PR.
Author can make all their commits in draft mode, and when they are ready to merge they can get PR out of draft mode.
Alternatively they can take it out of draft mode at anytime to test their progress.