### PR TITLE
Fix/adc

### DIFF
--- a/Examples/MAX32680/ADC/README.md
+++ b/Examples/MAX32680/ADC/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-Demonstrates the use of the ADC by continuously monitoring ADC input channel 0.  Vary the voltage on the AIN0 input (0 to 1.8V) to observe different readings from the ADC.
+Demonstrates the use of the ADC by continuously monitoring ADC input channel 4.  Vary the voltage on the AIN12 input (0 to 1.8V) to observe different readings from the ADC.
 
 The example can be configured to either use a polling or interrupt driven ADC Conversion by commenting or uncommenting the "USE_INTERRUPTS" define respectively. 
 
@@ -12,7 +12,7 @@ Any reading that exceeds the full-scale value of the ADC will have an '*' append
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP22(RX_SEL) and JP23(TX_SEL) to UART1 header.
 -   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--   Apply an input voltage between 0 and 0.9V to pin labeled 0 of the JH11 (Analog) header.
+-   Apply an input voltage between 0 and 1.8V to pin labeled 4 of the JH5 (Analog) header.
 
 ## Expected Output
 
@@ -20,20 +20,30 @@ The Console UART of the device will output these messages:
 
 ```
 ADC Example
-0: 0x0001
+ Low Limit on AIN12
+12: 0x0009
+
+ Low Limit on AIN12
+12: 0x001b
+
+ Low Limit on AIN12
+12: 0x000c
+
+ Low Limit on AIN12
+12: 0x001b
+
+ Low Limit on AIN12
+12: 0x0242
 
 
-0: 0x003f
+12: 0x01da
 
+ Low Limit on AIN12
+12: 0x03ff
 
-0: 0x01ad
+ High Limit on AIN12
+12: 0x03ff
 
-
-0: 0x028d
-
-
-0: 0x0289
-
-
-0: 0x006a
+ High Limit on AIN12
+12: 0x03ff
 ```

--- a/Examples/MAX32680/ADC/main.c
+++ b/Examples/MAX32680/ADC/main.c
@@ -85,7 +85,7 @@ int main(void)
     }
 
     /* Set up LIMIT0 to monitor high and low trip points */
-    MXC_ADC_SetMonitorChannel(MXC_ADC_MONITOR_0, MXC_ADC_CH_0);
+    MXC_ADC_SetMonitorChannel(MXC_ADC_MONITOR_0, MXC_ADC_CH_4);
     MXC_ADC_SetMonitorHighThreshold(MXC_ADC_MONITOR_0, 0x300);
     MXC_ADC_SetMonitorLowThreshold(MXC_ADC_MONITOR_0, 0x25);
     MXC_ADC_EnableMonitor(MXC_ADC_MONITOR_0);
@@ -103,20 +103,20 @@ int main(void)
         /* Convert channel 0 */
 #ifdef USE_INTERRUPTS
         adc_done = 0;
-        MXC_ADC_StartConversionAsync(MXC_ADC_CH_0, adc_complete_cb);
+        MXC_ADC_StartConversionAsync(MXC_ADC_CH_4, adc_complete_cb);
 
         while (!adc_done) {}
 #else
-        adc_val = MXC_ADC_StartConversion(MXC_ADC_CH_0);
+        adc_val = MXC_ADC_StartConversion(MXC_ADC_CH_4);
         overflow = (adc_val == E_OVERFLOW ? 1 : 0);
 #endif
 
         /* Display results on OLED display, display asterisk if overflow */
-        printf("0: 0x%04x%s\n\n", adc_val, overflow ? "*" : " ");
+        printf("4: 0x%04x%s\n\n", adc_val, overflow ? "*" : " ");
 
