### PR TITLE
Generate_Register_Files Workflow Test

### DIFF
--- a/.github/workflows/Generate_Register_Files.yml
+++ b/.github/workflows/Generate_Register_Files.yml
@@ -68,7 +68,17 @@ jobs:
 
       - name: Checkout msdk internal repository
         run: |
-          git clone git@github.com:Analog-Devices-MSDK/msdk-internal.git
+          pwd
+          ls
+
+          # BTM-CI might already have the msdk-internal repo cloned.
+          if [[ -d ${{ env.MSDK-INTERNAL_DIR }} ]]; then
+            cd ${{ env.MSDK-INTERNAL_DIR }}
+            git pull
+            cd ..
+          else
+            git clone git@github.com:Analog-Devices-MSDK/msdk-internal.git
+          fi
 
       - name: Generating register files.
         run: |

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva_me14.svd
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva_me14.svd
@@ -16,7 +16,7 @@
     </interrupt>
     <registers>
       <register>
-        <name>CTRL</name>
+        <name>CTRL0</name>
         <description>Control Register.</description>
         <addressOffset>0x00</addressOffset>
         <size>32</size>

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva_me14.svd
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva_me14.svd
@@ -16,7 +16,7 @@
     </interrupt>
     <registers>
       <register>
-        <name>CTRL0</name>
+        <name>CTRL</name>
         <description>Control Register.</description>
         <addressOffset>0x00</addressOffset>
         <size>32</size>


### PR DESCRIPTION
This PR was originally used to test the new "Generate_Register_Files" workflow, but I encountered an unexpected behavior running on the BTM-CI that needs to be resolved before I can test.

The runner shares the same workspace on the BTM-CI, and some repos weren't cleaned out before the runner picked up another job. Adding a guard around git clones is the best thing to get around leftover repos.