### PR TITLE
MSDK-1060: Fix unknown type error in ME10 mxc_lock.h

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32650/mxc_lock.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/mxc_lock.h
@@ -41,7 +41,7 @@
 #define LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32650_MXC_LOCK_H_
 
 /* **** Includes **** */
-#include "mxc_errors.h"
+#include "mxc_device.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This PR fixes the type error encountered when including mxc_lock.h in a MAX32650 project.