-        /* Determine if programmable limits on AIN0 were exceeded */
+        /* Determine if programmable limits on AIN12 were exceeded */
         if (MXC_ADC_GetFlags() & (MXC_F_ADC_INTR_LO_LIMIT_IF | MXC_F_ADC_INTR_HI_LIMIT_IF)) {
-            printf(" %s Limit on AIN0 ",
+            printf(" %s Limit on AIN12 ",
                    (MXC_ADC_GetFlags() & MXC_F_ADC_INTR_LO_LIMIT_IF) ? "Low" : "High");
             MXC_ADC_ClearFlags(MXC_F_ADC_INTR_LO_LIMIT_IF | MXC_F_ADC_INTR_HI_LIMIT_IF);
         } else {

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/gcr_regs.h
@@ -386,7 +386,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_GCR_PCLKDIV_ADCFRQ_POS                   10 /**< PCLKDIV_ADCFRQ Position */
-#define MXC_F_GCR_PCLKDIV_ADCFRQ                       ((uint32_t)(0x7UL << MXC_F_GCR_PCLKDIV_ADCFRQ_POS)) /**< PCLKDIV_ADCFRQ Mask */
+#define MXC_F_GCR_PCLKDIV_ADCFRQ                       ((uint32_t)(0xFUL << MXC_F_GCR_PCLKDIV_ADCFRQ_POS)) /**< PCLKDIV_ADCFRQ Mask */
 
 #define MXC_F_GCR_PCLKDIV_CNNCLKDIV_POS                14 /**< PCLKDIV_CNNCLKDIV Position */
 #define MXC_F_GCR_PCLKDIV_CNNCLKDIV                    ((uint32_t)(0x7UL << MXC_F_GCR_PCLKDIV_CNNCLKDIV_POS)) /**< PCLKDIV_CNNCLKDIV Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd
@@ -3220,7 +3220,7 @@
        <name>ADCFRQ</name>
        <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
        <bitOffset>10</bitOffset>
-       <bitWidth>3</bitWidth>
+       <bitWidth>4</bitWidth>
       </field>
       <field>
        <name>CNNCLKDIV</name>

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Include/gcr_regs.h
@@ -386,7 +386,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_GCR_PCLKDIV_ADCFRQ_POS                   10 /**< PCLKDIV_ADCFRQ Position */
-#define MXC_F_GCR_PCLKDIV_ADCFRQ                       ((uint32_t)(0x7UL << MXC_F_GCR_PCLKDIV_ADCFRQ_POS)) /**< PCLKDIV_ADCFRQ Mask */
+#define MXC_F_GCR_PCLKDIV_ADCFRQ                       ((uint32_t)(0xFUL << MXC_F_GCR_PCLKDIV_ADCFRQ_POS)) /**< PCLKDIV_ADCFRQ Mask */
 
 #define MXC_F_GCR_PCLKDIV_CNNCLKDIV_POS                14 /**< PCLKDIV_CNNCLKDIV Position */
 #define MXC_F_GCR_PCLKDIV_CNNCLKDIV                    ((uint32_t)(0x7UL << MXC_F_GCR_PCLKDIV_CNNCLKDIV_POS)) /**< PCLKDIV_CNNCLKDIV Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.svd
@@ -3220,7 +3220,7 @@
        <name>ADCFRQ</name>
        <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
        <bitOffset>10</bitOffset>
-       <bitWidth>3</bitWidth>
+       <bitWidth>4</bitWidth>
       </field>
       <field>
        <name>CNNCLKDIV</name>

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Include/gcr_regs.h
@@ -371,7 +371,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_GCR_PCLKDIV_ADCFRQ_POS                   10 /**< PCLKDIV_ADCFRQ Position */
-#define MXC_F_GCR_PCLKDIV_ADCFRQ                       ((uint32_t)(0x7UL << MXC_F_GCR_PCLKDIV_ADCFRQ_POS)) /**< PCLKDIV_ADCFRQ Mask */
+#define MXC_F_GCR_PCLKDIV_ADCFRQ                       ((uint32_t)(0xFUL << MXC_F_GCR_PCLKDIV_ADCFRQ_POS)) /**< PCLKDIV_ADCFRQ Mask */
 
 #define MXC_F_GCR_PCLKDIV_CNNCLKDIV_POS                14 /**< PCLKDIV_CNNCLKDIV Position */
 #define MXC_F_GCR_PCLKDIV_CNNCLKDIV                    ((uint32_t)(0x7UL << MXC_F_GCR_PCLKDIV_CNNCLKDIV_POS)) /**< PCLKDIV_CNNCLKDIV Mask */

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd
@@ -3408,7 +3408,7 @@
        <name>ADCFRQ</name>
        <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
        <bitOffset>10</bitOffset>
-       <bitWidth>3</bitWidth>
+       <bitWidth>4</bitWidth>
       </field>
       <field>
        <name>CNNCLKDIV</name>

--- a/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_ai85.svd
+++ b/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_ai85.svd
@@ -597,7 +597,7 @@
             <name>ADCFRQ</name>
             <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
             <bitOffset>10</bitOffset>
-            <bitWidth>3</bitWidth>
+            <bitWidth>4</bitWidth>
           </field>
           <field>
             <name>CNNCLKDIV</name>

--- a/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me17.svd
+++ b/Libraries/PeriphDrivers/Source/SYS/SVD/gcr_me17.svd
@@ -645,7 +645,7 @@
             <name>ADCFRQ</name>
             <description>ADC clock Frequency. These bits define the ADC clock frequency. fADC = fPCLK / (ADCFRQ)</description>
             <bitOffset>10</bitOffset>
-            <bitWidth>3</bitWidth>
+            <bitWidth>4</bitWidth>
           </field>
           <field>
             <name>CNNCLKDIV</name>


### PR DESCRIPTION
This PR modifies the ADC example to read an external analog input.

According to the datasheet 10-bit ADC supports four external analog inputs.

1. AIN12-P2.4-Channel 4
2. AIN13-P2.5-Channel 5
3. AIN14-P2.6-Channel 6
4. AIN15-P2.7-Channel 7

These pins are routed to JH5 connector on the EvKit. I updated the example to read AIN12.

The _adcfrq_ field in `GCR_PCLKDIV` is four bits wide ([13:10]) so fix that too in relevant header files.