### PR TITLE
minor refactor

### DIFF
--- a/.github/workflows/ci-tests/Examples_tests/test_launcher.sh
+++ b/.github/workflows/ci-tests/Examples_tests/test_launcher.sh
@@ -86,6 +86,16 @@ function initial_setup() {
         export OPENOCD_TCL_PATH=/home/eddie/workspace/openocd/tcl
         export OPENOCD=/home/eddie/workspace/openocd/src/openocd
         export ROBOT=/home/eddie/.local/bin/robot
+    
+        MAIN_DEVICE_ID=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board1']['daplink'])"`     
+        main_uart=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board1']['uart0'])"`
+        MAIN_DEVICE_SERIAL_PORT=/dev/"$(ls -la /dev/serial/by-id | grep -n $main_uart | rev | cut -d "/" -f1 | rev)"
+
+        # Get the serial number of all daplink devices, this is used to erase them all.
+        DEVICE1=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board1']['daplink'])"`
+        DEVICE2=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])"`
+        DEVICE3=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])"`
+        DEVICE4=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['daplink'])"`
     fi
     
     # "Main device" is the ME17 used as the cleint dudring connected tests

--- a/.github/workflows/ci-tests/Examples_tests/test_launcher.sh
+++ b/.github/workflows/ci-tests/Examples_tests/test_launcher.sh
@@ -58,7 +58,7 @@ function initial_setup() {
         DEVICE2=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])"`
         DEVICE3=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])"`
         DEVICE4=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_w1']['daplink'])"`
-        DEVICE5=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_A5']['DAP_sn'])"`
+       # DEVICE5=`/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32690_board_A5']['DAP_sn'])"`
     elif [ $(hostname) == "yingcai-OptiPlex-790" ]; then
         echo "On machine yingcai-OptiPlex-790"
         echo
