### PR TITLE
Setting default BT_VER to 9.

### DIFF
--- a/Libraries/Cordio/controller/build/ble5-ctr/gcc/makefile
+++ b/Libraries/Cordio/controller/build/ble5-ctr/gcc/makefile
@@ -36,7 +36,7 @@ INIT_PERIPHERAL := 1
 INIT_OBSERVER   := 1
 INIT_CENTRAL    := 1
 INIT_ENCRYPTED  := 1
-BT_VER          := 9
+BT_VER          := 11
 
 #--------------------------------------------------------------------------------------------------
 #     Configuration

--- a/Libraries/Cordio/controller/build/ble5-ctr/gcc/makefile
+++ b/Libraries/Cordio/controller/build/ble5-ctr/gcc/makefile
@@ -36,7 +36,7 @@ INIT_PERIPHERAL := 1
 INIT_OBSERVER   := 1
 INIT_CENTRAL    := 1
 INIT_ENCRYPTED  := 1
-BT_VER          := 11
+BT_VER          := 9
 
 #--------------------------------------------------------------------------------------------------
 #     Configuration

--- a/Libraries/Cordio/platform/targets/nordic/sources/pal_cfg.c
+++ b/Libraries/Cordio/platform/targets/nordic/sources/pal_cfg.c
@@ -129,16 +129,16 @@ void palCfgLoadLlParams(uint8_t *pConfig)
   const uint16_t maxGroup     = 1;
   const uint16_t maxStream    = 2;
 #else  /* Default */
-  const uint16_t maxAdvSets   = 6;
-  const uint16_t advDataLen   = 1650;
+  const uint16_t maxAdvSets   = 2;
+  const uint16_t advDataLen   = 256;
   const uint16_t aclDataLen   = 512;
-  const uint16_t maxConn      = 4;
-  const uint16_t maxGroup     = 2;
-  const uint16_t maxStream    = 6;
+  const uint16_t maxConn      = 2;
+  const uint16_t maxGroup     = 1;
+  const uint16_t maxStream    = 2;
 #endif
 
   pCfg->maxAdvSets            = maxAdvSets;
-  pCfg->maxAdvReports         = 8;
+  pCfg->maxAdvReports         = 4;
   pCfg->maxExtAdvDataLen      = advDataLen;
   /* pCfg->defExtAdvDataFragLen */  /* Use default. */
   pCfg->auxDelayUsec          = 0;
@@ -146,10 +146,10 @@ void palCfgLoadLlParams(uint8_t *pConfig)
   pCfg->maxExtScanDataLen     = advDataLen;
   pCfg->maxConn               = maxConn;
   pCfg->maxAclLen             = aclDataLen;
-  pCfg->numTxBufs             = 16;
+  pCfg->numTxBufs             = 8;
   pCfg->numRxBufs             = 8;
-  pCfg->numIsoTxBuf           = 16;
-  pCfg->numIsoRxBuf           = 8;
+  pCfg->numIsoTxBuf           = 0;
+  pCfg->numIsoRxBuf           = 0;
   pCfg->maxIsoSduLen          = aclDataLen;
   pCfg->maxIsoPduLen          = 251;
   pCfg->maxCig                = maxGroup;


### PR DESCRIPTION
Nordic device getting hard fault with HCI UART traffic. Works okay with limited traffic, but hard fault occurs with heavy traffic in automated tests.

``` c
0x00028982 in SystemDefaultHandler () at ../../../../platform/targets/nordic/build/startup_gcc_nrf52840.c:313
313   while (forever);
(gdb) bt
#0  0x00028982 in SystemDefaultHandler () at ../../../../platform/targets/nordic/build/startup_gcc_nrf52840.c:313
#1  <signal handler called>
#2  0x000227f8 in LctrRxIso () at ../../../../controller/sources/ble/lctr/lctr_main_iso.c:676
#3  0x00023de8 in LlRecvIsoData () at ../../../../controller/sources/ble/ll/ll_main_iso.c:143
#4  0x00023c6e in lhciRecvIso () at ../../../../controller/sources/ble/lhci/lhci_evt_iso.c:131
#5  0x00017c20 in lhciService (pType=0x2003ff59 "", pLen=0x2003ff5a, pBuf=0x2003ff5c) at ../../../../controller/sources/ble/lhci/lhci_main.c:288
#6  0x0001c2fe in ChciTrHandler (event=<optimized out>, pMsg=<optimized out>) at ../../../../controller/sources/common/chci/chci_tr.c:542
#7  ChciTrHandler (event=<optimized out>, pMsg=<optimized out>) at ../../../../controller/sources/common/chci/chci_tr.c:526
#8  0x00017a4e in LhciHandler (event=<optimized out>, pMsg=<optimized out>) at ../../../../controller/sources/ble/lhci/lhci_main.c:145
#9  0x000277a6 in wsfOsDispatcher () at ../../../../wsf/sources/targets/baremetal/wsf_os.c:328
#10 0x000277de in WsfOsEnterMainLoop () at ../../../../wsf/sources/targets/baremetal/wsf_os.c:398
#11 0x000004e0 in main () at ../../../../controller/build/ble5-ctr/main.c:184
```
