### PR TITLE
[MSDK-1042]: Resolving hardfault in MAX32672 LP example.

### DIFF
--- a/Examples/MAX32672/LP/lp.ld
+++ b/Examples/MAX32672/LP/lp.ld
@@ -32,14 +32,11 @@
  ******************************************************************************/
 
 MEMORY {
-    SPIX (rx)  : ORIGIN = 0x08000000, LENGTH = 128M
-    HEADER (rx): ORIGIN = 0x10000000, LENGTH = 0x200 /* 256B SLA Header, start on next page */
-    FLASH (rx) : ORIGIN = 0x10000200, LENGTH = 0x1FFE00 /* Remainder of 2MB flash */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 32k
-    SPID (r)   : ORIGIN = 0x80000000, LENGTH = 512M
+    HEADER (rx) : ORIGIN = 0x10000000, LENGTH = 0x200
+    FLASH (rx)  : ORIGIN = 0x10000200, LENGTH = 1024K - 0x200 /* 1024kB "FLASH" */
+    SRAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 32k
 }
 
-/* Added Oct 9, 2018 to go to correct reset vector. */
 ENTRY(Reset_Handler)
 PROVIDE( _start_SWAP = (((Reset_Handler) >> 24) | (((Reset_Handler) & 0x00FF0000) >> 8) | (((Reset_Handler) & 0x0000FF00) << 8) | ((Reset_Handler) << 24)));
 PROVIDE_HIDDEN( _SLA_Size = _endimage - __end_header );
@@ -47,13 +44,13 @@ PROVIDE( _SLA_Size_SWAP = (((_SLA_Size) >> 24) | (((_SLA_Size) & 0x00FF0000) >> 
 
 /* Sections Definitions */
 SECTIONS {
-	 .sla_header : ALIGN(4)
+     .sb_sla_header : ALIGN(4)
     {
-	FILL(0xFF)
-		KEEP(*(.sb_sla_header)) /* Header for ROM code */ 
-		 __end_header = . ;
-		. = ALIGN(512);
-    } >HEADER
+       FILL(0xFF)
+        KEEP(*(.sb_sla_header)) /* Header for ROM code */ 
+         __end_header = . ;
+        . = ALIGN(512);
+    } > HEADER
 
     .text :
     {
@@ -79,23 +76,12 @@ SECTIONS {
         __exidx_end = .;
     } > FLASH
 
-    /* This section will keep the SPIX data until loaded into the external device */
-    /* Upon initialization of SPIX (user code needs to do this) */
-    .xip_section :
-    {
-        KEEP(*(.xip_section*))
-    } > SPIX AT>FLASH
-
-    __load_start_xip = LOADADDR(.xip_section);
-    __load_length_xip = SIZEOF(.xip_section);
-    
     .data :
     {
         _data = ALIGN(., 4);
         *(.data*)           /*read-write initialized data: initialized global variable*/
         *(.spix_config*)    /* SPIX configuration functions need to be run from SRAM */
         *(.flashprog*)      /* Flash program */
-        
 
         /* These array sections are used by __libc_init_array to call static C++ constructors */
         . = ALIGN(4);
@@ -139,6 +125,7 @@ SECTIONS {
         LONG(0xDEADBEEF);
 
     }  > FLASH
+
     .bss :
     {
         . = ALIGN(4);

--- a/Examples/MAX32672/LP/lp.ld
+++ b/Examples/MAX32672/LP/lp.ld
@@ -35,7 +35,7 @@ MEMORY {
     SPIX (rx)  : ORIGIN = 0x08000000, LENGTH = 128M
     HEADER (rx): ORIGIN = 0x10000000, LENGTH = 0x200 /* 256B SLA Header, start on next page */
     FLASH (rx) : ORIGIN = 0x10000200, LENGTH = 0x1FFE00 /* Remainder of 2MB flash */
-    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 64k
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 32k
     SPID (r)   : ORIGIN = 0x80000000, LENGTH = 512M
 }
 

--- a/Examples/MAX32672/LP/main.c
+++ b/Examples/MAX32672/LP/main.c
@@ -188,7 +188,7 @@ int main(void)
 
     MXC_LP_ROMLightSleepEnable();
 
-    // MXC_LP_SysRam3LightSleepDisable();
+    MXC_LP_SysRam3LightSleepEnable();
     MXC_LP_SysRam2LightSleepEnable();
     MXC_LP_SysRam1LightSleepDisable();
     MXC_LP_SysRam0LightSleepDisable(); // Global variables are in RAM0 and RAM1
@@ -196,7 +196,7 @@ int main(void)
     PRINT("All unused RAMs placed in LIGHT SLEEP mode.\n");
     setTrigger(1);
 
-    // MXC_LP_SysRam3Shutdown();
+    MXC_LP_SysRam3Shutdown();
     MXC_LP_SysRam2Shutdown();
 
     MXC_LP_SysRam1PowerUp();


### PR DESCRIPTION
This PR updates the linkerfile used for the MAX32672 LP example. SRAM 2 and 3 is shutdown in the example so the SRAM usage needs to be contained in SRAM 0 and 1.