### PR TITLE
increase busy count

### DIFF
--- a/Libraries/MiscDrivers/ExtMemory/w25.c
+++ b/Libraries/MiscDrivers/ExtMemory/w25.c
@@ -238,7 +238,7 @@ int Ext_Flash_Reset(void)
 
     while (flash_busy()) {
         busy_count++;
-        if (busy_count > 10000) {
+        if (busy_count > 20000) {
             return EF_E_TIME_OUT;
         }
     }


### PR DESCRIPTION
I saw a similar issue with erase function in mx25 driver few months ago  https://github.com/Analog-Devices-MSDK/Libraries-miscDrivers/pull/10/files

This pr increases timeout on the reset function for w25. 
We dont see this issue with EvKits but on the FTHR board it times out.
fixes #376 