@@ -294,7 +294,7 @@ function erase_all_devices() {
     erase_with_openocd max32655 $DEVICE2
     erase_with_openocd max32665 $DEVICE3
     erase_with_openocd max32690 $DEVICE4
-    erase_with_openocd max32690 $DEVICE5
+   # erase_with_openocd max32690 $DEVICE5
 }
 #****************************************************************************************************
 function print_project_banner() {

--- a/Examples/MAX32655/BLE_datc/datc_main.c
+++ b/Examples/MAX32655/BLE_datc/datc_main.c
@@ -1003,8 +1003,7 @@ static void datcDiscCback(dmConnId_t connId, uint8_t status)
     case APP_DISC_FAILED:
         if (pAppCfg->abortDisc) {
             /* if discovery failed for proprietary data service then disconnect */
-            if (datcCb.discState[connId - 1] == DATC_DISC_WP_SVC ||
-                (datcCb.discState[connId - 1] == DATC_DISC_SDS_SVC)) {
+            if (datcCb.discState[connId - 1] < DATC_DISC_SVC_MAX) {
                 AppConnClose(connId);
                 break;
             }

--- a/Examples/MAX32655/BLE_otac/datc_main.c
+++ b/Examples/MAX32655/BLE_otac/datc_main.c
@@ -922,8 +922,8 @@ static void datcDiscCback(dmConnId_t connId, uint8_t status)
 
     case APP_DISC_FAILED:
         if (pAppCfg->abortDisc) {
-            /* if discovery failed for proprietary data service then disconnect */
-            if (datcCb.discState[connId - 1] == DATC_DISC_WP_SVC) {
+            /* if discovery failed for any service then disconnect */
+            if (datcCb.discState[connId - 1] < DATC_DISC_SVC_MAX) {
                 AppConnClose(connId);
                 break;
             }

--- a/Examples/MAX32655/BLE_otas/wdxs_file_ext.c
+++ b/Examples/MAX32655/BLE_otas/wdxs_file_ext.c
@@ -105,7 +105,7 @@ void wdxsFileEraseHandler(wsfEventMask_t event, wsfMsgHdr_t *pMsg)
     } else {
         /* Erase is complete */
         APP_TRACE_INFO0(">>> External flash erase complete <<<");
-        wdxsFtcSendRsp(1, WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
+        wdxsFtcSendRsp(AppConnIsOpen(), WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
     }
 }
 

--- a/Examples/MAX32655/BLE_otas/wdxs_file_int.c
+++ b/Examples/MAX32655/BLE_otas/wdxs_file_int.c
@@ -123,7 +123,7 @@ void wdxsFileEraseHandler(wsfEventMask_t event, wsfMsgHdr_t *pMsg)
     } else {
         /* Erase is complete */
         APP_TRACE_INFO0(">>> Internal flash erase complete <<<");
-        wdxsFtcSendRsp(1, WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
+        wdxsFtcSendRsp(AppConnIsOpen(), WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
     }
 }
 

--- a/Examples/MAX32665/BLE_datc/datc_main.c
+++ b/Examples/MAX32665/BLE_datc/datc_main.c
@@ -1003,8 +1003,7 @@ static void datcDiscCback(dmConnId_t connId, uint8_t status)
     case APP_DISC_FAILED:
         if (pAppCfg->abortDisc) {
             /* if discovery failed for proprietary data service then disconnect */
-            if (datcCb.discState[connId - 1] == DATC_DISC_WP_SVC ||
-                (datcCb.discState[connId - 1] == DATC_DISC_SDS_SVC)) {
+            if (datcCb.discState[connId - 1] < DATC_DISC_SVC_MAX) {
                 AppConnClose(connId);
                 break;
             }

--- a/Examples/MAX32665/BLE_otac/datc_main.c
+++ b/Examples/MAX32665/BLE_otac/datc_main.c
@@ -923,7 +923,7 @@ static void datcDiscCback(dmConnId_t connId, uint8_t status)
     case APP_DISC_FAILED:
         if (pAppCfg->abortDisc) {
             /* if discovery failed for proprietary data service then disconnect */
-            if (datcCb.discState[connId - 1] == DATC_DISC_WP_SVC) {
+            if (datcCb.discState[connId - 1] < DATC_DISC_SVC_MAX) {
                 AppConnClose(connId);
                 break;
             }

--- a/Examples/MAX32665/BLE_otas/wdxs_file_ext.c
+++ b/Examples/MAX32665/BLE_otas/wdxs_file_ext.c
@@ -105,7 +105,7 @@ void wdxsFileEraseHandler(wsfEventMask_t event, wsfMsgHdr_t *pMsg)
     } else {
         /* Erase is complete */
         APP_TRACE_INFO0(">>> External flash erase complete <<<");
-        wdxsFtcSendRsp(1, WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
+        wdxsFtcSendRsp(AppConnIsOpen(), WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
     }
 }
 

--- a/Examples/MAX32665/BLE_otas/wdxs_file_int.c
+++ b/Examples/MAX32665/BLE_otas/wdxs_file_int.c
@@ -106,7 +106,7 @@ void wdxsFileEraseHandler(wsfEventMask_t event, wsfMsgHdr_t *pMsg)
     } else {
         /* Erase is complete */
         APP_TRACE_INFO0(">>> Internal flash erase complete <<<");
-        wdxsFtcSendRsp(1, WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
+        wdxsFtcSendRsp(AppConnIsOpen(), WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
     }
 }
 /*************************************************************************************************/

--- a/Examples/MAX32690/BLE_datc/datc_main.c
+++ b/Examples/MAX32690/BLE_datc/datc_main.c
@@ -1003,8 +1003,7 @@ static void datcDiscCback(dmConnId_t connId, uint8_t status)
     case APP_DISC_FAILED:
         if (pAppCfg->abortDisc) {
             /* if discovery failed for proprietary data service then disconnect */
-            if (datcCb.discState[connId - 1] == DATC_DISC_WP_SVC ||
-                (datcCb.discState[connId - 1] == DATC_DISC_SDS_SVC)) {
+            if (datcCb.discState[connId - 1] < DATC_DISC_SVC_MAX ) {
                 AppConnClose(connId);
                 break;
             }

--- a/Examples/MAX32690/BLE_datc/datc_main.c
+++ b/Examples/MAX32690/BLE_datc/datc_main.c
@@ -1003,7 +1003,7 @@ static void datcDiscCback(dmConnId_t connId, uint8_t status)
     case APP_DISC_FAILED:
         if (pAppCfg->abortDisc) {
             /* if discovery failed for proprietary data service then disconnect */
-            if (datcCb.discState[connId - 1] < DATC_DISC_SVC_MAX ) {
+            if (datcCb.discState[connId - 1] < DATC_DISC_SVC_MAX) {
                 AppConnClose(connId);
                 break;
             }

--- a/Examples/MAX32690/BLE_otac/datc_main.c
+++ b/Examples/MAX32690/BLE_otac/datc_main.c
@@ -923,7 +923,7 @@ static void datcDiscCback(dmConnId_t connId, uint8_t status)
     case APP_DISC_FAILED:
         if (pAppCfg->abortDisc) {
             /* if discovery failed for proprietary data service then disconnect */
-            if (datcCb.discState[connId - 1] == DATC_DISC_WP_SVC) {
+            if (datcCb.discState[connId - 1] < DATC_DISC_SVC_MAX) {
                 AppConnClose(connId);
                 break;
             }

--- a/Examples/MAX32690/BLE_otas/wdxs_file_int.c
+++ b/Examples/MAX32690/BLE_otas/wdxs_file_int.c
@@ -106,7 +106,7 @@ void wdxsFileEraseHandler(wsfEventMask_t event, wsfMsgHdr_t *pMsg)
     } else {
         /* Erase is complete */
         APP_TRACE_INFO0(">>> Internal flash erase complete <<<");
-        wdxsFtcSendRsp(1, WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
+        wdxsFtcSendRsp(AppConnIsOpen(), WDX_FTC_OP_PUT_RSP, otaFileHdl, WDX_FTC_ST_SUCCESS);
     }
 }
 /*************************************************************************************************/


### PR DESCRIPTION
- If client fails to discover **any** service the example will not work as intended so disconnect. 
- Minor refactor of magic number used in function call
- Removes erase function of a board that is no longer on wall-e causing BLE test jobs to fail