### PR TITLE
Fix RISC-V Debug Functional Test Errors

### DIFF
--- a/Examples/MAX32655/Hello_World-riscv/main_riscv.c
+++ b/Examples/MAX32655/Hello_World-riscv/main_riscv.c
@@ -47,6 +47,9 @@ int main(void)
     Debug_Init(); // Set up RISCV JTAG
     MXC_ICC_Enable(MXC_ICC1); // Enable cache
 
+    // Signal the Cortex-M4
+    MXC_SEMA->irq0 = MXC_F_SEMA_IRQ0_EN | MXC_F_SEMA_IRQ0_CM4_IRQ;
+
     printf("Hello World!\n");
     while (1) {
         LED_On(0);
@@ -55,9 +58,6 @@ int main(void)
         MXC_Delay(500000);
         printf("count = %d\n", cnt++);
     }
-
-    // Signal the Cortex-M4
-    MXC_SEMA->irq0 = MXC_F_SEMA_IRQ0_EN | MXC_F_SEMA_IRQ0_CM4_IRQ;
 
     return 0;
 }

--- a/Examples/MAX32680/Hello_World-riscv/main_riscv.c
+++ b/Examples/MAX32680/Hello_World-riscv/main_riscv.c
@@ -47,6 +47,9 @@ int main(void)
     Debug_Init(); // Set up RISCV JTAG
     MXC_ICC_Enable(MXC_ICC1); // Enable cache
 
+    // Signal the Cortex-M4
+    MXC_SEMA->irq0 = MXC_F_SEMA_IRQ0_EN | MXC_F_SEMA_IRQ0_CM4_IRQ;
+
     printf("Hello World!\n");
     while (1) {
         LED_On(0);
@@ -55,9 +58,6 @@ int main(void)
         MXC_Delay(500000);
         printf("count = %d\n", cnt++);
     }
-
-    // Signal the Cortex-M4
-    MXC_SEMA->irq0 = MXC_F_SEMA_IRQ0_EN | MXC_F_SEMA_IRQ0_CM4_IRQ;
 
     return 0;
 }

--- a/Examples/MAX78002/CNN/imagenet-riscv/main.c
+++ b/Examples/MAX78002/CNN/imagenet-riscv/main.c
@@ -62,7 +62,7 @@ int main(void)
 
     MXC_FCR->urvbootaddr = (uint32_t)&__FlashStart_; // Set RISC-V boot address
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SMPHR); // Enable Sempahore clock
-    NVIC_SetVector(RISCV_IRQn, WakeISR); // Set wakeup ISR
+    MXC_NVIC_SetVector(RISCV_IRQn, WakeISR); // Set wakeup ISR
 
     // DO NOT DELETE THIS LINE:
     MXC_Delay(SEC(2)); // Let debugger interrupt if needed


### PR DESCRIPTION
After adding missing RISC-V config files in https://github.com/Analog-Devices-MSDK/openocd/pull/18, functional testing revealed some stragglers.
* The `Hello_World-riscv` projects would never signal the M4 core
* `imagenet-riscv` for the AI87 never triggered the M4 core's ISR.  (https://github.com/MaximIntegratedAI/ai8x-synthesis/pull/284 not merged yet)