### PR TITLE
Update MAX32570 camera interface

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32570/cameraif.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/cameraif.h
@@ -67,6 +67,16 @@ typedef enum {
 } mxc_pcif_datawidth_t;
 
 /**
+ * @brief   The list of Camera GPIO Datawidth options supported
+ *
+ */
+typedef enum {
+    MXC_PCIF_GPIO_DATAWIDTH_8_BIT = 0, ///<
+    MXC_PCIF_GPIO_DATAWIDTH_10_BIT, ///<
+    MXC_PCIF_GPIO_DATAWIDTH_12_BIT, ///<
+} mxc_pcif_gpio_datawidth_t;
+
+/**
  * @brief   The list of Camera Interface ReadMode options supported
  *
  */
@@ -87,11 +97,13 @@ typedef enum {
 /* **** Function Prototypes **** */
 
 /**
- * @brief   Initialize camera interface, set clock, configure gpios
+ * @brief Initialize the Parallel Camera Interface.
  *
- * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ * @param gpioDataWidth   Desired datawidth for the camera interface (8, 10 or 12 bits).
+ *
+ * @return E_NO_ERROR if successful, otherwise E_BAD_PARAM.
  */
-int MXC_PCIF_Init(void);
+int MXC_PCIF_Init(mxc_pcif_gpio_datawidth_t gpioDataWidth);
 
 /**
  * @brief   Initialize camera interface, set clock, configure gpios

--- a/Libraries/PeriphDrivers/Include/MAX32570/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/mxc_pins.h
@@ -133,8 +133,10 @@ extern const mxc_gpio_cfg_t gpio_cfg_emac_P2b;
 extern const mxc_gpio_cfg_t gpio_cfg_kbd_P2;
 
 // Note that both P0 and P1 must be configured for proper operation
-extern const mxc_gpio_cfg_t gpio_cfg_pcif_P0;
-extern const mxc_gpio_cfg_t gpio_cfg_pcif_P1;
+extern const mxc_gpio_cfg_t gpio_cfg_pcif_P0_BITS_0_7;
+extern const mxc_gpio_cfg_t gpio_cfg_pcif_P0_BITS_8;
+extern const mxc_gpio_cfg_t gpio_cfg_pcif_P1_BITS_9;
+extern const mxc_gpio_cfg_t gpio_cfg_pcif_P1_BITS_10_11;
 extern const mxc_gpio_cfg_t gpio_cfg_pcif_hsync;
 extern const mxc_gpio_cfg_t gpio_cfg_pcif_vsync;
 extern const mxc_gpio_cfg_t gpio_cfg_pcif_pclk;

--- a/Libraries/PeriphDrivers/Source/CAMERAIF/cameraif_me13.c
+++ b/Libraries/PeriphDrivers/Source/CAMERAIF/cameraif_me13.c
@@ -33,6 +33,10 @@
 
 /* **** Includes **** */
 #include <string.h>
+#include "mxc_device.h"
+#include "mxc_assert.h"
+#include "mxc_pins.h"
+#include "mxc_sys.h"
 #include "cameraif.h"
 #include "cameraif_reva.h"
 
@@ -42,8 +46,42 @@
 
 /* **** Functions **** */
 
-int MXC_PCIF_Init(void)
+int MXC_PCIF_Init(mxc_pcif_gpio_datawidth_t gpioDataWidth)
 {
+    if ((gpioDataWidth != MXC_PCIF_GPIO_DATAWIDTH_8_BIT) &&
+        (gpioDataWidth != MXC_PCIF_GPIO_DATAWIDTH_10_BIT) &&
+        (gpioDataWidth != MXC_PCIF_GPIO_DATAWIDTH_12_BIT)) {
+        return E_BAD_PARAM;
+    }
+
+    MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_PCIF);
+
+    switch (gpioDataWidth) {
+    case MXC_PCIF_DATAWIDTH_8_BIT:
+        MXC_GPIO_Config(&gpio_cfg_pcif_P0_BITS_0_7);
+        break;
+
+    case MXC_PCIF_DATAWIDTH_10_BIT:
+        MXC_GPIO_Config(&gpio_cfg_pcif_P0_BITS_0_7);
+        MXC_GPIO_Config(&gpio_cfg_pcif_P0_BITS_8);
+        MXC_GPIO_Config(&gpio_cfg_pcif_P1_BITS_9);
+        break;
+
+    case MXC_PCIF_DATAWIDTH_12_BIT:
+        MXC_GPIO_Config(&gpio_cfg_pcif_P0_BITS_0_7);
+        MXC_GPIO_Config(&gpio_cfg_pcif_P0_BITS_8);
+        MXC_GPIO_Config(&gpio_cfg_pcif_P1_BITS_9);
+        MXC_GPIO_Config(&gpio_cfg_pcif_P1_BITS_10_11);
+        break;
+    }
+
+    MXC_GPIO_Config(&gpio_cfg_pcif_hsync);
+    MXC_GPIO_Config(&gpio_cfg_pcif_vsync);
+    MXC_GPIO_Config(&gpio_cfg_pcif_pclk);
+    MXC_GPIO_Config(&gpio_cfg_pcif_pwrdwn);
+
+    MXC_GPIO_OutClr(gpio_cfg_pcif_pwrdwn.port, gpio_cfg_pcif_pwrdwn.mask);
+
     return MXC_PCIF_RevA_Init();
 }
 

