### PR TITLE
REV A ADC Driver Fix

### DIFF
--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
@@ -327,7 +327,9 @@ void MXC_ADC_RevA_DisableMonitorAsync(mxc_adc_monitor_t monitor)
 
 int MXC_ADC_RevA_StartConversion(mxc_adc_reva_regs_t *adc, mxc_adc_chsel_t channel)
 {
-    int data;
+    uint16_t data;
+    
+    
     int error;
 #if TARGET_NUM != 32650
     if (channel > AIN16) {
@@ -352,11 +354,11 @@ int MXC_ADC_RevA_StartConversion(mxc_adc_reva_regs_t *adc, mxc_adc_chsel_t chann
 
     while (adc->status & MXC_F_ADC_REVA_STATUS_ACTIVE) {}
 
-    if ((error = MXC_ADC_GetData((uint16_t *)&data)) != E_NO_ERROR) {
+    if ((error = MXC_ADC_GetData(&data)) != E_NO_ERROR) {
         return error;
     }
 
-    return data;
+    return (int)data;
 }
 
 int MXC_ADC_RevA_StartConversionAsync(mxc_adc_reva_regs_t *adc, mxc_adc_chsel_t channel,

--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
@@ -328,8 +328,7 @@ void MXC_ADC_RevA_DisableMonitorAsync(mxc_adc_monitor_t monitor)
 int MXC_ADC_RevA_StartConversion(mxc_adc_reva_regs_t *adc, mxc_adc_chsel_t channel)
 {
     uint16_t data;
-    
-    
+
     int error;
 #if TARGET_NUM != 32650
     if (channel > AIN16) {


### PR DESCRIPTION
Data returned from the following function is not correct. 

https://github.com/Analog-Devices-MSDK/msdk/blob/27e4f783a8c5ea709aabad22633a3a4e1f6dd097/Libraries/PeriphDrivers/Source/ADC/adc_reva.c#L328

The cast shown below causes the format of the value to be messed up.

https://github.com/Analog-Devices-MSDK/msdk/blob/27e4f783a8c5ea709aabad22633a3a4e1f6dd097/Libraries/PeriphDrivers/Source/ADC/adc_reva.c#L355

Instead of declaring the data as an int, I swiched to uint16_t to avoid this issue. Casting it as an int upon return fixes this issue and the data matches, the data coming from _MXC_ADC_GetData_

I haven't looked at the other revisions of the driver, but it is probably in them as well. 


The example doesn't catch this issue, because MXC_ADC_GetData is used directly.



