### PR TITLE
Resolve TFT Null Pointer issue.

### DIFF
--- a/Libraries/Boards/MAX32570/Source/tft.c
+++ b/Libraries/Boards/MAX32570/Source/tft.c
@@ -727,14 +727,16 @@ int MXC_TFT_Init(void)
     int result = E_NO_ERROR;
     mxc_gpio_cfg_t config;
 
-    // set images start addr
-    if (images_start_addr == NULL) {
-        images_start_addr = (uint8_t *)&_bin_start_;
-    }
-
-    // set header
+    // Initialize images_header to contain no image data.
+    // This sets the number of palettes, fonts, and bitmaps to 0.
     memset(&images_header, 0, sizeof(Header_images_t));
-    memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+
+    // Is there any image data to work with?
+    if(_bin_start_ != _bin_end_) {
+        images_start_addr = (uint8_t *)&_bin_start_;
+        // set header
+        memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+    }
 
     /*
      *      Configure GPIO Pins
@@ -823,11 +825,11 @@ void MXC_TFT_ShowImage(int x0, int y0, int id)
     bitmap_info_t bitmap_info;
     uint8_t *pixel;
 
-    __disable_irq();
-
     if ((uint32_t)id >= images_header.nb_bitmap) {
         return;
     }
+
+    __disable_irq();
 
     get_bitmap_info(id, &bitmap_info, &pixel);
 

--- a/Libraries/Boards/MAX32570/Source/tft.c
+++ b/Libraries/Boards/MAX32570/Source/tft.c
@@ -108,6 +108,7 @@ typedef struct {
 #pragma pack()
 
 extern uint32_t _bin_start_; // binary start address, defined in linker file
+extern uint32_t _bin_end_; // binary end address, defined in linker file
 static uint8_t *images_start_addr = NULL;
 static Header_images_t images_header;
 
@@ -732,7 +733,7 @@ int MXC_TFT_Init(void)
     memset(&images_header, 0, sizeof(Header_images_t));
 
     // Is there any image data to work with?
-    if(_bin_start_ != _bin_end_) {
+    if (_bin_start_ != _bin_end_) {
         images_start_addr = (uint8_t *)&_bin_start_;
         // set header
         memcpy(&images_header, images_start_addr, sizeof(Header_images_t));

--- a/Libraries/Boards/MAX32572/Source/tft.c
+++ b/Libraries/Boards/MAX32572/Source/tft.c
@@ -105,6 +105,7 @@ typedef struct {
 #pragma pack()
 
 extern uint32_t _bin_start_; // binary start address, defined in linker file
+extern uint32_t _bin_end_; // binary end address, defined in linker file
 static uint8_t *images_start_addr = NULL;
 static Header_images_t images_header;
 
@@ -724,7 +725,7 @@ int MXC_TFT_Init(void)
     memset(&images_header, 0, sizeof(Header_images_t));
 
     // Is there any image data to work with?
-    if(_bin_start_ != _bin_end_) {
+    if (_bin_start_ != _bin_end_) {
         images_start_addr = (uint8_t *)&_bin_start_;
         // set header
         memcpy(&images_header, images_start_addr, sizeof(Header_images_t));

--- a/Libraries/Boards/MAX32572/Source/tft.c
+++ b/Libraries/Boards/MAX32572/Source/tft.c
@@ -719,14 +719,16 @@ int MXC_TFT_Init(void)
     int result = E_NO_ERROR;
     mxc_gpio_cfg_t config;
 
-    // set images start addr
-    if (images_start_addr == NULL) {
-        images_start_addr = (uint8_t *)&_bin_start_;
-    }
-
-    // set header
+    // Initialize images_header to contain no image data.
+    // This sets the number of palettes, fonts, and bitmaps to 0.
     memset(&images_header, 0, sizeof(Header_images_t));
-    memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+
+    // Is there any image data to work with?
+    if(_bin_start_ != _bin_end_) {
+        images_start_addr = (uint8_t *)&_bin_start_;
+        // set header
+        memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+    }
 
     /*
      *      Configure GPIO Pins

--- a/Libraries/Boards/MAX32655/Source/tft.c
+++ b/Libraries/Boards/MAX32655/Source/tft.c
@@ -838,14 +838,16 @@ int MXC_TFT_Init(mxc_spi_regs_t *tft_spi, int ss_idx, mxc_gpio_cfg_t *reset_ctrl
     reset_pin = reset_ctrl;
     blen_pin = bl_ctrl;
 
-    // set images start addr
-    if (images_start_addr == NULL) {
-        images_start_addr = (uint8_t *)&_bin_start_;
-    }
-
-    // set header
+    // Initialize images_header to contain no image data.
+    // This sets the number of palettes, fonts, and bitmaps to 0.
     memset(&images_header, 0, sizeof(Header_images_t));
-    memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+
+    // Is there any image data to work with?
+    if(_bin_start_ != _bin_end_) {
+        images_start_addr = (uint8_t *)&_bin_start_;
+        // set header
+        memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+    }
 
     /*
      *      Configure GPIO Pins

--- a/Libraries/Boards/MAX32655/Source/tft.c
+++ b/Libraries/Boards/MAX32655/Source/tft.c
@@ -102,6 +102,7 @@ typedef struct {
 #pragma pack()
 
 extern uint32_t _bin_start_; // binary start address, defined in linker file
+extern uint32_t _bin_end_; // binary end address, defined in linker file
 static uint8_t *images_start_addr = NULL;
 static Header_images_t images_header;
 
@@ -843,7 +844,7 @@ int MXC_TFT_Init(mxc_spi_regs_t *tft_spi, int ss_idx, mxc_gpio_cfg_t *reset_ctrl
     memset(&images_header, 0, sizeof(Header_images_t));
 
     // Is there any image data to work with?
-    if(_bin_start_ != _bin_end_) {
+    if (_bin_start_ != _bin_end_) {
         images_start_addr = (uint8_t *)&_bin_start_;
         // set header
         memcpy(&images_header, images_start_addr, sizeof(Header_images_t));

--- a/Libraries/MiscDrivers/Display/tft_ssd2119.c
+++ b/Libraries/MiscDrivers/Display/tft_ssd2119.c
@@ -932,14 +932,16 @@ int MXC_TFT_Init(void)
 {
     int result = E_NO_ERROR;
 
-    // set images start addr
-    if (images_start_addr == NULL) {
-        images_start_addr = (unsigned char *)&_bin_start_;
-    }
-
-    // set header
+    // Initialize images_header to contain no image data.  
+    // This sets the number of palettes, fonts, and bitmaps to 0.
     memset(&images_header, 0, sizeof(Header_images_t));
-    memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+
+    // Is there any image data to work with?
+    if(_bin_start_ != _bin_end_) {
+        images_start_addr = (unsigned char *)&_bin_start_;
+        // set header
+        memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+    }
 
     /*
      *      Configure GPIO Pins

--- a/Libraries/MiscDrivers/Display/tft_ssd2119.c
+++ b/Libraries/MiscDrivers/Display/tft_ssd2119.c
@@ -130,6 +130,7 @@ typedef struct {
 #pragma pack()
 
 extern unsigned int _bin_start_; // binary start address, defined in linker file
+extern unsigned int _bin_end_; // binary end address, defined in linker file
 static unsigned char *images_start_addr = NULL;
 static Header_images_t images_header;
 
@@ -932,12 +933,12 @@ int MXC_TFT_Init(void)
 {
     int result = E_NO_ERROR;
 
-    // Initialize images_header to contain no image data.  
+    // Initialize images_header to contain no image data.
     // This sets the number of palettes, fonts, and bitmaps to 0.
     memset(&images_header, 0, sizeof(Header_images_t));
 
     // Is there any image data to work with?
-    if(_bin_start_ != _bin_end_) {
+    if (_bin_start_ != _bin_end_) {
         images_start_addr = (unsigned char *)&_bin_start_;
         // set header
         memcpy(&images_header, images_start_addr, sizeof(Header_images_t));


### PR DESCRIPTION
See MSDK-1061.  The TFT driver did not properly handle the case where there is no code/data placed in the .bin_storage section.  The fix was to initialize the image data structure so that the number of bitmaps, fonts, and palettes are initialized to 0.  All functions were then checked to make sure they confirmed the image ID they were asked to use was less than then number of objects.