### PR TITLE
Build Action:  Fix Unexpected End of JSON Input

### DIFF
--- a/.github/workflows/Build_Examples.yml
+++ b/.github/workflows/Build_Examples.yml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}
         uses: actions/setup-python@v4.5.0
         with:
-          cache: pip
+          python-version: '3.10'
 
       - name: Install packages
         if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}


### PR DESCRIPTION
This should fix the Python post-setup failure (ex https://github.com/Analog-Devices-MSDK/msdk/actions/runs/4389485741/jobs/7687079761) in the Build Examples action as per https://github.com/actions/setup-python/issues/475