--- a/Libraries/PeriphDrivers/Source/CAMERAIF/cameraif_me13.c
+++ b/Libraries/PeriphDrivers/Source/CAMERAIF/cameraif_me13.c
@@ -82,7 +82,7 @@ int MXC_PCIF_Init(mxc_pcif_gpio_datawidth_t gpioDataWidth)
 
     MXC_GPIO_OutClr(gpio_cfg_pcif_pwrdwn.port, gpio_cfg_pcif_pwrdwn.mask);
 
-    return MXC_PCIF_RevA_Init();
+    return E_NO_ERROR;
 }
 
 void MXC_PCIF_SetDatawidth(mxc_pcif_datawidth_t datawidth)

--- a/Libraries/PeriphDrivers/Source/CAMERAIF/cameraif_reva.c
+++ b/Libraries/PeriphDrivers/Source/CAMERAIF/cameraif_reva.c
@@ -51,16 +51,6 @@
 
 int MXC_PCIF_RevA_Init(void)
 {
-    MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_PCIF);
-    //MXC_GPIO_Config (&gpio_cfg_pcif_P0);
-    //MXC_GPIO_Config (&gpio_cfg_pcif_P1);
-    //MXC_GPIO_Config (&gpio_cfg_pcif_hsync);
-    //MXC_GPIO_Config (&gpio_cfg_pcif_vsync);
-    //MXC_GPIO_Config (&gpio_cfg_pcif_pclk);
-    //MXC_GPIO_Config (&gpio_cfg_pcif_pwrdwn);
-
-    //MXC_GPIO_OutClr (gpio_cfg_pcif_pwrdwn.port, gpio_cfg_pcif_pwrdwn.mask);
-
     return 0;
 }
 

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me13.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me13.c
@@ -168,7 +168,7 @@ const mxc_gpio_cfg_t gpio_cfg_pt3 = { MXC_GPIO0, MXC_GPIO_PIN_12, MXC_GPIO_FUNC_
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO };
 const mxc_gpio_cfg_t gpio_cfg_pt4 = { MXC_GPIO0, MXC_GPIO_PIN_13, MXC_GPIO_FUNC_ALT4,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_pt5 = { MXC_GPIO0, MXC_GPIO_PIN_14, MXC_GPIO_FUNC_ALT4,
+const mxc_gpio_cfg_t gpio_cfg_pt5 = { MXC_GPIO1, MXC_GPIO_PIN_7, MXC_GPIO_FUNC_ALT3,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO };
 const mxc_gpio_cfg_t gpio_cfg_pt6 = { MXC_GPIO1, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT3,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO };
@@ -245,12 +245,19 @@ const mxc_gpio_cfg_t gpio_cfg_kbd_P2 = { MXC_GPIO2, 0x000003FC, MXC_GPIO_FUNC_AL
                                          MXC_GPIO_PAD_PULL_UP };
 
 // Note that both P0 and P1 must be configured for proper operation
-const mxc_gpio_cfg_t gpio_cfg_pcif_P0 = { MXC_GPIO0, 0x00007FC0, MXC_GPIO_FUNC_ALT2,
-                                          MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH };
-const mxc_gpio_cfg_t gpio_cfg_pcif_P1 = { MXC_GPIO1,
-                                          (MXC_GPIO_PIN_1 | MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15),
-                                          MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE,
-                                          MXC_GPIO_VSSEL_VDDIOH };
+const mxc_gpio_cfg_t gpio_cfg_pcif_P0_BITS_0_7 = {
+    MXC_GPIO0,
+    (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7 | MXC_GPIO_PIN_8 | MXC_GPIO_PIN_9 | MXC_GPIO_PIN_10 |
+     MXC_GPIO_PIN_11 | MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13),
+    MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH
+};
+const mxc_gpio_cfg_t gpio_cfg_pcif_P0_BITS_8 = { MXC_GPIO0, (MXC_GPIO_PIN_14), MXC_GPIO_FUNC_ALT2,
+                                                 MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH };
+const mxc_gpio_cfg_t gpio_cfg_pcif_P1_BITS_9 = { MXC_GPIO1, (MXC_GPIO_PIN_14), MXC_GPIO_FUNC_ALT2,
+                                                 MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH };
+const mxc_gpio_cfg_t gpio_cfg_pcif_P1_BITS_10_11 = { MXC_GPIO1, (MXC_GPIO_PIN_1 | MXC_GPIO_PIN_15),
+                                                     MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE,
+                                                     MXC_GPIO_VSSEL_VDDIOH };
 const mxc_gpio_cfg_t gpio_cfg_pcif_hsync = { MXC_GPIO1, MXC_GPIO_PIN_2, MXC_GPIO_FUNC_ALT2,
                                              MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH };
 const mxc_gpio_cfg_t gpio_cfg_pcif_vsync = { MXC_GPIO1, MXC_GPIO_PIN_18, MXC_GPIO_FUNC_ALT4,


### PR DESCRIPTION
MSDK-1075: MAX32570 camera interface update
P1.7 is connected to camera on EvKits (M/Q, MN/QN)

Tested with CameraIF and BarcodeDecoder example it works.