### PR TITLE
ME21: Removed aes_key_regs.h inclusion from max32672.h.

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -46,7 +46,6 @@
 // for grace period before eventually removing support for deprecated features. 10-24-2022
 //>>>
 #include "trimsir_regs.h"
-#include "aes_key_regs.h"
 #include "aes_regs.h"
 //<<<
 


### PR DESCRIPTION
aes_key_regs.h was included in max32672.h from a previous deprecated change with the AES/ECC/TRIMSIR peripherals. This line should have been removed when the AESKEYS were scrubbed.