### PR TITLE
Add Paths ignore to BLE test

### DIFF
--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -7,7 +7,17 @@ on:
   #  branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
+    paths-ignore:
+      # Any files in a docs directory anywhere in the repository.
+      - '**/docs/**'
+      - '**/Documentation/**'
+      # Any README.md file anywhere in the repository.
+      - '**/README.md'	
+      # Any .pdf file anywhere in the repository.
+      - '**/*.pdf'
+      # Any .yml file anywhere in the repository.
+      # can comment this out when testing changinges to THIS yml file
+      - '**/*.yml'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -16,7 +16,7 @@ on:
       # Any .pdf file anywhere in the repository.
       - '**/*.pdf'
       # Any .yml file anywhere in the repository.
-      # can comment this out when testing changinges to THIS yml file
+      # can comment this out when testing changes to THIS yml file
       - '**/*.yml'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Feel free to suggest other paths/extensions to add.

If changes to a PR are only located in the Ignore Paths the BLE test will not run.
Currently we include Cordio  in watched files but it has a `docs` directory being worked on 
this stops BLE test from  running on those changes.