### PR TITLE
MSDK-1008: MAX11261 Driver Implementation

### DIFF
--- a/Examples/MAX32650/ADC_MAX11261/.cproject
+++ b/Examples/MAX32650/ADC_MAX11261/.cproject
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/ADC&quot;"/>				
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="ADC_MAX11261.null.923778415" name="ADC_MAX11261"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/ADC_MAX11261"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32650/ADC_MAX11261/.project
+++ b/Examples/MAX32650/ADC_MAX11261/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ADC_MAX11261</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32650/ADC_MAX11261/.settings/language.settings.xml
+++ b/Examples/MAX32650/ADC_MAX11261/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-426639965303056487" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32650/ADC_MAX11261/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32650/ADC_MAX11261/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32650/ADC_MAX11261/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32650/ADC_MAX11261/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=ADC_MAX11261
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32650
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/README.md
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/README.md
@@ -1,0 +1,547 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+* [Wiki](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/wiki)
+  * If it's not in the readme, check the wiki.
+  * If it's not in the wiki, open a ticket!
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX-series](https://www.maximintegrated.com/en/products/microcontrollers.html) microcontrollers.
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+* [C/C++ VSCode Extension](https://github.com/microsoft/vscode-cpptools)
+* [Maxim Micros SDK](https://www.maximintegrated.com/content/maximintegrated/en/design/software-description.html/swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.maximintegrated.com/en/products/microcontrollers/artificial-intelligence.html/tab4/vd_1_2eaktism#.YyDxHaE8U_Y.mailto).
+
+1. Download & install the Maxim Microcontrollers SDK for your OS from the links below.
+    * [Windows](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018720A)
+    * [MacOS](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MaximSDK installation, taking note of where the MaximSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+8. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+9. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the MaximSDK.  Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        
+        // There may be other settings down here...
+    }
+    ```
+
+10. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+11. That's it!  You're ready to start using Visual Studio Code to develop with Maxim's Microcontrollers.  The MaximSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the SDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note:  You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MaximSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for Maxim's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+  
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+  
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, Maxim's microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MaximSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/MaximIntegratedTechSupport/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MaximSDK.  
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, Maxim's perpiheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.  
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MaximSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+The file named `Makefile` is the "core" file for the project.  It should not be edited directly.  Instead, it offers a number of configuration variables that can be overridden in the `project.mk` file, on the command-line, in your system's environment, or via your IDE.  It also comes with a default configuration that is suitable for most projects.
+
+### Default Build Behavior
+
+By default, the build system will auto-search the root project directory source code (`*.c`) and header files (`*.h`).  The optional "include" and "src" directories are also searched if they exist.
+
+```shell
+Root Project Directory
+├─ project.mk
+├─ Makefile
+├─ *.h
+├─ *.c
+├─include  # <-- Optional
+  └─ *.h
+├─src      # <-- Optional
+  └─ *.c
+```
+
+Additionally, the "core" `Makefile` will come pre-configured for a specific target microcontroller and Board Support Package (BSP).  The default BSP will match the main EVKIT for the device.  In VSCode-Maxim, the two [Basic Config Options](#basic-config-options) can be used to easily override the target microcontroller and BSP.  These options are passed to `make` on the command-line when the ["Build" task](#build-tasks) is run.
+
+For more advanced build configuration, configuration variables should be used.
+
+### How to Set a Configuration Variable
+
+A configuration variable is a [Makefile variable](https://www.gnu.org/software/make/manual/make.html#Using-Variables), and therefore follows the same rules.  However, they have been streamlined to be made much easier to use, so most of the official GNU Make documentation is only needed for advanced use-cases.
+
+To set a configuration variable, use the syntax...
+
+```Makefile
+VARIABLE=VALUE
+```
+
+The `=` operater is used for _most_ configuration variables with a few exceptions (that are clearly documented) when a variable should contain a _list_ of values.  In such cases, use the syntax...
+
+```Makefile
+VARIABLE+=VALUE1
+VARIABLE+=VALUE2
+```
+
+... to _add_ values to the list.
+
+In most cases, you should do this from inside of **project.mk**.  
+
+For example, if I wanted to enable hardware floating-point acceleration for my project, I would use the `MFLOAT_ABI` configuration variable to set its value to `hard`.  The contents of **project.mk** might then look as follows:
+
+(_Inside project.mk_)
+
+```Makefile
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+MFLOAT_ABI=hard # Enable hardware floating point acceleration
+```
+
+It should also be noted that configuration variables can be set on the **command-line** as well.  For example...
+
+```shell
+make MFLOAT_ABI=hard
+```
+
+... will have the same effect.
+
+Additionally, **environment variables** can be used.  For example (on linux)...
+
+```shell
+export TARGET=MAX78000
+```
+
+... will set all projects to build for the MAX78000.
+
+However, there is a precedence hierarchy that should be taken into consideration.
+
+### Precedence Hierarchy
+
+The precedence hierarchy for the value of a configuration variable is:
+
+* **IDE/command-line > project.mk > environment variable > default value**
+
+...meaning if a value is set on the command-line _and_ project.mk, the command-line value will take precedence.  However, the ["override" directive](https://www.gnu.org/software/make/manual/make.html#Override-Directive) can be used in project.mk to give it max precedence.
+
+### Configuration Variables Table
+
+The following configuration variables are available.
+
+| Variable | Description | Example | Details |
+|--- | --- | --- | ---|
+**Target**
+| `TARGET` | Set the target microcontroller | `TARGET=MAX78000` |
+| `BOARD` | Set the Board Support Package (BSP) | `BOARD=FTHR_RevA` | Every microcontroller has a number of BSPs available for it that can be found in the `Libraries/Boards/TARGET` folder of the MaximSDK.  When you change this option, it's usually a good idea to fully clean your project, then re-build.
+**SDK**
+| `MAXIM_PATH` | (Optional) Specify the location of the MaximSDK | `MAXIM_PATH=/path/to/MSDK` | This optional variable can be used to change where the Makefile looks for the MaximSDK.  By default, the Makefile will attempt to locate the MaximSDK with a relative path moving "up" from its original location.  This option is most useful when a project is moved _outside_ of the SDK and you're developing on the command-line, since VS Code and Eclipse will set this via an environment variable.  It's also useful for re-targeting a project to point to the development repository.
+| `CAMERA` | (Optional) Set the Camera drivers to use | `CAMERA=HM0360_MONO` | This option is only useful for the MAX78000 and MAX78002, and sets the camera drivers to use for the project.  Permitted values are `HM01B0`, `HM0360_MONO`, `HM0360_COLOR`, `OV5642`, `OV7692` (default), or `PAG7920`.  Camera drivers can be found in the `Libraries/MiscDrivers/Camera` folder of the MaximSDK.  Depending on the selected camera, a compiler definition may be added to the build. See the `board.mk` Makefile in the active BSP for more details.
+**Source Code**
+| `VPATH` | Where to search for source (.c) files | `VPATH+=your/source/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **source code** files.  If `AUTOSEARCH` is enabled (which it is by default) this controls which paths will be searched.  If `AUTOSEARCH` is disabled, this tells the Makefile where to look for the files specified by `SRCS`.
+| `IPATH` | Where to search for header (.h) files | `IPATH+=your/include/path` | **Use the `+=` operator with this option**.  This controls where the Makefile will look for **header** files.  _Unlike_ the `VPATH` option, this is not related to `AUTOSEARCH`.  Individual header files are _not_ ever manually added into the build.  Instead, you only need to specify the _location_ of your header files.
+| `AUTOSEARCH` | Automatically search for source (.c) files | `AUTOSEARCH=0` | Enable or disable the automatic detection of .c files on `VPATH` (enabled by default).  Set to `0` to disable, or `1` to enable.  If autosearch is disabled, source files must be manually added to `SRCS`.
+| `SRCS` | List of source (.c) files to add to the build | `SRCS+=./my/other/source.c` | **Use the `+=` operator with this option**.  All of the files in this list will be added to the build.  If `AUTOSEARCH` is enabled, this is most useful for adding the full absolute path to a singular source file to selectively add to the build.  If `AUTOSEARCH` is disabled, _all_ of the source files for the project must be added to `SRCS`, and they must also all be located on an entry in `VPATH`.  Otherwise, a full path relative to the Makefile must be used.
+| `PROJECT` | Set the output filename | `PROJECT=MyProject` | This controls the output filename of the build.  File extensions should _not_ be set here since the output file format may vary depending on the build recipe.  For VSCode-Maxim, you should use the [project_name](#project_name) advanced config option instead, which sets `PROJECT` on the command-line [Build Tasks](#build-tasks).
+**Compiler**
+| `MXC_OPTIMIZE_CFLAGS` | Set the optimization level | `MXC_OPTIMIZE_CFLAGS=-O2` | See [Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html) for more details.  Normal builds will default to `-Og`, which is good for debugging, while release builds will default to `-O2`.
+| `PROJ_CFLAGS` | Add a compiler flag to the build | `PROJ_CFLAGS+=-Wextra`, `PROJ_CFLAGS+=-DMYDEFINE` | Compiler flags can be added with this option, including compiler definitions.  For each value, the same syntax should be used as if the compiler flag was passed in via the command-line.  These can include standard [GCC options](https://gcc.gnu.org/onlinedocs/gcc-10.4.0/gcc/Option-Summary.html#Option-Summary) and/or [ARM-specific](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html) options.
+| `MFLOAT_ABI` | Set the floating point acceleration level | `MFLOAT_ABI=hard` | Sets the floating-point acceleration level.  Permitted values are `hard`, `soft`, `softfp` (default).  To enable full hardware acceleration instructions use `hard`, but keep in mind that _all_ libraries your source code uses must also be compiled with `hard`.  If there is any conflict, you'll get a linker error.  For more details, see `-mfloat-abi` under [ARM Options](https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html).
+**Linker**
+| `LINKERFILE` | Set the linkerfile to use | `LINKERFILE=newlinker.ld` | You can use a different linkerfile with this option.  The file should exists in `Libraries/CMSIS/Device/Maxim/TARGET/Source/GCC` in the MaximSDK, or it should be placed inside the root directory of the project.
+**Libraries**
+| `LIB_BOARD` | Include the BSP library (enabled by default) | `LIB_BOARD=0` | Inclusion of the Board-Support Package (BSP) library, which is enabled by default, can be toggled with this variable.  This library contains important startup code specific to a microcontroller's evaluation platform, such as serial port initialization, power sequencing, external peripheral initalization, etc.  Set to `0` to disable, or `1` to enable.
+| `LIB_PERIPHDRIVERS` | Include the peripheral driver library (enabled by default) | `LIB_PERIPHDRIVERS=0` | The peripheral driver library can be toggled with this option.  If disabled, you'll lose access to the higher-level driver functions but still have access to the register-level files.  Set to `0` to disable, or `1` to enable.
+| `LIB_CMSIS_DSP` | Include the CMSIS-DSP library | `LIB_CMSIS_DSP=1` | The [CMSIS-DSP library](https://www.keil.com/pack/doc/CMSIS/DSP/html/index.html) can be enabled with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_CORDIO` | Include the Cordio library | `LIB_CORDIO=1` | The Cordio BLE library can be included with this option.  This is only applicable towards microcontrollers with an integrated BLE controller.
+| `LIB_FCL` | Include the Free Cryptographic Library (FCL) | `LIB_FCL=1` | This option toggles the Free Cryptographic Library (FCL), which is a collection of software-implemented common cryptographic functions can be included with this option.  Set to `0` to disable, or `1` to enable.
+| `LIB_FREERTOS` | Include the FreeRTOS library | `LIB_FREERTOS=1` | The [FreeRTOS](https://freertos.org/) library can be enabled with this option, which is an open-source Real-Time Operating System (RTOS).  Set to `0` to disable, or `1` to enable.
+| `LIB_LC3` | Include the LC3 codec library | `LIB_LC3=1` | This option enables the inclusion of the Low Complexity Communication Codec (LC3), which is an efficient low latency audio codec.  Set to `0` to disable, or `1` to enable.
+| `LIB_LITTLEFS` | Include the littleFS library | `LIB_LITTLEFS=1` | This option toggles the ["Little File System"](https://github.com/littlefs-project/littlefs) library - a small filesystem library designed for microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_LWIP` | Include the lwIP library | `LIB_LWIP=1` | |
+| `LIB_MAXUSB` | Include the MaxUSB library | `LIB_MAXUSB=1` | This option toggles the inclusion of the MAXUSB library, which facilitates the use of the native USB peripherals on some microcontrollers.  Set to `0` to disable, or `1` to enable.
+| `LIB_SDHC` | Include the SDHC library | `LIB_SDHC=1` | This options toggles the Secure Digital High Capacity (SDHC) library, which can be used to interface with SD cards.  Additionally, it enables the [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) library, which implements a generic FAT filesystem.
+**Secure Boot Tools (SBT)**
+| `SBT` | Toggle SBT integration | `SBT=1` | Toggles integration with the [Secure Boot Tools (SBTs)](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7637.html).  These are a suite of applications designed for use with microcontrollers that have secure bootloaders.  When this is enabled, some additional rules become available such as `make sla` and `make scpa`.  Set to `0` to disable or `1` to enable.
+| `MAXIM_SBT_DIR` | Where to find the SBTs | `MAXIM_SBT_DIR=C:/MaximSBT` | This option can be used to manually specify the location of the SBTs.  Usually, this is not necessary.  By default, the `Tools/SBT` directory of the MaximSDK will be searched.  If the [SBT installer](https://www.maximintegrated.com/en/design/software-description.html/swpart=SFW0015360C) is used, it will set the `MAXIM_SBT_DIR` environment variable to point to itself automatically.
+| `TARGET_SEC` | Secure part number to use | `TARGET_SEC=MAX32651` | Some secure microcontrollers have multiple secure variants, and this option can be used to specify the variant to use with the SBTs.  Defaults are intelligently selected, and can be found in `$(MAXIM_SBT_DIR)/SBT-config.mk`
+| `SCP_PACKETS` | Where to build the scp_packets folder | | Defaults to `build/scp_packets` |
+| `TEST_KEY` | Which test key to sign applications with | | Defaults to `$(MAXIM_SBT_DIR)/devices/$(TARGET_SEC)/keys/maximtestcrk.key`, which is the Maxim test key that can be used for development.
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.  
+
+The release package for this project (Located at Tools/VSCode-Maxim in the MaximSDK) contains a `New_Project` folder designed for such purposes.  Additionally, any of the VS Code-enabled Example projects can be copied from the SDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Creating a Project from Scratch
+
+If you want to start from scratch, take this option.
+
+1. Create your project folder.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder created in step 2.  This includes a `.vscode` folder and a `Makefile`.  In the example above, the contents of the 'MyProject' folder would be the following :
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    +-- \.vscode
+    +-- Makefile
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Fundamentally, that's it.  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/MaximIntegratedTechSupport/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/flash.gdb
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/launch.json
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/launch.json
@@ -1,0 +1,104 @@
+{
+    "configurations": [
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },          
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/settings.json
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/settings.json
@@ -1,0 +1,73 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+    
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    
+    "target":"MAX32650",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32650.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"10.2.0-1.2",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+        "${config:board}"
+    ]
+}
+

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/tasks.json
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [                
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",                
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",                
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32650/ADC_MAX11261/ADC_MAX11261.launch
+++ b/Examples/MAX32650/ADC_MAX11261/ADC_MAX11261.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32650.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32650/Include/max32650.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/ADC_MAX11261.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="ADC_MAX11261"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/ADC_MAX11261"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32650/ADC_MAX11261/Makefile
+++ b/Examples/MAX32650/ADC_MAX11261/Makefile
@@ -1,0 +1,399 @@
+# /*******************************************************************************
+# * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+# *
+# * Permission is hereby granted, free of charge, to any person obtaining a
+# * copy of this software and associated documentation files (the "Software"),
+# * to deal in the Software without restriction, including without limitation
+# * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# * and/or sell copies of the Software, and to permit persons to whom the
+# * Software is furnished to do so, subject to the following conditions:
+# *
+# * The above copyright notice and this permission notice shall be included
+# * in all copies or substantial portions of the Software.
+# *
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+# * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# * OTHER DEALINGS IN THE SOFTWARE.
+# *
+# * Except as contained in this notice, the name of Maxim Integrated
+# * Products, Inc. shall not be used except as stated in the Maxim Integrated
+# * Products, Inc. Branding Policy.
+# *
+# * The mere transfer of this software does not imply any licenses
+# * of trade secrets, proprietary technology, copyrights, patents,
+# * trademarks, maskwork rights, or any other form of intellectual
+# * property whatsoever. Maxim Integrated Products, Inc. retains all
+# * ownership rights.
+# *******************************************************************************
+# */
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK 
+# project. The available configuration options can be overridden 
+# in "project.mk", on the command-line, or with system environment 
+# variables.
+
+# See https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration 
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than 
+# this file, but the comments found in this file also outline the 
+# available configuration variables. This file is organized into 
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.  
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are 
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP 
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32650
+TARGET_UC := MAX32650
+TARGET_LC := max32650
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK 
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH 
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+include ./project.mk
+$(info Loaded project.mk)
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.  
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.  
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option. 
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Default optimization level for debug builds (make DEBUG=1 ...)
+# gcc.mk checks for this flag to add some additional debug
+# info to the build, and should be used when you really need to
+# debug.
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Fallback default optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles, who check this too
+export MFLOAT_ABI
+
+ifeq "$(RISCV_CORE)" ""
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+# Check if linkerfile exists
+ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
+# Doesn't exists, attempt to use root project folder.
+LINKERPATH:=.
+endif
+
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
+endif
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the 
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean: 
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+	
+clean: 
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32650/ADC_MAX11261/README.md
+++ b/Examples/MAX32650/ADC_MAX11261/README.md
@@ -1,0 +1,30 @@
+## Description
+
+Demonstrates the use of MAX11261 24-bit Analog-to-Digital converter. By default the program will monitor the analog voltage value of the AIN0 input. A voltage between -Vref (-2.5V) and +Vref (2.5V) can be applied to the input pins.
+
+Conversion results outside the convertor range will be clipped to the minimum or maximum value. The ADC can also detect if the input signal is outside reference voltage boundaries.
+
+Any reading that exceeds the full-scale value of the ADC will have an '*' appended to the value.
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the CN2 (USB/PWR) connector.
+-   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   Connect the analog voltage input to the AIN0 pin. For a quick test you can short RSTN (1.8V) to AIN0.
+
+## Expected Output
+
+The Console UART of the device will output the voltage values in millivolts.
+
+```
+******************** MAX11261 ADC Example ********************
+Demonstrates various features of MAX11261 ADC.
+
+An input voltage between -Vref and +Vref can be applied to AIN
+inputs. Conversion results for any input voltage outside this
+range will be clipped to the minimum or maximum level.
+
+
+    1753 mV at 21360 us
+...
+```

--- a/Examples/MAX32650/ADC_MAX11261/main.c
+++ b/Examples/MAX32650/ADC_MAX11261/main.c
@@ -1,0 +1,294 @@
+/******************************************************************************
+ * Copyright (C) 2022 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   MAX11261 ADC demo application
+ * @details Continuously monitors the ADC channels
+ */
+
+/***** Includes *****/
+#include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#include "mxc_delay.h"
+#include "mxc_errors.h"
+#include "nvic_table.h"
+#include "gpio.h"
+#include "i2c.h"
+#include "tmr.h"
+
+#include "max11261.h"
+
+#include "led.h"
+#include "pb.h"
+
+/***** Definitions *****/
+#define I2C_MASTER	MXC_I2C1	// SDA P2_17; SCL P2_18
+#define I2C_FREQ	100			// 100kHz
+
+#define ADC_V_AVDD      3000	// 3V
+#define ADC_V_REF       2500	// 2.5V
+
+#define ADC_SLAVE_ADDR  0x30	// Depends on ADR0 and ADR1 pins
+
+#define ADC_RST_PORT	MXC_GPIO_PORT_0
+#define ADC_RST_PIN  	16
+#define ADC_INT_PORT	MXC_GPIO_PORT_0
+#define ADC_INT_PIN		17
+
+#define ADC_RST_ACTIVE_LOW  1 // Reset is active low
+
+#define PB_MODE_SWITCH      0 // Use push button 0 for mode switching
+#define PB_CHANNEL_SWITCH   1 // Use push button 1 for channel switching
+
+/**
+ * Event flags that will be handled in main loop
+ */
+#define FLAG_CHANNEL_CHANGED    (0x01UL << 0)
+#define FLAG_RATE_CHANGED       (0x01UL << 1)
+#define FLAG_POLARITY_CHANGED   (0x01UL << 2)
+#define FLAG_FORMAT_CHANGED     (0x01UL << 3)
+#define FLAG_MODE_PRESSED       (0x01UL << 8)
+#define FLAG_CHANNEL_PRESSED    (0x01UL << 9)
+#define FLAG_TMR_100MS          (0x01UL << 16)
+
+/***** Globals *****/
+static volatile uint32_t ticksUs = 0;
+static volatile uint32_t flags = 0;
+
+/***** Functions *****/
+static void pb_irq_handler(void *pb);
+static void sys_timer_handler(void);
+
+static int i2c1_transfer(uint8_t *txbuf, uint8_t txsize, uint8_t *rxbuf,
+        uint8_t rxsize, uint8_t slave)
+{
+    mxc_i2c_req_t req;
+    req.addr = slave;
+    req.i2c = I2C_MASTER;
+    req.restart = 0;
+    req.rx_buf = rxbuf;
+    req.rx_len = rxsize;
+    req.tx_buf = txbuf;
+    req.tx_len = txsize;
+
+    return MXC_I2C_MasterTransaction(&req) == 0 ? 0 : -EIO;
+}
+
+static void max11261_reset_set(int ctrl)
+{
+    MXC_GPIO_OutPut(MXC_GPIO_GET_GPIO(ADC_RST_PORT), 1 << ADC_RST_PIN,
+            (ctrl ^ ADC_RST_ACTIVE_LOW) << ADC_RST_PIN);
+}
+
+static int max11261_ready()
+{
+    return !MXC_GPIO_InGet(MXC_GPIO_GET_GPIO(ADC_INT_PORT), 1 << ADC_INT_PIN);
+}
+
+static inline void delay_us(uint32_t us)
+{
+    MXC_Delay(us);
+}
+
+int main(void)
+{
+	int error;
+	mxc_gpio_cfg_t gpioCfg;
+	mxc_tmr_cfg_t tmrCfg;
+	max11261_conversion_mode_t convMode = MAX11261_SINGLE_CYCLE;
+	max11261_sequencer_mode_t seqMode = MAX11261_SEQ_MODE_1;
+	max11261_adc_channel_t channel = MAX11261_ADC_CHANNEL_0;
+	max11261_pol_t polarity = MAX11261_POL_UNIPOLAR;
+	max11261_fmt_t format = MAX11261_FMT_OFFSET_BINARY;
+	int32_t adcVal;
+	uint32_t tickStart;
+
+    printf("\n******************** ADC Example ********************\n\n");
+    printf("Demonstrates various features of MAX11261 ADC.\n");
+    printf("An input voltage between -Vref and +Vref can be applied to AIN "
+    		"inputs. Conversion results for the input values outside this "
+    		"range will be clipped to the minimum or maximum level\n");
+
+    /* Setup I2C master */
+    error = MXC_I2C_Init(I2C_MASTER, 1, 0);
+    if (error != E_NO_ERROR) {
+    	printf("Failed to initialize I2C%d master!\n", I2C_MASTER, error);
+    	return -1;
+    }
+
+    error = MXC_I2C_SetFrequency(I2C_MASTER, I2C_FREQ * 1000);
+    if (error < 0) {
+    	printf("Failed to set I2C bus speed to %d kHz\n", I2C_FREQ);
+    	return -1;
+    }
+
+    /* Setup reset GPIO */
+	gpioCfg.func = MXC_GPIO_FUNC_OUT;
+	gpioCfg.mask = 1 << ADC_RST_PIN;
+	gpioCfg.pad = MXC_GPIO_PAD_NONE;
+	gpioCfg.port = MXC_GPIO_GET_GPIO(ADC_RST_PORT);
+	gpioCfg.vssel = MXC_GPIO_VSSEL_VDDIO; /* 3V3 */
+	error = MXC_GPIO_Config(&gpioCfg);
+	if (error != E_NO_ERROR) {
+		printf("Failed to configure reset GPIO\n");
+		return -1;
+	}
+
+	/* Setup ready GPIO */
+	gpioCfg.func = MXC_GPIO_FUNC_IN;
+	gpioCfg.mask = 1 << ADC_INT_PIN;
+	gpioCfg.pad = MXC_GPIO_PAD_NONE;
+	gpioCfg.port = MXC_GPIO_GET_GPIO(ADC_INT_PORT);;
+	gpioCfg.vssel = MXC_GPIO_VSSEL_VDDIO; /* 3V3 */
+	//MXC_GPIO_RegisterCallback(&gpioCfg, gpio_irq_handler, NULL);
+	MXC_GPIO_IntConfig(&gpioCfg, MXC_GPIO_INT_FALLING);
+	if (error != E_NO_ERROR) {
+		printf("Failed to configure ready GPIO\n");
+		return -1;
+	}
+	//MXC_GPIO_EnableInt(gpioCfg.port, gpioCfg.mask);
+	//NVIC_EnableIRQ(MXC_GPIO_GET_IRQ(ADC_INT_PORT));
+
+	/* Enable push button interrupts */
+	PB_IntEnable(PB_MODE_SWITCH);
+	PB_IntEnable(PB_CHANNEL_SWITCH);
+	PB_RegisterCallback(PB_MODE_SWITCH, pb_irq_handler);
+	PB_RegisterCallback(PB_CHANNEL_SWITCH, pb_irq_handler);
+
+	/* Setup timer 0 as system tick timer */
+	/* Configure for 1us */
+	tmrCfg.cmp_cnt = (PeripheralClock / 1000000) / 4;
+	tmrCfg.mode = TMR_MODE_CONTINUOUS;
+	tmrCfg.pol = 0;
+	tmrCfg.pres = TMR_PRES_4;
+	MXC_NVIC_SetVector(TMR0_IRQn, sys_timer_handler);
+	NVIC_EnableIRQ(TMR0_IRQn);
+	MXC_TMR_Init(MXC_TMR0, &tmrCfg);
+	MXC_TMR_Start(MXC_TMR0);
+
+	/* Initialize MAX11261 platform specific functions */
+	max11261_adc_platform_init(i2c1_transfer, max11261_reset_set,
+	            delay_us);
+
+	/* Set ADC hardware parameters */
+	error = max11261_adc_config_init(ADC_V_AVDD, ADC_V_REF, I2C_FREQ,
+			ADC_SLAVE_ADDR);
+	if (error != E_NO_ERROR) {
+		printf("Failed to initialize MAX11261\n");
+		return -1;
+	}
+
+	/* Use max11261_ready to check ADC status */
+	max11261_adc_set_ready_func(max11261_ready);
+
+	/* Reset ADC */
+	max11261_adc_reset();
+	max11261_adc_standby();
+
+	/* Set ADC sequencer parameters. Default values are already set by the
+	 * driver */
+	error = max11261_adc_set_channel(channel);
+	if (error < 0) {
+		printf("Failed to set ADC channel to %d: %d\n", channel, error);
+		return -1;
+	}
+
+	error = max11261_adc_set_mode(convMode, seqMode);
+	if (error < 0) {
+		printf("Failed to set conversion and sequencer modes: %d\n", error);
+		return -1;
+	}
+
+	error = max11261_adc_set_polarity(polarity);
+	if (error < 0) {
+		printf("Failed to set ADC polarity: %d\n", error);
+		return -1;
+	}
+
+	error = max11261_adc_set_format(format);
+	if (error < 0) {
+		printf("Failed to set ADC format: %d\n", error);
+	}
+
+	error = max11261_adc_convert_prepare();
+	if (error < 0) {
+		printf("Failed to prepare for conversion: %d\n", error);
+		return -1;
+	}
+
+    while (1) {
+
+        tickStart = ticksUs;
+        switch (convMode) {
+        case MAX11261_LATENT_CONTINUOUS:
+        	break;
+        case MAX11261_SINGLE_CYCLE:
+        	if (max11261_adc_convert() < 0) {
+        		printf("Failed to start conversion\n");
+        		return -1;
+        	}
+
+        	error = max11261_adc_result(&adcVal);
+        	if (error == 0) {
+        		printf("\r     %5d mV at %u us", adcVal, ticksUs - tickStart);
+        	} else {
+        		printf("Error obtaining result: %d\n", error);
+        		return -1;
+        	}
+        	break;
+        case MAX11261_SINGLE_CYCLE_CONTINUOUS:
+        	break;
+        }
+        fflush(stdout);
+    }
+
+    return 0;
+}
+
+static void pb_irq_handler(void *pb)
+{
+    if (pb == (void *) PB_CHANNEL_SWITCH) {
+        flags |= FLAG_CHANNEL_PRESSED;
+    } else if (pb == (void *) PB_MODE_SWITCH) {
+        flags |= FLAG_MODE_PRESSED;
+    }
+}
+
+void sys_timer_handler(void)
+{
+    MXC_TMR_ClearFlags(MXC_TMR0);
+    ticksUs++;
+}

--- a/Examples/MAX32650/ADC_MAX11261/project.mk
+++ b/Examples/MAX32650/ADC_MAX11261/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called 
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://github.com/Analog-Devices-MSDK/VSCode-Maxim/tree/develop#build-configuration
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the 
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+# Add your config here!

--- a/Libraries/Boards/MAX32650/FTHR_APPS_A/Source/board.c
+++ b/Libraries/Boards/MAX32650/FTHR_APPS_A/Source/board.c
@@ -34,16 +34,24 @@
  *
  **************************************************************************** */
 
+#include <errno.h>
 #include <stdio.h>
 #include "mxc_sys.h"
+#include "mxc_delay.h"
 #include "mxc_errors.h"
 #include "mxc_assert.h"
 #include "board.h"
 #include "uart.h"
 #include "gpio.h"
+#include "i2c.h"
 #include "mxc_pins.h"
 #include "led.h"
 #include "pb.h"
+
+#include "max11261.h"
+
+/* **** Definitions **** */
+#define ADC_RST_ACTIVE_LOW  1 // Reset is active low
 
 /* **** Global Variables **** */
 mxc_uart_regs_t *ConsoleUart = MXC_UART_GET_UART(CONSOLE_UART);
@@ -120,20 +128,65 @@ void NMI_Handler(void)
 #endif /* __GNUC__ */
 
 /* ************************************************************************** */
+static int i2c1_transfer(uint8_t *txbuf, uint8_t txsize, uint8_t *rxbuf,
+        uint8_t rxsize, uint8_t slave)
+{
+    mxc_i2c_req_t req;
+    req.addr = slave;
+    req.i2c = MXC_I2C1;
+    req.restart = 0;
+    req.rx_buf = rxbuf;
+    req.rx_len = rxsize;
+    req.tx_buf = txbuf;
+    req.tx_len = txsize;
+
+    return MXC_I2C_MasterTransaction(&req) == 0 ? 0 : -EIO;
+}
+
+static void max11261_reset_set(int ctrl)
+{
+    MXC_GPIO_OutPut(MXC_GPIO0, MXC_GPIO_PIN_16,
+            (ctrl ^ ADC_RST_ACTIVE_LOW) << 16);
+}
+
+static int max11261_ready()
+{
+    return !MXC_GPIO_InGet(MXC_GPIO0, MXC_GPIO_PIN_17);
+}
+
+static inline void delay_us(uint32_t us)
+{
+    MXC_Delay(us);
+}
+
 int MAX11261_Init(void)
 {
     mxc_gpio_cfg_t adc_reset_n;
+    mxc_gpio_cfg_t adc_int_n;
 
+    /* Setup ADC reset GPIO */
     adc_reset_n.func = MXC_GPIO_FUNC_OUT;
     adc_reset_n.pad = MXC_GPIO_PAD_NONE;
     adc_reset_n.port = MXC_GPIO0;
     adc_reset_n.mask = MXC_GPIO_PIN_16;
     MXC_GPIO_Config(&adc_reset_n);
 
-    // Set it to device start to work
-    MXC_GPIO_OutSet(adc_reset_n.port, adc_reset_n.mask);
+    /* Setup ready GPIO */
+    adc_int_n.func = MXC_GPIO_FUNC_IN;
+    adc_int_n.pad = MXC_GPIO_PAD_NONE;
+    adc_int_n.port = MXC_GPIO0;
+    adc_int_n.mask = MXC_GPIO_PIN_17;
+    adc_int_n.vssel = MXC_GPIO_VSSEL_VDDIO; /* 3V3 */
+    //MXC_GPIO_RegisterCallback(&gpioCfg, gpio_irq_handler, NULL);
+    MXC_GPIO_Config(&adc_int_n);
 
-    //...
+    //MXC_GPIO_EnableInt(gpioCfg.port, gpioCfg.mask);
+    //NVIC_EnableIRQ(MXC_GPIO_GET_IRQ(ADC_INT_PORT));
+    /* Initialize MAX11261 platform specific functions */
+    max11261_adc_platform_init(i2c1_transfer, max11261_reset_set, delay_us);
+
+    /* Use max11261_ready to check ADC status */
+    max11261_adc_set_ready_func(max11261_ready);
 
     return E_NO_ERROR;
 }

--- a/Libraries/Boards/MAX32650/FTHR_APPS_A/board.mk
+++ b/Libraries/Boards/MAX32650/FTHR_APPS_A/board.mk
@@ -45,6 +45,7 @@ SRCS += led.c
 SRCS += mx25.c
 SRCS += pb.c
 SRCS += rom_stub.c
+SRCS += max11261.c
 
 PROJ_CFLAGS+=-DEXT_FLASH_MX25
 
@@ -54,8 +55,10 @@ MISC_DRIVERS_DIR=$(LIBS_DIR)/MiscDrivers
 VPATH += $(BOARD_DIR)/Source
 VPATH += $(BOARD_DIR)/../Source
 VPATH += $(MISC_DRIVERS_DIR)/ExtMemory
+VPATH += $(MISC_DRIVERS_DIR)/ADC
 
 # Where to find BSP header files
 IPATH += $(BOARD_DIR)/Include
 IPATH += $(BOARD_DIR)/../Include
 IPATH += $(MISC_DRIVERS_DIR)/ExtMemory
+IPATH += $(MISC_DRIVERS_DIR)/ADC

--- a/Libraries/MiscDrivers/ADC/max11261.c
+++ b/Libraries/MiscDrivers/ADC/max11261.c
@@ -1,0 +1,641 @@
+/**
+ * @file    max11261.c
+ * @brief   MAX11261 driver source.
+ * @details This is the driver source of MAX11261 Analog-to-Digital converter.
+ */
+
+/******************************************************************************
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "max11261.h"
+#include "max11261_regs.h"
+
+/* **** Definitions **** */
+#ifndef DBG_LVL
+#define DBG_LVL 0
+#endif
+
+#if DBG_LVL > 0
+#define log_err(fmt, ...) do { \
+        printf("[MAX11261] ERR: %s:"  fmt "\n", __func__, ##__VA_ARGS__); \
+} while (0)
+#else
+#define log_err(fmt, ...)
+#endif
+
+#if DBG_LVL > 1
+#define log_inf(fmt, ...) do { \
+        printf("[MAX11261] INF: " fmt "\n", ##__VA_ARGS__); \
+} while (0)
+#else
+#define log_inf(fmt, ...)
+#endif
+
+#if DBG_LVL > 2
+#define log_dbg(fmt, ...) do { \
+        printf("[MAX11261] DBG: %s: " fmt "\n", __func__, ##__VA_ARGS__); \
+} while (0)
+#else
+#define log_dbg(fmt, ...)
+#endif
+
+#define MAX11261_V_AVDD_MIN     2700
+#define MAX11261_V_AVDD_MAX     3600
+#define MAX11261_V_REF_MIN      1500
+#define MAX11261_MAX_SERIAL_FREQ    5000 // KHz
+#define MAX11261_MAX_REG_SIZE   4U
+#define MAX11261_CHANNEL_COUNT  6
+#define MAX11261_ADC_RESOLUTION 24
+
+/* **** Variable Declaration **** */
+
+/**
+ * @brief MAX11261 ADC platform context.
+ *
+ * Structure to hold platform specific methods used by this driver.
+ */
+typedef struct {
+    max11261_transfer_func_t transfer;  /**< MCU specific I2C transfer function */
+    max11261_reset_ctrl_t reset;        /**< MCU specific hard reset function */
+    max11261_delay_func_t delayUs;      /**< MCU specific delay function */
+    max11261_ready_func_t ready;        /**< MCU specific ready function */
+} max11261_adc_platform_ctx_t;
+
+/**
+ * @brief Structure to hold configuration parameters.
+ */
+typedef struct {
+    uint16_t avdd;  /**< V_AVDD in millivolts */
+    uint16_t vref;  /**< REFP - REFN in millivolts */
+    uint8_t slave;  /**< I2C slave address */
+    uint8_t freq;   /**< Interface speed */
+    uint8_t res;    /**< ADC resolution */
+} max11261_adc_config_t;
+
+/**
+ * @brief Sequencer parameters.
+ */
+typedef struct {
+    max11261_single_rate_t srate; /**< Conversion rate in single cycle mode */
+    max11261_cont_rate_t crate;   /**< Conversion rate in continuous mode */
+    max11261_adc_channel_t chan;  /**< Conversion channel */
+    max11261_conversion_mode_t convMode;    /**< Conversion mode */
+    max11261_sequencer_mode_t seqMode;      /**< Sequencer mode */
+    max11261_pol_t polarity;      /**< Input polarity */
+    max11261_fmt_t format;        /**< Result format */
+} max11261_adc_seq_t;
+
+struct max11261_reg {
+    const char *name;
+    uint8_t size;
+};
+
+static const struct max11261_reg regs[] = {
+        {"STAT", 3},
+        {"CTRL1", 1},
+        {"CTRL2", 1},
+        {"CTRL3", 1},
+        {"SEQ", 2},
+        {"CHMAP1", 3},
+        {"CHMAP0", 3},
+        {"DELAY", 3},
+        {"LIMIT_LOW0", 3},
+        {"LIMIT_LOW1", 3},
+        {"LIMIT_LOW2", 3},
+        {"LIMIT_LOW3", 3},
+        {"LIMIT_LOW4", 3},
+        {"LIMIT_LOW5", 3},
+        {"SOC", 3},
+        {"SGC", 3},
+        {"SCOC", 3},
+        {"SCGC", 3},
+        {"GPO_DIR", 1},
+        {"FIFO", 4},
+        {"FIFO_LEVEL", 1},
+        {"FIFO_CTRL", 1},
+        {"INPUT_INT_EN", 1},
+        {"INT_STAT", 2},
+        {"HPF", 1},
+        {"LIMIT_HIGH0", 3},
+        {"LIMIT_HIGH1", 3},
+        {"LIMIT_HIGH2", 3},
+        {"LIMIT_HIGH3", 3},
+        {"LIMIT_HIGH4", 3},
+        {"LIMIT_HIGH5", 3},
+};
+
+/**
+ * 10x microseconds delay for each sample rate.
+ */
+static const uint32_t max11261_single_cycle_delay[] = {
+        2000,  // MAX11261_SINGLE_RATE_50
+        1600,  // MAX11261_SINGLE_RATE_62_5
+        1000,  // MAX11261_SINGLE_RATE_100
+        800,   // MAX11261_SINGLE_RATE_125
+        500,   // MAX11261_SINGLE_RATE_200
+        400,   // MAX11261_SINGLE_RATE_250
+        250,   // MAX11261_SINGLE_RATE_400
+        200,   // MAX11261_SINGLE_RATE_500
+        125,   // MAX11261_SINGLE_RATE_800
+        100,   // MAX11261_SINGLE_RATE_1000
+        62,    // MAX11261_SINGLE_RATE_1600
+        50,    // MAX11261_SINGLE_RATE_2000
+        31,    // MAX11261_SINGLE_RATE_3200
+        25,    // MAX11261_SINGLE_RATE_4000
+        16,    // MAX11261_SINGLE_RATE_6400
+        8      // MAX11261_SINGLE_RATE_12800
+};
+
+/* **** Global Variables **** */
+
+/**
+ * @brief Platform specific methods and variables.
+ */
+static max11261_adc_platform_ctx_t platCtx;
+
+/**
+ * @brief Device specific variables.
+ */
+static max11261_adc_config_t cfg;
+
+/**
+ * @brief Variables concerning ADC behaviour.
+ */
+static max11261_adc_seq_t seq = {
+        .srate = MAX11261_SINGLE_RATE_50,
+        .crate = MAX11261_CONT_RATE_1_9,
+        .chan = MAX11261_ADC_CHANNEL_0,
+        .convMode = MAX11261_SINGLE_CYCLE,
+        .seqMode = MAX11261_SEQ_MODE_1,
+        .polarity = MAX11261_POL_UNIPOLAR,
+        .format = MAX11261_FMT_OFFSET_BINARY,
+};
+
+/* **** Function Prototypes **** */
+
+
+void max11261_adc_platform_init(max11261_transfer_func_t transferFunc,
+        max11261_reset_ctrl_t resetCtrl,
+        max11261_delay_func_t delayFunc)
+{
+    platCtx.transfer = transferFunc;
+    platCtx.reset = resetCtrl;
+    platCtx.delayUs = delayFunc;
+    platCtx.ready = NULL;
+}
+
+int max11261_adc_config_init(uint16_t vavdd, uint16_t vref, uint16_t freq,
+        uint8_t slaveAddr)
+{
+    if (vavdd < MAX11261_V_AVDD_MIN || vavdd > MAX11261_V_AVDD_MAX)
+            return -EINVAL;
+
+    if (vref < MAX11261_V_REF_MIN || vref > vavdd)
+        return -EINVAL;
+
+    if (freq < 100 || freq >= MAX11261_MAX_SERIAL_FREQ)
+        return -EINVAL;
+
+    cfg.avdd = vavdd;
+    cfg.vref = vref;
+    cfg.freq = freq;
+    cfg.slave = slaveAddr;
+    cfg.res = MAX11261_ADC_RESOLUTION;
+
+    return 0;
+}
+
+void max11261_adc_set_ready_func(max11261_ready_func_t readyFunc)
+{
+    platCtx.ready = readyFunc;
+}
+
+int max11261_adc_reset(void)
+{
+    int error;
+    platCtx.reset(1);
+    platCtx.delayUs(100);
+    platCtx.reset(0);
+    /* From any state to STANDBY state: 10ms */
+    platCtx.delayUs(10000);
+    error = platCtx.transfer(NULL, 0, NULL, 0, cfg.slave);
+    if (error < 0) {
+        log_err("Probe failed unexpectedly: %d", error);
+        return error;
+    }
+
+    return error;
+}
+
+static int max11261_read_reg(uint8_t addr, uint32_t *val)
+{
+    int error;
+    uint8_t txbuf[0];
+    uint8_t rxbuf[MAX11261_MAX_REG_SIZE];
+
+    txbuf[0] = MAX11261_CMD_READ(addr);
+    error = platCtx.transfer(txbuf, 1, &rxbuf[0], regs[addr].size, cfg.slave);
+    if (error < 0) {
+        log_err("Failed to read reg 0x%02X (%s)", addr, regs[addr].name);
+    } else {
+        switch (regs[addr].size) {
+            case 1:
+                *val = rxbuf[0];
+                break;
+            case 2:
+                *val = rxbuf[1] | rxbuf[0] << 8;
+                break;
+            case 3:
+                *val = rxbuf[2] | rxbuf[1] << 8 | rxbuf[0] << 16;
+                break;
+            case 4:
+            default:
+                *val = rxbuf[3] | rxbuf[2] << 8 | rxbuf[1] << 16
+                | rxbuf[0] << 24;
+                break;
+        }
+    }
+
+    return error;
+}
+
+static inline int max11261_write_byte(uint8_t byte)
+{
+    return platCtx.transfer(&byte, 1, NULL, 0, cfg.slave);
+}
+
+static int max11261_write_reg(uint8_t addr, uint32_t val)
+{
+    int error;
+    uint8_t txbuf[MAX11261_MAX_REG_SIZE + 1];
+
+    txbuf[0] = MAX11261_CMD_WRITE(addr);
+    switch (regs[addr].size) {
+        case 1:
+            txbuf[1] = val & 0xFF;
+            break;
+        case 2:
+            txbuf[1] = (val >> 8) & 0xFF;
+            txbuf[2] = val & 0xFF;
+            break;
+        case 3:
+            txbuf[1] = (val >> 16) & 0xFF;
+            txbuf[2] = (val >> 8) & 0xFF;
+            txbuf[3] = val & 0xFF;
+            break;
+        case 4:
+        default:
+            txbuf[1] = (val >> 24) & 0xFF;
+            txbuf[2] = (val >> 16) & 0xFF;
+            txbuf[3] = (val >> 8) & 0xFF;
+            txbuf[4] = val & 0xFF;
+            break;
+    }
+
+    error = platCtx.transfer(txbuf, regs[addr].size + 1, NULL, 0, cfg.slave);
+    if (error < 0)
+        log_err("Failed to write reg 0x%02X", addr);
+
+    return error;
+}
+
+static int max11261_update_reg(uint8_t addr, uint32_t mask, uint32_t val)
+{
+    int error;
+    uint32_t tmp;
+
+    error = max11261_read_reg(addr, &tmp);
+    if (error < 0)
+        return error;
+
+    tmp &= ~mask;
+    tmp |= val;
+
+    return max11261_write_reg(addr, tmp);
+}
+
+static int max11261_set_powerdown_mode(uint8_t mode)
+{
+    int error;
+    uint32_t val, timeout;
+    uint8_t mask;
+
+    error = max11261_update_reg(MAX11261_CTRL1, MAX11261_CTRL1_PD, mode);
+    if (error < 0)
+        return error;
+
+    error = max11261_write_byte(MAX11261_CMD_POWERDOWN);
+    if (error < 0)
+        return error;
+
+    mask = (mode == MAX11261_CTRL1_PD_SLEEP) ? MAX11261_STAT_PDSTAT_SLEEP
+            : MAX11261_STAT_PDSTAT_STANDBY;
+    timeout = 2000; /* 2000 x 10us */
+    max11261_read_reg(MAX11261_STAT, &val);
+    while ((val & MAX11261_STAT_PDSTAT) != mask && --timeout) {
+        platCtx.delayUs(10);
+        max11261_read_reg(MAX11261_STAT, &val);
+    }
+
+    if (timeout == 0)
+        return -ETIMEDOUT;
+
+    log_dbg("Time remaining %u us", timeout * 10);
+    return error;
+}
+
+int max11261_adc_set_polarity(max11261_pol_t pol)
+{
+    if (pol == MAX11261_POL_UNIPOLAR && seq.seqMode == MAX11261_SEQ_MODE_4)
+        return -EINVAL;
+
+    seq.polarity = pol;
+
+    return 0;
+}
+
+int max11261_adc_set_format(max11261_fmt_t fmt)
+{
+    if (seq.polarity == MAX11261_POL_UNIPOLAR) {
+        if (fmt == MAX11261_FMT_TWOS_COMPLEMENT)
+            return -EINVAL;
+    }
+
+    if (seq.polarity == MAX11261_POL_BIPOLAR) {
+        if (fmt == MAX11261_FMT_OFFSET_BINARY) {
+            if (seq.seqMode == MAX11261_SEQ_MODE_4)
+                return -EINVAL;
+        }
+    }
+
+    seq.format = fmt;
+
+    return 0;
+}
+
+void max11261_adc_set_rate_single(max11261_single_rate_t rate)
+{
+    seq.srate = rate;
+}
+
+int max11261_adc_set_rate_continuous(max11261_cont_rate_t rate)
+{
+    if (rate == MAX11261_CONT_RATE_16000 && cfg.freq < 1000)
+        return -EINVAL;
+
+    seq.crate = rate;
+
+    return 0;
+}
+
+int max11261_adc_set_channel(max11261_adc_channel_t chan)
+{
+    if (chan < MAX11261_ADC_CHANNEL_0 || chan >= MAX11261_ADC_CHANNEL_MAX)
+        return -EINVAL;
+
+    seq.chan = chan;
+
+    return 0;
+}
+
+int max11261_adc_set_mode(max11261_conversion_mode_t convMode,
+        max11261_sequencer_mode_t seqMode)
+{
+    int error;
+    if (convMode < MAX11261_LATENT_CONTINUOUS
+        || convMode > MAX11261_SINGLE_CYCLE_CONTINUOUS)
+        return -EINVAL;
+
+    if (seqMode < MAX11261_SEQ_MODE_1 || seqMode > MAX11261_SEQ_MODE_4)
+        return -EINVAL;
+
+    if (max11261_adc_pd_state() == MAX11261_PDSTATE_CONVERSION) {
+        log_inf("Device is in conversion state, stopping");
+        error = max11261_adc_standby();
+        if (error < 0) {
+            log_err("Failed to stop conversion");
+            return error;
+        }
+    }
+
+    /* Sequencer mode 2, 3, 4 can only run single cycle */
+    if (seqMode != MAX11261_SEQ_MODE_1) {
+        if (convMode != MAX11261_SINGLE_CYCLE)
+            return -EINVAL;
+    }
+
+    seq.seqMode = seqMode;
+    seq.convMode = convMode;
+
+    return 0;
+}
+
+max11261_pd_state_t max11261_adc_pd_state(void)
+{
+    int error;
+    uint32_t val;
+
+    error = max11261_read_reg(MAX11261_STAT, &val);
+
+    if (error == 0)
+        return (val & MAX11261_STAT_PDSTAT) >> MAX11261_STAT_PDSTAT_POS;
+
+    return error;
+}
+
+int max11261_adc_dump_regs(void)
+{
+    int error;
+    uint32_t val;
+
+    for (uint8_t reg = MAX11261_STAT; reg <= MAX11261_LIMIT_HIGH5; reg++) {
+        error = max11261_read_reg(reg, &val);
+        if (error == 0)
+            log_inf("%s@%02Xh: 0x%08X", regs[reg].name, reg, val);
+        else
+            break;
+    }
+
+    return error;
+}
+
+int max11261_adc_sleep(void)
+{
+    return max11261_set_powerdown_mode(MAX11261_CTRL1_PD_SLEEP);
+}
+
+int max11261_adc_standby(void)
+{
+    return max11261_set_powerdown_mode(MAX11261_CTRL1_PD_STANDBY);
+}
+
+int max11261_adc_calibrate_self(void)
+{
+    int error = max11261_update_reg(MAX11261_CTRL1, MAX11261_CTRL1_CAL,
+            MAX11261_CTRL1_CAL_SELF);
+
+    if (error < 0)
+        return error;
+
+    error = max11261_write_byte(MAX11261_CMD_CALIBRATE);
+    if (error < 0)
+        return error;
+
+    platCtx.delayUs(100000);
+
+    return 0;
+}
+
+static inline int sif_freq(uint16_t freq)
+{
+    if (freq <= 400)
+        return MAX11261_SIF_FREQ_100_400;
+    else if (freq <= 1000)
+        return MAX11261_SIF_FREQ_401_1000;
+    else if (freq <= 3000)
+        return MAX11261_SIF_FREQ_1001_3000;
+    else
+        return MAX11261_SIF_FREQ_3001_5000;
+}
+
+int max11261_adc_convert_prepare(void)
+{
+    int error;
+
+    /* Set sequencer register */
+    error = max11261_update_reg(MAX11261_SEQ,
+            MAX11261_SEQ_MUX | MAX11261_SEQ_SIF_FREQ,
+            (seq.chan << MAX11261_SEQ_MUX_POS) | sif_freq(cfg.freq));
+    if (error < 0)
+        return error;
+
+    /* Set control register 1
+     * PD       : Go to standby after conversion
+     * U_B      : Unipolar input range
+     * FORMAT   : Offset binary format
+     * SCYCLE   : Single cycle conversion
+     */
+    error = max11261_write_reg(MAX11261_CTRL1,
+              MAX11261_CTRL1_PD_STANDBY
+            | ((seq.format == MAX11261_FMT_TWOS_COMPLEMENT) ?
+                    MAX11261_CTRL1_FORMAT_TWOS_COMP :
+                    MAX11261_CTRL1_FORMAT_OFFSET_BIN)
+            | ((seq.polarity == MAX11261_POL_UNIPOLAR) ?
+                    MAX11261_CTRL1_U_B_UNIPOLAR :
+                    MAX11261_CTRL1_U_B_BIPOLAR)
+            | ((seq.convMode != MAX11261_LATENT_CONTINUOUS) ?
+                    MAX11261_CTRL1_SCYCLE_SINGLE :
+                    MAX11261_CTRL1_SCYCLE_CONT));
+    if (error < 0)
+        return error;
+
+    /* Enable input interrupts if ready function is set, disable otherwise */
+    error = max11261_update_reg(MAX11261_INPUT_INT_EN,
+            MAX11261_INPUT_INT_EN_RDYB,
+            platCtx.ready ? MAX11261_INPUT_INT_EN_RDYB : 0);
+
+    return error;
+}
+
+int max11261_adc_result(int32_t *val)
+{
+    int error;
+    uint32_t cnt, timeout, reg;
+    int32_t tmp;
+
+    /* 10 times delay amounts to the data rates given in the datasheet. Adding
+     * two extra delay cycles to make up for the communication delay. */
+    timeout = 12;
+    if (platCtx.ready) {
+        while (!platCtx.ready() && --timeout) {
+            platCtx.delayUs(max11261_single_cycle_delay[seq.srate]);
+        }
+    } else {
+        max11261_read_reg(MAX11261_STAT, &reg);
+        while ((reg & MAX11261_STAT_RDY) == 0 && --timeout) {
+            platCtx.delayUs(max11261_single_cycle_delay[seq.srate]);
+            max11261_read_reg(MAX11261_STAT, &reg);
+        }
+    }
+    if (timeout == 0)
+        return -ETIMEDOUT;
+
+    error = max11261_read_reg(MAX11261_FIFO_LEVEL, &cnt);
+    if (error < 0)
+        return error;
+
+    if (cnt > 1)
+        log_inf("More than 1 conversion result is available: %u", cnt);
+
+    while (cnt--) {
+        error = max11261_read_reg(MAX11261_FIFO, &reg);
+        if (error < 0)
+            return error;
+    }
+
+    reg &= ((1 << cfg.res) - 1);
+    tmp = reg;
+    /* Extend signed 24-bit integer to 32-bit if the value read from the FIFO
+     * is negative. */
+    if (seq.format == MAX11261_FMT_TWOS_COMPLEMENT && (tmp & 0x800000)) {
+        tmp |= 0xFF000000;
+    }
+
+    tmp = ((int64_t) (tmp) * cfg.vref) >> cfg.res;
+    if (seq.polarity == MAX11261_POL_BIPOLAR) {
+        if (seq.format == MAX11261_FMT_OFFSET_BINARY)
+            tmp = 2 * tmp - cfg.vref;
+        else
+            tmp = 2 * tmp;
+    }
+    *val = tmp;
+
+    return 0;
+}
+
+int max11261_adc_convert(void)
+{
+    int error;
+
+    /* Start conversion */
+    error = max11261_write_byte(MAX11261_CMD_SEQUENCER(seq.srate));
+    if (error < 0)
+        return error;
+
+    return 0;
+}

--- a/Libraries/MiscDrivers/ADC/max11261.h
+++ b/Libraries/MiscDrivers/ADC/max11261.h
@@ -1,0 +1,360 @@
+/**
+ * @file        max11261.h
+ * @brief       MAX11261 driver API definitions.
+ * @details     This header file contains the MAX11261 driver API definitions.
+ */
+
+/******************************************************************************
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+#ifndef MAX11261_H_
+#define MAX11261_H_
+
+#include <stdint.h>
+
+/**
+ * @brief MAX11261 device access function prototype.
+ */
+typedef int (*max11261_transfer_func_t) (uint8_t *txbuf, uint8_t txsize,
+        uint8_t *rxbuf, uint8_t rxsize, uint8_t slave);
+
+/**
+ * @brief MAX11261 reset function prototype.
+ */
+typedef void (*max11261_reset_ctrl_t) (int);
+
+/**
+ * @brief MAX11261 microseconds delay function prototype.
+ */
+typedef void (*max11261_delay_func_t) (uint32_t);
+
+/**
+ * @brief MAX11261 RDYB pin status check function.
+ */
+typedef int (*max11261_ready_func_t) (void);
+
+/**
+ * Channel enumeration.
+ * There are six ADC channels available in this chip.
+ */
+typedef enum {
+    MAX11261_ADC_CHANNEL_0 = 0,
+    MAX11261_ADC_CHANNEL_1,
+    MAX11261_ADC_CHANNEL_2,
+    MAX11261_ADC_CHANNEL_3,
+    MAX11261_ADC_CHANNEL_4,
+    MAX11261_ADC_CHANNEL_5,
+    MAX11261_ADC_CHANNEL_MAX
+} max11261_adc_channel_t;
+
+/**
+ * Conversion modes.
+ * Sequencer modes 2, 3 and 4 can only run in \a MAX11261_SINGLE_CYCLE mode.
+ */
+typedef enum {
+    MAX11261_LATENT_CONTINUOUS,         /**< Latent continuous single cycle conversion. Valid only in 1 */
+    MAX11261_SINGLE_CYCLE,              /**< No-latency single cycle conversion. Valid in 1, 2, 3 and 4 */
+    MAX11261_SINGLE_CYCLE_CONTINUOUS,   /**< Continuous no-latency single cycle conversion. Valid only in 1. */
+} max11261_conversion_mode_t;
+
+/**
+ * Sequencer modes.
+ * 2, 3 and 4 are only valid with MAX11261_SINGLE_CYCLE.
+ */
+typedef enum {
+    MAX11261_SEQ_MODE_1,    /**< Single-Channel Conversion with GPO Control and MUX Delays. */
+    MAX11261_SEQ_MODE_2,    /**< Multichannel Scan with GPO Control and MUX Delays */
+    MAX11261_SEQ_MODE_3,    /**< Scan, with Sequenced GPO Controls */
+    MAX11261_SEQ_MODE_4,    /**< Autoscan with GPO Controls (CHMAP) and Interrupt */
+} max11261_sequencer_mode_t;
+
+/**
+ * Sample rates available for continuous conversion.
+ * \a MAX11261_CONT_RATE_16000 is only supported with serial interface speeds
+ * equal to or greater than 1MHz.
+ */
+typedef enum {
+    MAX11261_CONT_RATE_1_9 = 0,
+    MAX11261_CONT_RATE_3_9,
+    MAX11261_CONT_RATE_7_8,
+    MAX11261_CONT_RATE_15_6,
+    MAX11261_CONT_RATE_31_2,
+    MAX11261_CONT_RATE_62_5,
+    MAX11261_CONT_RATE_125,
+    MAX11261_CONT_RATE_250,
+    MAX11261_CONT_RATE_500,
+    MAX11261_CONT_RATE_1000,
+    MAX11261_CONT_RATE_2000,
+    MAX11261_CONT_RATE_4000,
+    MAX11261_CONT_RATE_8000,
+    MAX11261_CONT_RATE_16000,
+} max11261_cont_rate_t;
+
+/**
+ * Sample rates available for single cycle conversion.
+ */
+typedef enum {
+    MAX11261_SINGLE_RATE_50 = 0,
+    MAX11261_SINGLE_RATE_62_5,
+    MAX11261_SINGLE_RATE_100,
+    MAX11261_SINGLE_RATE_125,
+    MAX11261_SINGLE_RATE_200,
+    MAX11261_SINGLE_RATE_250,
+    MAX11261_SINGLE_RATE_400,
+    MAX11261_SINGLE_RATE_500,
+    MAX11261_SINGLE_RATE_800,
+    MAX11261_SINGLE_RATE_1000,
+    MAX11261_SINGLE_RATE_1600,
+    MAX11261_SINGLE_RATE_2000,
+    MAX11261_SINGLE_RATE_3200,
+    MAX11261_SINGLE_RATE_4000,
+    MAX11261_SINGLE_RATE_6400,
+    MAX11261_SINGLE_RATE_12800,
+} max11261_single_rate_t;
+
+typedef enum {
+    MAX11261_PDSTATE_CONVERSION = 0,
+    MAX11261_PDSTATE_SLEEP,
+    MAX11261_PDSTATE_STANDBY,
+    MAX11261_PDSTATE_RESET
+} max11261_pd_state_t;
+
+typedef enum {
+    MAX11261_SIF_FREQ_100_400 = 0,
+    MAX11261_SIF_FREQ_401_1000,
+    MAX11261_SIF_FREQ_1001_3000,
+    MAX11261_SIF_FREQ_3001_5000,
+} max11261_sif_freq_t;
+
+/**
+ * Input polarity.
+ */
+typedef enum {
+    MAX11261_POL_UNIPOLAR = 0,  /**< 0 to +VREF */
+    MAX11261_POL_BIPOLAR,       /**< -VREF to +VREF */
+} max11261_pol_t;
+
+/**
+ * Digital format of the bipolar range data.
+ */
+typedef enum {
+    MAX11261_FMT_TWOS_COMPLEMENT = 0,
+    MAX11261_FMT_OFFSET_BINARY,
+} max11261_fmt_t;
+
+/**
+ * @brief Initializes MAX11261 platform configuration.
+ *
+ * These are platform-specific functions and must be provided by the user. The
+ * first parameter, @p transferFunc is the I2C transfer function that takes a
+ * transmit buffer, receive buffer and slave address and should return 0 if
+ * I2C transaction succeeds.
+ *
+ * @p resetCtrl provides the hardware reset functionality. Passing 1 to this
+ * function should assert the reset line and passing 0 should clear it.
+ *
+ * @p delayFunc should provide delay functionality in microseconds resolution.
+ *
+ * @param transferFunc I2C transfer function.
+ * @param resetCtrl Function that controls the reset line.
+ * @param delayFunc Microseconds delay function.
+ */
+void max11261_adc_platform_init(max11261_transfer_func_t transferFunc,
+        max11261_reset_ctrl_t resetCtrl, max11261_delay_func_t delayFunc
+);
+
+/**
+ * @brief Configures MAX11261 hardware parameters.
+ *
+ * @param vavdd V_AVDD in millivolts.
+ * @param vref  REFP - REFN in millivolts.
+ * @param freq Interface frequency.
+ * @param slaveAddr I2C slave address of the MAX11261 chip.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_config_init(uint16_t vavdd, uint16_t vref, uint16_t freq,
+        uint8_t slaveAddr);
+
+/**
+ * @brief Sets the function that checks if data is available by monitoring the
+ * RDYB pin.
+ *
+ * If RDYB pin is not connected and ready function is not set, the STAT
+ * register will be polled until RDY bit is set. It is recommended to use the
+ * RDYB pin as polling over serial interface takes longer.
+ *
+ * @param readyFunc Function that monitors the level of the ready pin. Should
+ *                  return 1 if ready pin is asserted, 0 otherwise.
+ */
+void max11261_adc_set_ready_func(max11261_ready_func_t readyFunc);
+
+/**
+ * @brief Resets MAX11261 using the reset function provided earlier.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_reset(void);
+
+/**
+ * @brief Sets the polarity of the input. Default polarity is
+ * \a MAX11261_POL_UNIPOLAR.
+ *
+ * Unipolar mode is not supported in sequencer mode 4.
+ *
+ * @param pol Input polarity. See \ref max11261_pol_t.
+ *
+ * @return Success/Fail, 0 if success, -EINVAL if the polarity is not
+ * compatible with the current sequencer mode.
+ */
+int max11261_adc_set_polarity(max11261_pol_t pol);
+
+/**
+ * @brief Sets the format of the conversion results. Default format is
+ * \a MAX11261_FMT_OFFSET_BINARY.
+ *
+ * In unipolar mode, data format is always offset binary. In offset binary
+ * format the most negative value is 0x000000, the midscale value is
+ * 0x800000 and the most positive value is 0xFFFFFF. In two's complement,
+ * the negative full-scale value is 0x800000, the midscale is 0x000000,
+ * and the positive full scale is 0x7FFFFF.
+ *
+ * @param fmt Data format. See \ref max11261_fmt_t.
+ *
+ * @return Success/Fail, 0 if success, -EINVAL if the format is not compatible
+ * with the current polarity selection.
+ */
+int max11261_adc_set_format(max11261_fmt_t fmt);
+
+/**
+ * @brief Set the output data rate used during single cycle conversion.
+ *
+ * The maximum data rate depends on the I2C interface speed.
+ *
+ * @param rate Data rate to be used.
+ *
+ */
+void max11261_adc_set_rate_single(max11261_single_rate_t rate);
+
+/**
+ * @brief Set the output data rate used during continuous conversion.
+ *
+ * The maximum data rate depends on the I2C interface speed.
+ *
+ * @param ctx ADC context structure.
+ * @param rate Data rate to be used.
+ *
+ * @return Success/Fail, 0 if success, -EINVAL if the rate is invalid.
+ */
+int max11261_adc_set_rate_continuous(max11261_cont_rate_t rate);
+
+/**
+ * @brief Sets the ADC channel to be scanned. Default is \a MAX11261_ADC_CHANNEL_0.
+ *
+ * @param chan Channel to scan.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_set_channel(max11261_adc_channel_t chan);
+
+/**
+ * @brief Sets conversion and sequencer mode to be used. Default values are
+ * \a MAX11261_SINGLE_CYCLE and MAX11261_SEQ_MODE_1.
+ *
+ * @param convMode Conversion mode to use.
+ * @param seqMode Sequencer mode to use.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_set_mode(max11261_conversion_mode_t convMode,
+        max11261_sequencer_mode_t seqMode);
+
+/**
+ * @brief Returns the MAX11261 powerdown state.
+ *
+ * @return Current power-down state, error code otherwise.
+ */
+max11261_pd_state_t max11261_adc_pd_state(void);
+
+/**
+ * @brief Read and print the values inside the MAX11261 registers.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_dump_regs(void);
+
+/**
+ * @brief Puts the MAX11261 into sleep mode.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_sleep(void);
+
+/**
+ * @brief Puts the MAX11261 into standby mode.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_standby(void);
+
+/**
+ * @brief Performs a self-calibration operation.
+ */
+int max11261_adc_calibrate_self(void);
+
+/**
+ * @brief Prepares MAX11261 internal registers for conversion.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_convert_prepare(void);
+
+/**
+ * @brief Reads the available conversion result into @p val.
+ *
+ * Device must be in conversion state otherwise the function will fail.
+ *
+ * @param val Pointer to the variable to write the result into.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_result(int32_t *val);
+
+/**
+ * @brief Starts conversion by sending a sequencer command.
+ *
+ * @return Success/Fail, see \ref errno.h for a list of return codes.
+ */
+int max11261_adc_convert(void);
+
+#endif /* MAX11261_H_ */

--- a/Libraries/MiscDrivers/ADC/max11261_regs.h
+++ b/Libraries/MiscDrivers/ADC/max11261_regs.h
@@ -1,0 +1,698 @@
+/**
+ * @file        max11261_regs.h
+ * @brief       MAX11261 register definitions.
+ * @details     This header file contains definitions of MAX11261 registers and
+ *              their bitfields.
+ */
+
+/******************************************************************************
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+#ifndef MAX11261_REGS_H_
+#define MAX11261_REGS_H_
+
+/**
+ * @ingroup  max11261_commands
+ * @defgroup MAX11261_COMMAND_BYTE
+ * @brief    Command byte.
+ * @{
+ */
+#define MAX11261_CMD_READ(addr)     ((0x03UL << 6) | (addr << 1) | (0x01UL << 0))
+#define MAX11261_CMD_WRITE(addr)    ((0x03UL << 6) | (addr << 1))
+#define MAX11261_CMD_POWERDOWN      0x90
+#define MAX11261_CMD_CALIBRATE      0xA0
+#define MAX11261_CMD_SEQUENCER(r)   0xB0 | (r & 0x0F)
+
+/**@} end of group MAX11261_COMMAND_BYTE */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_STAT MAX11261_STAT
+ * @brief    Status Register.
+ * @{
+ */
+#define MAX11261_STAT   0x00
+
+#define MAX11261_STAT_RDY_POS       0 /**< STAT_RDY Position */
+#define MAX11261_STAT_RDY           ((uint32_t) (0x01UL << MAX11261_STAT_RDY_POS))
+
+#define MAX11261_STAT_MSAT_POS      1 /**< STAT_MSAT Position */
+#define MAX11261_STAT_MSAT          ((uint32_t) (0x01UL << MAX11261_STAT_MSAT_POS))
+
+#define MAX11261_STAT_PDSTAT_POS        2 /**< STAT_PDSTAT Position */
+#define MAX11261_STAT_PDSTAT            ((uint32_t) (0x03UL << MAX11261_STAT_PDSTAT_POS))
+#define MAX11261_STAT_PDSTAT_CONVERSION ((uint32_t) (0x00UL << MAX11261_STAT_PDSTAT_POS))
+#define MAX11261_STAT_PDSTAT_SLEEP      ((uint32_t) (0x01UL << MAX11261_STAT_PDSTAT_POS))
+#define MAX11261_STAT_PDSTAT_STANDBY    ((uint32_t) (0x02UL << MAX11261_STAT_PDSTAT_POS))
+#define MAX11261_STAT_PDSTAT_RESET      ((uint32_t) (0x03UL << MAX11261_STAT_PDSTAT_POS))
+
+#define MAX11261_STAT_RATE_POS      4 /**< STAT_RATE Position */
+#define MAX11261_STAT_RATE          ((uint32_t) (0x0FUL << MAX11261_STAT_RATE_POS))
+
+#define MAX11261_STAT_AOR_POS       8 /**< STAT_AOR Position */
+#define MAX11261_STAT_AOR           ((uint32_t) (0x01UL << MAX11261_STAT_AOR_POS))
+
+#define MAX11261_STAT_DOR_POS       9 /**< STAT_DOR Position */
+#define MAX11261_STAT_DOR           ((uint32_t) (0x01UL << MAX11261_STAT_DOR_POS))
+
+#define MAX11261_STAT_SYSGOR_POS    10 /**< STAT_SYSGOR Position */
+#define MAX11261_STAT_SYSGOR        ((uint32_t) (0x01UL << MAX11261_STAT_SYSGOR_POS))
+
+#define MAX11261_STAT_ERROR_POS     11 /**< STAT_ERROR Position */
+#define MAX11261_STAT_ERROR         ((uint32_t) (0x01UL << MAX11261_STAT_ERROR_POS))
+
+#define MAX11261_STAT_GPOERR_POS    12 /**< STAT_GPOERR Position */
+#define MAX11261_STAT_GPOERR        ((uint32_t) (0x01UL << MAX11261_STAT_GPOERR_POS))
+
+#define MAX11261_STAT_ORDERR_POS    13 /**< STAT_ORDERR Position */
+#define MAX11261_STAT_ORDERR        ((uint32_t) (0x01UL << MAX11261_STAT_ORDERR_POS))
+
+#define MAX11261_STAT_REFDET_POS    14 /**< STAT_REFDET Position */
+#define MAX11261_STAT_REFDET        ((uint32_t) (0x01UL << MAX11261_STAT_REFDET_POS))
+
+#define MAX11261_STAT_SCANERR_POS   15 /**< STAT_SCANERR Position */
+#define MAX11261_STAT_SCANERR       ((uint32_t) (0x01UL << MAX11261_STAT_SCANERR_POS))
+
+#define MAX11261_STAT_SRDY_POS      16 /**< STAT_SRDY Position */
+#define MAX11261_STAT_SRDY          ((uint32_t) (0x03FUL << MAX11261_STAT_SRDY_POS))
+
+#define MAX11261_STAT_INRESET_POS   22 /**< STAT_INRESET Position */
+#define MAX11261_STAT_INRESET       ((uint32_t) (0x01UL << MAX11261_STAT_INRESET_POS))
+
+/**@} end of group MAX11261_STAT_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_CTRL1 MAX11261_CTRL1
+ * @brief    Control Register 1.
+ * @{
+ */
+#define MAX11261_CTRL1  0x01
+
+#define MAX11261_CTRL1_CONTSC_POS   0 /**< CONTSC Position */
+#define MAX11261_CTRL1_CONTSC       ((uint8_t) (0x01UL << MAX11261_CTRL1_CONTSC_POS))
+
+#define MAX11261_CTRL1_SCYCLE_POS   1 /**< SCYCLE Position */
+#define MAX11261_CTRL1_SCYCLE       ((uint8_t) (0x01UL << MAX11261_CTRL1_SCYCLE_POS))
+#define MAX11261_CTRL1_SCYCLE_CONT      ((uint8_t) (0x00UL << MAX11261_CTRL1_SCYCLE_POS))
+#define MAX11261_CTRL1_SCYCLE_SINGLE    ((uint8_t) (0x01UL << MAX11261_CTRL1_SCYCLE_POS))
+
+#define MAX11261_CTRL1_FORMAT_POS   2 /**< FORMAT Position */
+#define MAX11261_CTRL1_FORMAT       ((uint8_t) (0x01UL << MAX11261_CTRL1_FORMAT_POS))
+#define MAX11261_CTRL1_FORMAT_TWOS_COMP     ((uint8_t) (0x00UL << MAX11261_CTRL1_FORMAT_POS))
+#define MAX11261_CTRL1_FORMAT_OFFSET_BIN    ((uint8_t) (0x01UL << MAX11261_CTRL1_FORMAT_POS))
+
+#define MAX11261_CTRL1_U_B_POS      3 /**< U_B Position */
+#define MAX11261_CTRL1_U_B          ((uint8_t) (0x01UL << MAX11261_CTRL1_U_B_POS))
+#define MAX11261_CTRL1_U_B_BIPOLAR  ((uint8_t) (0x00UL << MAX11261_CTRL1_U_B_POS))
+#define MAX11261_CTRL1_U_B_UNIPOLAR ((uint8_t) (0x01UL << MAX11261_CTRL1_U_B_POS))
+
+#define MAX11261_CTRL1_PD_POS       4 /**< PD Position */
+#define MAX11261_CTRL1_PD           ((uint8_t) (0x03UL << MAX11261_CTRL1_PD_POS))
+#define MAX11261_CTRL1_PD_SLEEP     ((uint8_t) (0x01UL << MAX11261_CTRL1_PD_POS))
+#define MAX11261_CTRL1_PD_STANDBY   ((uint8_t) (0x02UL << MAX11261_CTRL1_PD_POS))
+#define MAX11261_CTRL1_PD_RESET     ((uint8_t) (0x03UL << MAX11261_CTRL1_PD_POS))
+
+#define MAX11261_CTRL1_CAL_POS      6 /**< CAL Position */
+#define MAX11261_CTRL1_CAL          ((uint8_t) (0x03UL << MAX11261_CTRL1_CAL_POS))
+#define MAX11261_CTRL1_CAL_SELF     ((uint8_t) (0x00UL << MAX11261_CTRL1_CAL_POS))
+/**@} end of group MAX11261_CTRL1_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_CTRL2 MAX11261_CTRL2
+ * @brief    Control Register 2.
+ * @{
+ */
+#define MAX11261_CTRL2  0x02
+
+#define MAX11261_CTRL2_PGA_POS      0 /**< PGA Position */
+#define MAX11261_CTRL2_PGA          ((uint8_t) (0x07UL << MAX11261_CTRL2_PGA_POS))
+
+#define MAX11261_CTRL2_PGAEN_POS    3 /**< PGAEN Position */
+#define MAX11261_CTRL2_PGAEN        ((uint8_t) (0x01UL << MAX11261_CTRL2_PGAEN_POS))
+
+#define MAX11261_CTRL2_LPMODE_POS   4 /**< LPMODE Position */
+#define MAX11261_CTRL2_LPMODE       ((uint8_t) (0x01UL << MAX11261_CTRL2_LPMODE_POS))
+
+#define MAX11261_CTRL2_LDOEN_POS    5 /**< LDOEN Position */
+#define MAX11261_CTRL2_LDOEN        ((uint8_t) (0x01UL << MAX11261_CTRL2_LDOEN_POS))
+
+#define MAX11261_CTRL2_CSSEN_POS    6 /**< CSSEN Position */
+#define MAX11261_CTRL2_CSSEN        ((uint8_t) (0x01UL << MAX11261_CTRL2_CSSEN_POS))
+
+#define MAX11261_CTRL2_RST_POS      7 /**< RST Position */
+#define MAX11261_CTRL2_RST          ((uint8_t) (0x01UL << MAX11261_CTRL2_RST_POS))
+/**@} end of group MAX11261_CTRL2_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_CTRL3 MAX11261_CTRL3
+ * @brief    Control Register 3.
+ * @{
+ */
+#define MAX11261_CTRL3  0x03
+
+#define MAX11261_CTRL3_NOSCO_POS        0 /**< NOSCO Position */
+#define MAX11261_CTRL3_NOSCO            ((uint8_t) (0x01UL << MAX11261_CTRL3_NOSCO_POS))
+
+#define MAX11261_CTRL3_NOSCG_POS        1 /**< NOSCG Position */
+#define MAX11261_CTRL3_NOSCG            ((uint8_t) (0x01UL << MAX11261_CTRL3_NOSCG_POS))
+
+#define MAX11261_CTRL3_NOSYSO_POS       2 /**< NOSYSO Position */
+#define MAX11261_CTRL3_NOSYSO           ((uint8_t) (0x01UL << MAX11261_CTRL3_NOSYSO_POS))
+
+#define MAX11261_CTRL3_NOSYSG_POS       3 /**< NOSYSG Position */
+#define MAX11261_CTRL3_NOSYSG           ((uint8_t) (0x01UL << MAX11261_CTRL3_NOSYSG_POS))
+
+#define MAX11261_CTRL3_CALREGSEL_POS    4 /**< CALREGSEL Position */
+#define MAX11261_CTRL3_CALREGSEL        ((uint8_t) (0x01UL << MAX11261_CTRL3_CALREGSEL_POS))
+
+#define MAX11261_CTRL3_SYNC_POS         5 /**< SYNC Position */
+#define MAX11261_CTRL3_SYNC             ((uint8_t) (0x01UL << MAX11261_CTRL3_SYNC_POS))
+
+#define MAX11261_CTRL3_SYNCZ_POS        6 /**< SYNCZ Position */
+#define MAX11261_CTRL3_SYNCZ            ((uint8_t) (0x01UL << MAX11261_CTRL3_SYNCZ_POS))
+
+/**@} end of group MAX11261_CTRL3_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_SEQ MAX11261_SEQ
+ * @brief    Sequencer Register.
+ * @{
+ */
+#define MAX11261_SEQ    0x04
+
+#define MAX11261_SEQ_SIF_FREQ_POS   0 /**< SIF_FREQ Position */
+#define MAX11261_SEQ_SIF_FREQ       ((uint32_t) (0x03UL << MAX11261_SEQ_SIF_FREQ_POS))
+
+#define MAX11261_SEQ_RDYBEN_POS     8 /**< RDYBEN Position */
+#define MAX11261_SEQ_RDYBEN         ((uint32_t) (0x01UL << MAX11261_SEQ_RDYBEN_POS))
+
+#define MAX11261_SEQ_MDREN_POS      9 /**< MDREN Position */
+#define MAX11261_SEQ_MDREN          ((uint32_t) (0x01UL << MAX11261_SEQ_MDREN_POS))
+
+#define MAX11261_SEQ_GPODREN_POS    10 /**< GPODREN Position */
+#define MAX11261_SEQ_GPODREN        ((uint32_t) (0x01UL << MAX11261_SEQ_GPODREN_POS))
+
+#define MAX11261_SEQ_MODE_POS       11 /**< MODE Position */
+#define MAX11261_SEQ_MODE           ((uint32_t) (0x03UL << MAX11261_SEQ_MODE_POS))
+
+#define MAX11261_SEQ_MUX_POS        13 /**< MUX Position */
+#define MAX11261_SEQ_MUX            ((uint32_t) (0x07UL << MAX11261_SEQ_MUX_POS))
+
+/**@} end of group MAX11261_SEQ_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_CHMAP1 MAX11261_CHMAP1
+ * @brief    Channel Map Register.
+ * @{
+ */
+#define MAX11261_CHMAP1 0x05
+
+#define MAX11261_CHMAP1_CH3_GPOEN_POS   0 /**< CH3_GPOEN Position */
+#define MAX11261_CHMAP1_CH3_GPOEN       ((uint32_t) (0x01UL << MAX11261_CHMAP1_GPOEN_POS))
+
+#define MAX11261_CHMAP1_CH3_EN_POS      1 /**< CH3_EN Position */
+#define MAX11261_CHMAP1_CH3_EN          ((uint32_t) (0x01UL << MAX11261_CHMAP1_CH3_EN_POS))
+
+#define MAX11261_CHMAP1_CH3_ORD_POS     2 /**< CH3_ORD Position */
+#define MAX11261_CHMAP1_CH3_ORD         ((uint32_t) (0x07UL << MAX11261_CHMAP1_CH3_ORD_POS))
+
+#define MAX11261_CHMAP1_CH3_GPO_POS     5 /**< CH3_GPO Position */
+#define MAX11261_CHMAP1_CH3_GPO         ((uint32_t) (0x07UL << MAX11261_CHMAP1_CH3_GPO_POS))
+
+#define MAX11261_CHMAP1_CH4_GPOEN_POS   8 /**< CH4_GPOEN Position */
+#define MAX11261_CHMAP1_CH4_GPOEN       ((uint32_t) (0x01UL << MAX11261_CHMAP1_CH4_GPOEN_POS))
+
+#define MAX11261_CHMAP1_CH4_EN_POS      9 /**< CH4_EN Position */
+#define MAX11261_CHMAP1_CH4_EN          ((uint32_t) (0x01UL << MAX11261_CHMAP1_CH4_EN_POS))
+
+#define MAX11261_CHMAP1_CH4_ORD_POS     10 /**< CH4_ORD Position */
+#define MAX11261_CHMAP1_CH4_ORD         ((uint32_t) (0x07UL << MAX11261_CHMAP1_CH4_ORD_POS))
+
+#define MAX11261_CHMAP1_CH4_GPO_POS     13 /**< CH4_GPO Position */
+#define MAX11261_CHMAP1_CH4_GPO         ((uint32_t) (0x07UL << MAX11261_CHMAP1_CH4_GPO_POS))
+
+#define MAX11261_CHMAP1_CH5_GPOEN_POS   16 /**< CH5_GPOEN Position */
+#define MAX11261_CHMAP1_CH5_GPOEN       ((uint32_t) (0x01UL << MAX11261_CHMAP1_CH5_GPOEN_POS))
+
+#define MAX11261_CHMAP1_CH5_EN_POS      17 /**< CH5_EN Position */
+#define MAX11261_CHMAP1_CH5_EN          ((uint32_t) (0x01UL << MAX11261_CHMAP1_CH5_EN_POS))
+
+#define MAX11261_CHMAP1_CH5_ORD_POS     18 /**< CH5_ORD Position */
+#define MAX11261_CHMAP1_CH5_ORD         ((uint32_t) (0x07UL << MAX11261_CHMAP1_CH5_ORD_POS))
+
+#define MAX11261_CHMAP1_CH5_GPO_POS     21 /**< CH5_GPO Position */
+#define MAX11261_CHMAP1_CH5_GPO         ((uint32_t) (0x07UL << MAX11261_CHMAP1_CH5_GPO_POS))
+
+/**@} end of group MAX11261_CHMAP1_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_CHMAP0 MAX11261_CHMAP0
+ * @brief    Channel Map Register.
+ * @{
+ */
+#define MAX11261_CHMAP0 0x06
+
+#define MAX11261_CHMAP0_CH0_GPOEN_POS   0 /**< CH0_GPOEN Position */
+#define MAX11261_CHMAP0_CH0_GPOEN       ((uint32_t) (0x01UL << MAX11261_CHMAP0_GPOEN_POS))
+
+#define MAX11261_CHMAP0_CH0_EN_POS      1 /**< CH0_EN Position */
+#define MAX11261_CHMAP0_CH0_EN          ((uint32_t) (0x01UL << MAX11261_CHMAP0_CH0_EN_POS))
+
+#define MAX11261_CHMAP0_CH0_ORD_POS     2 /**< CH0_ORD Position */
+#define MAX11261_CHMAP0_CH0_ORD         ((uint32_t) (0x07UL << MAX11261_CHMAP0_CH0_ORD_POS))
+
+#define MAX11261_CHMAP0_CH0_GPO_POS     5 /**< CH0_GPO Position */
+#define MAX11261_CHMAP0_CH0_GPO         ((uint32_t) (0x07UL << MAX11261_CHMAP0_CH0_GPO_POS))
+
+#define MAX11261_CHMAP0_CH1_GPOEN_POS   8 /**< CH1_GPOEN Position */
+#define MAX11261_CHMAP0_CH1_GPOEN       ((uint32_t) (0x01UL << MAX11261_CHMAP0_CH1_GPOEN_POS))
+
+#define MAX11261_CHMAP0_CH1_EN_POS      9 /**< CH1_EN Position */
+#define MAX11261_CHMAP0_CH1_EN          ((uint32_t) (0x01UL << MAX11261_CHMAP0_CH1_EN_POS))
+
+#define MAX11261_CHMAP0_CH1_ORD_POS     10 /**< CH1_ORD Position */
+#define MAX11261_CHMAP0_CH1_ORD         ((uint32_t) (0x07UL << MAX11261_CHMAP0_CH1_ORD_POS))
+
+#define MAX11261_CHMAP0_CH1_GPO_POS     13 /**< CH1_GPO Position */
+#define MAX11261_CHMAP0_CH1_GPO         ((uint32_t) (0x07UL << MAX11261_CHMAP0_CH1_GPO_POS))
+
+#define MAX11261_CHMAP0_CH2_GPOEN_POS   16 /**< CH2_GPOEN Position */
+#define MAX11261_CHMAP0_CH2_GPOEN       ((uint32_t) (0x01UL << MAX11261_CHMAP0_CH2_GPOEN_POS))
+
+#define MAX11261_CHMAP0_CH2_EN_POS      17 /**< CH2_EN Position */
+#define MAX11261_CHMAP0_CH2_EN          ((uint32_t) (0x01UL << MAX11261_CHMAP0_CH2_EN_POS))
+
+#define MAX11261_CHMAP0_CH2_ORD_POS     18 /**< CH2_ORD Position */
+#define MAX11261_CHMAP0_CH2_ORD         ((uint32_t) (0x07UL << MAX11261_CHMAP0_CH2_ORD_POS))
+
+#define MAX11261_CHMAP0_CH2_GPO_POS     21 /**< CH2_GPO Position */
+#define MAX11261_CHMAP0_CH2_GPO         ((uint32_t) (0x07UL << MAX11261_CHMAP0_CH2_GPO_POS))
+
+/**@} end of group MAX11261_CHMAP0_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_DELAY MAX11261_DELAY
+ * @brief    Delay Register.
+ * @{
+ */
+#define MAX11261_DELAY  0x07
+
+#define MAX11261_DELAY_GPO_POS      0 /**< GPO Position */
+#define MAX11261_DELAY_GPO          ((uint32_t) (0xFFUL << MAX11261_DELAY_GPO_POS))
+
+#define MAX11261_DELAY_MUX_POS      8 /**< MUX Position */
+#define MAX11261_DELAY_MUX          ((uint32_t) (0xFFUL << MAX11261_DELAY_MUX_POS))
+
+#define MAX11261_DELAY_AUTOSCAN_POS 16 /**< AUTOSCAN Position */
+#define MAX11261_DELAY_AUTOSCAN     ((uint32_t) (0xFFUL << MAX11261_DELAY_AUTOSCAN_POS))
+
+/**@} end of group MAX11261_DELAY_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_LOW0 MAX11261_LIMIT_LOW0
+ * @brief    Lower Limit Register for Channel 0.
+ * @{
+ */
+#define MAX11261_LIMIT_LOW0 0x08
+
+#define MAX11261_LIMIT_LOW0_D_POS   0 /**< D Position */
+#define MAX11261_LIMIT_LOW0_D       ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_LOW0_D_POS))
+
+/**@} end of group MAX11261_LIMIT_LOW0_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_LOW1 MAX11261_LIMIT_LOW1
+ * @brief    Lower Limit Register for Channel 1.
+ * @{
+ */
+#define MAX11261_LIMIT_LOW1 0x09
+
+#define MAX11261_LIMIT_LOW1_D_POS   0 /**< D Position */
+#define MAX11261_LIMIT_LOW1_D       ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_LOW1_D_POS))
+
+/**@} end of group MAX11261_LIMIT_LOW1_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_LOW2 MAX11261_LIMIT_LOW2
+ * @brief    Lower Limit Register for Channel 2.
+ * @{
+ */
+#define MAX11261_LIMIT_LOW2 0x10
+
+#define MAX11261_LIMIT_LOW2_D_POS   0 /**< D Position */
+#define MAX11261_LIMIT_LOW2_D       ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_LOW2_D_POS))
+
+/**@} end of group MAX11261_LIMIT_LOW2_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_LOW3 MAX11261_LIMIT_LOW3
+ * @brief    Lower Limit Register for Channel 3.
+ * @{
+ */
+#define MAX11261_LIMIT_LOW3 0x11
+
+#define MAX11261_LIMIT_LOW3_D_POS   0 /**< D Position */
+#define MAX11261_LIMIT_LOW3_D       ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_LOW3_D_POS))
+
+/**@} end of group MAX11261_LIMIT_LOW3_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_LOW4 MAX11261_LIMIT_LOW4
+ * @brief    Lower Limit Register for Channel 4.
+ * @{
+ */
+#define MAX11261_LIMIT_LOW4 0x12
+
+#define MAX11261_LIMIT_LOW4_D_POS   0 /**< D Position */
+#define MAX11261_LIMIT_LOW4_D       ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_LOW4_D_POS))
+
+/**@} end of group MAX11261_LIMIT_LOW4_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_LOW5 MAX11261_LIMIT_LOW5
+ * @brief    Lower Limit Register for Channel 5.
+ * @{
+ */
+#define MAX11261_LIMIT_LOW5 0x13
+
+#define MAX11261_LIMIT_LOW5_D_POS   0 /**< D Position */
+#define MAX11261_LIMIT_LOW5_D       ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_LOW5_D_POS))
+
+/**@} end of group MAX11261_LIMIT_LOW5_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_SOC MAX11261_SOC
+ * @brief    System Offset Calibration Register.
+ * @{
+ */
+#define MAX11261_SOC    0x0E
+
+#define MAX11261_SOC_D_POS   0 /**< D Position */
+#define MAX11261_SOC_D       ((uint32_t) (0xFFFFFFUL << MAX11261_SOC_D_POS))
+
+/**@} end of group MAX11261_SOC_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_SGC MAX11261_SGC
+ * @brief    System Gain Calibration Register.
+ * @{
+ */
+#define MAX11261_SGC    0x0F
+
+#define MAX11261_SGC_D_POS   0 /**< D Position */
+#define MAX11261_SGC_D       ((uint32_t) (0xFFFFFFUL << MAX11261_SGC_D_POS))
+
+/**@} end of group MAX11261_SGC_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_SCOC MAX11261_SCOC
+ * @brief    Self-Calibration Offset Calibration Register.
+ * @{
+ */
+#define MAX11261_SCOC   0x10
+
+#define MAX11261_SCOC_D_POS   0 /**< D Position */
+#define MAX11261_SCOC_D       ((uint32_t) (0xFFFFFFUL << MAX11261_SCOC_D_POS))
+
+/**@} end of group MAX11261_SCOC_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_SCGC MAX11261_SCGC
+ * @brief    Self-Calibration Gain Calibration Register.
+ * @{
+ */
+#define MAX11261_SCGC   0x11
+
+#define MAX11261_SCGC_D_POS   0 /**< D Position */
+#define MAX11261_SCGC_D       ((uint32_t) (0xFFFFFFUL << MAX11261_SCGC_D_POS))
+
+/**@} end of group MAX11261_SCGC_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_GPO_DIR MAX11261_GPO_DIR
+ * @brief    GPO Direct Access Register.
+ * @{
+ */
+#define MAX11261_GPO_DIR    0x12
+
+#define MAX11261_GPO_DIR_GPO_POS    0 /**< GPO Position */
+#define MAX11261_GPO_DIR_GPO        ((uint32_t) (0x1FUL << MAX11261_GPO_DIR_GPO_POS))
+
+/**@} end of group MAX11261_GPO_DIR_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_FIFO MAX11261_FIFO
+ * @brief    FIFO Register.
+ * @{
+ */
+#define MAX11261_FIFO   0x13
+
+#define MAX11261_FIFO_D_POS     0 /**< D Position */
+#define MAX11261_FIFO_D         ((uint32_t) (0xFFFFFFUL << MAX11261_FIFO_D_POS))
+
+#define MAX11261_FIFO_OOR_POS   24 /**< OOR Position */
+#define MAX11261_FIFO_OOR       ((uint32_t) (0x01UL << MAX11261_FIFO_OOR_POS))
+
+#define MAX11261_FIFO_CH_POS    25 /**< CH Position */
+#define MAX11261_FIFO_CH        ((uint32_t) (0x07UL << MAX11261_FIFO_CH_POS))
+
+#define MAX11261_FIFO_OVW_POS   31 /**< OVW Position */
+#define MAX11261_FIFO_OVW       ((uint32_t) (0x01UL << MAX11261_FIFO_OVW_POS))
+
+/**@} end of group MAX11261_FIFO_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_FIFO_LEVEL MAX11261_FIFO_LEVEL
+ * @brief    FIFO Level Register.
+ * @{
+ */
+#define MAX11261_FIFO_LEVEL 0x14
+
+#define MAX11261_FIFO_LEVEL_FIFO_LEVEL_POS  0 /**< FIFO_LEVEL Position */
+#define MAX11261_FIFO_LEVEL_FIFO_LEVEL      ((uint8_t) (0x7FUL << MAX11261_FIFO_LEVEL_FIFO_LEVEL_POS))
+
+/**@} end of group MAX11261_FIFO_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_FIFO_CTRL MAX11261_FIFO_CTRL
+ * @brief    FIFO Control Register.
+ * @{
+ */
+#define MAX11261_FIFO_CTRL  0x15
+
+#define MAX11261_FIFO_CTRL_RST_POS  0 /**< RST Position */
+#define MAX11261_FIFO_CTRL_RST      ((uint8_t) (0x01UL << MAX11261_FIFO_CTRL_RST_POS))
+
+#define MAX11261_FIFO_CTRL_FIFO1_8_INTEN_POS    1 /**< FIFO1_8_INTEN Position */
+#define MAX11261_FIFO_CTRL_FIFO1_8_INTEN        ((uint8_t) (0x01UL << MAX11261_FIFO_CTRL_FIFO1_8_INTEN_POS))
+
+#define MAX11261_FIFO_CTRL_FIFO2_8_INTEN_POS    2 /**< FIFO2_8_INTEN Position */
+#define MAX11261_FIFO_CTRL_FIFO2_8_INTEN        ((uint8_t) (0x01UL << MAX11261_FIFO_CTRL_FIFO2_8_INTEN_POS))
+
+#define MAX11261_FIFO_CTRL_FIFO4_8_INTEN_POS    3 /**< FIFO4_8_INTEN Position */
+#define MAX11261_FIFO_CTRL_FIFO4_8_INTEN        ((uint8_t) (0x01UL << MAX11261_FIFO_CTRL_FIFO4_8_INTEN_POS))
+
+#define MAX11261_FIFO_CTRL_FIFO6_8_INTEN_POS    4 /**< FIFO6_8_INTEN Position */
+#define MAX11261_FIFO_CTRL_FIFO6_8_INTEN        ((uint8_t) (0x01UL << MAX11261_FIFO_CTRL_FIFO6_8_INTEN_POS))
+
+#define MAX11261_FIFO_CTRL_FIFO7_8_INTEN_POS    5 /**< FIFO7_8_INTEN Position */
+#define MAX11261_FIFO_CTRL_FIFO7_8_INTEN        ((uint8_t) (0x01UL << MAX11261_FIFO_CTRL_FIFO7_8_INTEN_POS))
+
+#define MAX11261_FIFO_CTRL_OVW_INTEN_POS        6 /**< OVW_INTEN Position */
+#define MAX11261_FIFO_CTRL_OVW_INTEN            ((uint8_t) (0x01UL << MAX11261_FIFO_CTRL_OVW_INTEN_POS))
+
+/**@} end of group MAX11261_FIFO_CTRL_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_INPUT_INT_EN MAX11261_INPUT_INT_EN
+ * @brief    Input Interrupt Enable Register.
+ * @{
+ */
+#define MAX11261_INPUT_INT_EN   0x16
+
+#define MAX11261_INPUT_INT_EN_CH_POS    0 /**< CH Position */
+#define MAX11261_INPUT_INT_EN_CH        ((uint8_t) (0x3FUL << MAX11261_INPUT_INT_EN_CH_POS))
+
+#define MAX11261_INPUT_INT_EN_RDYB_POS  7 /**< RDYB Position */
+#define MAX11261_INPUT_INT_EN_RDYB      ((uint8_t) (0x01UL << MAX11261_INPUT_INT_EN_RDYB_POS))
+
+/**@} end of group MAX11261_INPUT_INT_EN_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_INT_STAT MAX11261_INT_STAT
+ * @brief    Interrupt Status Register.
+ * @{
+ */
+#define MAX11261_INT_STAT   0x17
+
+#define MAX11261_INPUT_INT_STAT_CH_POS       0 /**< CH Position */
+#define MAX11261_INPUT_INT_STAT_CH           ((uint32_t) (0x3FUL << MAX11261_INPUT_INT_STAT_CH_POS))
+
+#define MAX11261_INPUT_INT_STAT_FIFO1_8_POS  9 /**< FIFO1_8 Position */
+#define MAX11261_INPUT_INT_STAT_FIFO1_8      ((uint32_t) (0x01UL << MAX11261_INPUT_INT_STAT_FIFO1_8_POS))
+
+#define MAX11261_INPUT_INT_STAT_FIFO2_8_POS  10 /**< FIFO2_8 Position */
+#define MAX11261_INPUT_INT_STAT_FIFO2_8      ((uint32_t) (0x01UL << MAX11261_INPUT_INT_STAT_FIFO2_8_POS))
+
+#define MAX11261_INPUT_INT_STAT_FIFO4_8_POS  11 /**< FIFO4_8 Position */
+#define MAX11261_INPUT_INT_STAT_FIFO4_8      ((uint32_t) (0x01UL << MAX11261_INPUT_INT_STAT_FIFO4_8_POS))
+
+#define MAX11261_INPUT_INT_STAT_FIFO6_8_POS  12 /**< FIFO6_8 Position */
+#define MAX11261_INPUT_INT_STAT_FIFO6_8      ((uint32_t) (0x01UL << MAX11261_INPUT_INT_STAT_FIFO6_8_POS))
+
+#define MAX11261_INPUT_INT_STAT_FIFO7_8_POS  13 /**< FIFO7_8 Position */
+#define MAX11261_INPUT_INT_STAT_FIFO7_8      ((uint32_t) (0x01UL << MAX11261_INPUT_INT_STAT_FIFO7_8_POS))
+
+#define MAX11261_INPUT_INT_STAT_FIFO_OVW_POS 14 /**< FIFO_OVW Position */
+#define MAX11261_INPUT_INT_STAT_FIFO_OVW     ((uint32_t) (0x01UL << MAX11261_INPUT_INT_STAT_FIFO_OVW_POS))
+
+/**@} end of group MAX11261_INT_STAT_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_HPF MAX11261_HPF
+ * @brief    High-Pass Digital Filter Control Register.
+ * @{
+ */
+#define MAX11261_HPF    0x18
+
+#define MAX11261_HPF_FREQUENCY_POS  0 /**< FREQUENCY Position */
+#define MAX11261_HPF_FREQUENCY      ((uint8_t) (0x07UL << MAX11261_HPF_FREQUENCY_POS))
+
+#define MAX11261_HPF_CMP_MODE_POS   3 /**< CMP_MODE Position */
+#define MAX11261_HPF_CMP_MODE       ((uint8_t) (0x03UL << MAX11261_HPF_CMP_MODE_POS))
+
+/**@} end of group MAX11261_HPF_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_HIGH0 MAX11261_LIMIT_HIGH0
+ * @brief    Higher Limit Register for Channel 0.
+ * @{
+ */
+#define MAX11261_LIMIT_HIGH0    0x19
+
+#define MAX11261_LIMIT_HIGH0_D_POS  0 /**< D Position */
+#define MAX11261_LIMIT_HIGH0_D      ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_HIGH0_D_POS))
+
+/**@} end of group MAX11261_LIMIT_HIGH0_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_HIGH1 MAX11261_LIMIT_HIGH1
+ * @brief    Higher Limit Register for Channel 1.
+ * @{
+ */
+#define MAX11261_LIMIT_HIGH1    0x1A
+
+#define MAX11261_LIMIT_HIGH1_D_POS  0 /**< D Position */
+#define MAX11261_LIMIT_HIGH1_D      ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_HIGH1_D_POS))
+
+/**@} end of group MAX11261_LIMIT_HIGH1_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_HIGH2 MAX11261_LIMIT_HIGH2
+ * @brief    Higher Limit Register for Channel 2.
+ * @{
+ */
+#define MAX11261_LIMIT_HIGH2    0x1B
+
+#define MAX11261_LIMIT_HIGH2_D_POS  0 /**< D Position */
+#define MAX11261_LIMIT_HIGH2_D      ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_HIGH2_D_POS))
+
+/**@} end of group MAX11261_LIMIT_HIGH2_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_HIGH3 MAX11261_LIMIT_HIGH3
+ * @brief    Higher Limit Register for Channel 3.
+ * @{
+ */
+#define MAX11261_LIMIT_HIGH3    0x1C
+
+#define MAX11261_LIMIT_HIGH3_D_POS  0 /**< D Position */
+#define MAX11261_LIMIT_HIGH3_D      ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_HIGH3_D_POS))
+
+/**@} end of group MAX11261_LIMIT_HIGH3_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_HIGH4 MAX11261_LIMIT_HIGH4
+ * @brief    Higher Limit Register for Channel 4.
+ * @{
+ */
+#define MAX11261_LIMIT_HIGH4    0x1D
+
+#define MAX11261_LIMIT_HIGH4_D_POS  0 /**< D Position */
+#define MAX11261_LIMIT_HIGH4_D      ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_HIGH4_D_POS))
+
+/**@} end of group MAX11261_LIMIT_HIGH4_Register */
+
+/**
+ * @ingroup  max11261_registers
+ * @defgroup MAX11261_LIMIT_HIGH5 MAX11261_LIMIT_HIGH5
+ * @brief    Higher Limit Register for Channel 5.
+ * @{
+ */
+#define MAX11261_LIMIT_HIGH5    0x1E
+
+#define MAX11261_LIMIT_HIGH5_D_POS  0 /**< D Position */
+#define MAX11261_LIMIT_HIGH5_D      ((uint32_t) (0xFFFFFFUL << MAX11261_LIMIT_HIGH5_D_POS))
+
+/**@} end of group MAX11261_LIMIT_HIGH5_Register */
+
+#endif /* MAX11261_REGS_H_ */

--- a/Libraries/MiscDrivers/libinfo.json
+++ b/Libraries/MiscDrivers/libinfo.json
@@ -11,6 +11,7 @@
         "CODEC"
 	],
 	"vpaths":[
+		"ADC",
 		"Camera",
 		"Display",
 		"LED",


### PR DESCRIPTION
Initial MAX11261 ADC driver support and example application.

- Supports sequencer mode 1 with configurable polarity and format.
- Can switch input channels.
- Can switch sample rates.
- Platform functions are initialized in the board file.
- Driver works in GPIO or register poll mode.

Remaining work:
- Self and system calibration
- Error and overflow bit checks
- Programmable gain amplifier (PGA) support
- Interrupt support
- Sequencer modes 2, 3 and 4
