### PR TITLE
Initialize some pins to VDDIOH on MAX78002EVKIT, MSDK-927

### DIFF
--- a/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
@@ -64,7 +64,8 @@ const unsigned int num_leds = (sizeof(led_pin) / sizeof(mxc_gpio_cfg_t));
 // and therefore must be initialized to VDDIOH to prevent current injection into VDDIO/VDDA
 // in standby, backup, and powerdown modes.
 const uint32_t _port0_vddioh_mask = MXC_GPIO_PIN_0;
-const uint32_t _port1_vddioh_mask = (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11 | MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13 | MXC_GPIO_PIN_14 | MXC_GPIO_PIN_16);
+const uint32_t _port1_vddioh_mask = (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11 | MXC_GPIO_PIN_12 |
+                                     MXC_GPIO_PIN_13 | MXC_GPIO_PIN_14 | MXC_GPIO_PIN_16);
 const uint32_t _port2_vddioh_mask = MXC_GPIO_PIN_2;
 
 // TFT Data/Command pin

--- a/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
@@ -60,6 +60,13 @@ const mxc_gpio_cfg_t led_pin[] = {
 };
 const unsigned int num_leds = (sizeof(led_pin) / sizeof(mxc_gpio_cfg_t));
 
+// The following pins are pulled up to 3V3 via external resistors on the AI87 EVKIT,
+// and therefore must be initialized to VDDIOH to prevent current injection into VDDIO/VDDA
+// in standby, backup, and powerdown modes.
+const uint32_t _port0_vddioh_mask = MXC_GPIO_PIN_0;
+const uint32_t _port1_vddioh_mask = (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11 | MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13 | MXC_GPIO_PIN_14 | MXC_GPIO_PIN_16);
+const uint32_t _port2_vddioh_mask = MXC_GPIO_PIN_2;
+
 // TFT Data/Command pin
 const mxc_gpio_cfg_t tft_dc_pin = { TFT_DC_PORT, TFT_DC_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_NONE,
                                     MXC_GPIO_VSSEL_VDDIOH };
@@ -291,6 +298,12 @@ int Board_Init(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO0);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO2);
+
+    // Set VSSEL to VDDIOH to for any pins that are pulled
+    // up to 3V3 on the EVKIT.
+    MXC_GPIO_SetVSSEL(MXC_GPIO0, MXC_GPIO_VSSEL_VDDIOH, _port0_vddioh_mask);
+    MXC_GPIO_SetVSSEL(MXC_GPIO1, MXC_GPIO_VSSEL_VDDIOH, _port1_vddioh_mask);
+    MXC_GPIO_SetVSSEL(MXC_GPIO2, MXC_GPIO_VSSEL_VDDIOH, _port2_vddioh_mask);
 
     if ((err = Console_Init()) < E_NO_ERROR) {
         return err;

--- a/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78002/EvKit_V1/Source/board.c
@@ -300,7 +300,7 @@ int Board_Init(void)
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO1);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_GPIO2);
 
-    // Set VSSEL to VDDIOH to for any pins that are pulled
+    // Set VSSEL to VDDIOH for any pins that are pulled
     // up to 3V3 on the EVKIT.
     MXC_GPIO_SetVSSEL(MXC_GPIO0, MXC_GPIO_VSSEL_VDDIOH, _port0_vddioh_mask);
     MXC_GPIO_SetVSSEL(MXC_GPIO1, MXC_GPIO_VSSEL_VDDIOH, _port1_vddioh_mask);


### PR DESCRIPTION
This PR initializes some pins that are pulled up to 3v3 on the MAX780002EVKIT.  The board startup file has been modified to set VSSEL of these pins to VDDIOH.

---

From [MSDK-927](https://jira.maxim-ic.com/browse/MSDK-927)

8 GPIOs are configured to use VDDIO (1.8V), but are pulled up to 3V3 via 10kohm resistors on the AI87 external EVKit. This injects current into the VDDIO/VDDA node and causes it to rise to about 2.4V in Standby, Backup and PowerDown modes.

Pin          Resistor

P0.0       R110

P1.10     R98

P1.11     R95

P1.12     R94

P1.13     R93

P1.14     R93

P1.16     R96

P2.2       R104