### PR TITLE
implements script to mass erase devices upon unlock

### DIFF
--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -194,137 +194,8 @@ jobs:
           fi
 
       #----------------------------------------------------------------------------------------------
-      - name: Lock MAX32655 B1
-        if: env.LOCK_MAX32655_B1 == 'true'
-        id: lock_max32655_b1_0
-        run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32655_board1
+      #------------------------------| MAX32665 |----------------------------------------------------
       #----------------------------------------------------------------------------------------------
-      - name: Lock MAX32655 B2
-        if: env.LOCK_MAX32655_B2 == 'true'
-        id: lock_max32655_b2
-        run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32655_board2
-      #----------------------------------------------------------------------------------------------
-      - name: Test MAX32655 #name used for display purposes on github webpage
-        if: steps.lock_max32655_b2.outcome == 'success'
-        id: Test_MAX32655 #id used to reference this step in other parts of the yml
-        run: |
-          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
-          dut_uart=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['uart0'])")
-          dut_serial=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])")
-          examples_to_test=(${MAX32655_EXAMPLES_TO_TEST[@]})
-          echo
-          echo
-          echo "Examples to be tested : ${examples_to_test[@]}"
-          echo "MAX32655_RUN_ALL_TEST        : $MAX32655_RUN_ALL_TEST"
-          echo "MAX32655_DATS_CONNECTED_TEST : $MAX32655_DATS_CONNECTED_TEST "
-          echo "MAX32655_OTAS_CONNECTED_TEST  : $MAX32655_OTAS_CONNECTED_TEST"
-          echo "MAX32655_BLE_FILES_CHANGED   : $MAX32655_BLE_FILES_CHANGED "
-          echo "LOCK_MAX32655_B2             : $LOCK_MAX32655_B2 "
-
-          cd .github/workflows/scripts
-
-          if [[ $MAX32655_RUN_ALL_TEST == 'true' ]]; then
-              echo "Testing all examples"
-              set +e
-              ./test_launcher.sh max32655 $dut_uart $dut_serial "all"
-              let "testResult=$?"
-              if [ "$testResult" -ne "0" ]; then
-                    # update failed test count
-                    let "numOfFailedTests+=$testResult"
-              fi
-              set -e
-          else
-              if [[ $MAX32655_BLE_FILES_CHANGED == 'true' ]]; then
-                  #------non connected tests---------
-                  for example in "${examples_to_test[@]}"; do
-                      # launch single tests
-                      echo "Running $example test on MAX32655"
-                      set +e
-                      ./test_launcher.sh max32655 $dut_uart $dut_serial $example
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| $example"
-                      fi
-                      set -e
-                  done
-
-                  #------connected tests---------
-                  if [[ $MAX32655_DATS_CONNECTED_TEST == 'true' ]]; then
-                      #conencted test launcher
-                      echo "Testing MAX32655_DATS_CONNECTED_TEST"
-                      set +e
-                      ./test_launcher.sh max32655 $dut_uart $dut_serial "dats"
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed_test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| MAX32655 Dats/c"
-                      fi
-                      set -e
-
-                  fi
-                  #------connected tests---------
-                  if [[ $MAX32655_OTAS_CONNECTED_TEST == 'true' ]]; then
-                      #conencted test launcher
-                      echo "Testing MAX32655_OTAS_CONNECTED_TEST"
-                      set +e
-                      #call test here
-                      #***************** uncomment actual test here *************
-                      ./test_launcher.sh max32655 $dut_uart $dut_serial "ota"
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| MAX32655 OTAS/C"
-                      fi
-                      set -e
-                  fi
-              else
-                  echo "Skipping all tests"
-              fi
-            echo "=============================================================================="
-            echo "=============================================================================="
-
-            if [[ $numOfFailedTests -ne 0 ]]; then
-                printf "Test completed with $numOfFailedTests failed tests located in: \r\n $failedTestList"
-            else
-                echo "Relax! ALL TESTS PASSED"
-            fi
-            echo
-            echo "=============================================================================="
-            echo "=============================================================================="
-            echo
-          fi
-
-          exit $numOfFailedTests
-
-      - name: Unlock MAX32655 B1
-        if: ${{ always() && steps.lock_max32655_b1_0.outcome == 'success'}}
-        run: |
-          # leave board in known state if workflow should end early
-          cd .github/workflows/scripts
-          echo "Erasing Main MAX32655"
-          ./mass_erase_board.sh max32655 max32655_board1
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
-          echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
-
-      - name: Unlock MAX32655 B2
-        if: ${{ always() && steps.lock_max32655_b2.outcome == 'success'}}
-        run: |
-          # leave board in known state if workflow should end early
-          cd .github/workflows/scripts
-          echo "Erasing MAX32655"
-          ./mass_erase_board.sh max32655 max32655_board2
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board2
-
-
- #----------------------------------------------------------------------------------------------
- #------------------------------| MAX32665 |----------------------------------------------------
- #----------------------------------------------------------------------------------------------
 
       # Checks if changes have been made to require a test on ME14
       - name: Check MAX32665
@@ -445,135 +316,8 @@ jobs:
           fi
 
       #----------------------------------------------------------------------------------------------
-      - name: Lock MAX32655 B1
-        if: env.LOCK_MAX32655_B1 == 'true'
-        id: lock_max32655_b1_1
-        run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32655_board1
+      #------------------------------| MAX32690 |----------------------------------------------------
       #----------------------------------------------------------------------------------------------
-      - name: Lock MAX32665 B1
-        if: env.LOCK_MAX32665_B1 == 'true'
-        id: lock_max32665_b1
-        run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32665_board1
-      #----------------------------------------------------------------------------------------------
-      - name: Test MAX32665 #name used for display purposes on github webpage
-        if: steps.lock_max32665_b1.outcome == 'success'
-        id: Test_MAX32665 #id used to reference this step in other parts of the yml
-        run: |
-          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
-          dut_uart=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['uart1'])")
-          dut_serial=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])")
-          examples_to_test=(${MAX32665_EXAMPLES_TO_TEST[@]})
-          echo
-          echo
-          echo "Examples to be tested : ${examples_to_test[@]}"
-          echo "MAX32665_RUN_ALL_TEST        : $MAX32665_RUN_ALL_TEST"
-          echo "MAX32665_DATS_CONNECTED_TEST : $MAX32665_DATS_CONNECTED_TEST "
-          echo "MAX32665_OTAS_CONNECTED_TEST  : $MAX32665_OTAS_CONNECTED_TEST"
-          echo "MAX32665_BLE_FILES_CHANGED   : $MAX32665_BLE_FILES_CHANGED "
-          echo "LOCK_MAX32665_B1             : $LOCK_MAX32665_B1 "
-
-          cd .github/workflows/scripts
-
-          if [[ $MAX32665_RUN_ALL_TEST == 'true' ]]; then
-              echo "Testing all examples"
-               set +e
-               ./test_launcher.sh max32665 $dut_uart $dut_serial "all"
-               let "testResult=$?"
-               if [ "$testResult" -ne "0" ]; then
-                    # update failed test count
-                    let "numOfFailedTests+=$testResult"
-                fi
-                set -e
-          else
-              if [[ $MAX32665_BLE_FILES_CHANGED == 'true' ]]; then
-                  #------non connected tests---------
-                  for example in "${examples_to_test[@]}"; do
-                      # launch single tests
-                      echo "Running $example test on MAX32665"
-                      set +e
-                      ./test_launcher.sh max32665 $dut_uart $dut_serial $example
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| $example"
-                      fi
-                      set -e
-                  done
-
-                  #------connected tests---------
-                  if [[ $MAX32665_DATS_CONNECTED_TEST == 'true' ]]; then
-                      #conencted test launcher
-                      echo "Testing MAX32665_DATS_CONNECTED_TEST"
-                      set +e
-                      ./test_launcher.sh max32665 $dut_uart $dut_serial "dats"
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed_test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| MAX32665 Dats/c"
-                      fi
-                      set -e
-
-                  fi
-                  #------connected tests---------
-                  if [[ $MAX32665_OTAS_CONNECTED_TEST == 'true' ]]; then
-                      #conencted test launcher
-                      echo "Testing MAX32665_OTAS_CONNECTED_TEST"
-                      set +e
-                      #call test here
-                      #***************** uncomment actual test here *************
-                      ./test_launcher.sh max32665 $dut_uart $dut_serial "ota"
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| MAX32665 OTAS/C"
-                      fi
-                      set -e
-                  fi
-              else
-                  echo "Skipping all tests"
-              fi
-            echo "=============================================================================="
-            echo "=============================================================================="
-
-            if [[ $numOfFailedTests -ne 0 ]]; then
-                printf "Test completed with $numOfFailedTests failed tests located in: \r\n $failedTestList"
-            else
-                echo "Relax! ALL TESTS PASSED"
-            fi
-            echo
-            echo "=============================================================================="
-            echo "=============================================================================="
-            echo
-          fi
-          exit $numOfFailedTests
-
-      - name: Unlock MAX32655 B1
-        if: ${{ always() && steps.lock_max32655_b1_1.outcome == 'success'}}
-        run: |
-          echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
-          # leave board in known state if workflow should end early
-          cd .github/workflows/scripts
-          echo "Erasing Main MAX32655"
-          ./mass_erase_board.sh max32655 max32655_board1
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
-
-      - name: Unlock MAX32665 B1
-        if: ${{ always() && steps.lock_max32665_b1.outcome == 'success'}}
-        run: |
-          # leave board in known state if workflow should end early
-          cd .github/workflows/scripts
-          echo "Erasing MAX32665"
-          ./mass_erase_board.sh max32665 max32665_board1
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32665_board1
-
- #----------------------------------------------------------------------------------------------
- #------------------------------| MAX32690 |----------------------------------------------------
- #----------------------------------------------------------------------------------------------
 
       # Checks if changes have been made to require a test on ME14
       - name: Check MAX32690
@@ -694,17 +438,225 @@ jobs:
           fi
 
       #----------------------------------------------------------------------------------------------
+      #------------------------------| Lock all required board at once |-----------------------------
+      #----------------------------------------------------------------------------------------------
       - name: Lock MAX32655 B1
         if: env.LOCK_MAX32655_B1 == 'true'
-        id: lock_max32655_b1_2
+        id: lock_max32655_b1
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32655_board1
+      #----------------------------------------------------------------------------------------------
+      - name: Lock MAX32655 B2
+        if: env.LOCK_MAX32655_B2 == 'true'
+        id: lock_max32655_b2
+        run: |
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32655_board2
+      #----------------------------------------------------------------------------------------------
+      - name: Lock MAX32665 B1
+        if: env.LOCK_MAX32665_B1 == 'true'
+        id: lock_max32665_b1
+        run: |
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32665_board1
       #----------------------------------------------------------------------------------------------
       - name: Lock MAX32690 B1
         if: env.LOCK_MAX32690_B1 == 'true'
         id: lock_max32690_b1
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32690_board_w1
+      #----------------------------------------------------------------------------------------------
+      #----------------------------------------------------------------------------------------------
+      #------------------------------| Test all required board at once |-----------------------------
+      #----------------------------------------------------------------------------------------------
+      - name: Test MAX32665 #name used for display purposes on github webpage
+        if: steps.lock_max32665_b1.outcome == 'success'
+        id: Test_MAX32665 #id used to reference this step in other parts of the yml
+        run: |
+          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+          dut_uart=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['uart1'])")
+          dut_serial=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])")
+          examples_to_test=(${MAX32665_EXAMPLES_TO_TEST[@]})
+          echo
+          echo
+          echo "Examples to be tested : ${examples_to_test[@]}"
+          echo "MAX32665_RUN_ALL_TEST        : $MAX32665_RUN_ALL_TEST"
+          echo "MAX32665_DATS_CONNECTED_TEST : $MAX32665_DATS_CONNECTED_TEST "
+          echo "MAX32665_OTAS_CONNECTED_TEST  : $MAX32665_OTAS_CONNECTED_TEST"
+          echo "MAX32665_BLE_FILES_CHANGED   : $MAX32665_BLE_FILES_CHANGED "
+          echo "LOCK_MAX32665_B1             : $LOCK_MAX32665_B1 "
+
+          cd .github/workflows/scripts
+
+          if [[ $MAX32665_RUN_ALL_TEST == 'true' ]]; then
+              echo "Testing all examples"
+               set +e
+               ./test_launcher.sh max32665 $dut_uart $dut_serial "all"
+               let "testResult=$?"
+               if [ "$testResult" -ne "0" ]; then
+                    # update failed test count
+                    let "numOfFailedTests+=$testResult"
+                fi
+                set -e
+          else
+              if [[ $MAX32665_BLE_FILES_CHANGED == 'true' ]]; then
+                  #------non connected tests---------
+                  for example in "${examples_to_test[@]}"; do
+                      # launch single tests
+                      echo "Running $example test on MAX32665"
+                      set +e
+                      ./test_launcher.sh max32665 $dut_uart $dut_serial $example
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| $example"
+                      fi
+                      set -e
+                  done
+
+                  #------connected tests---------
+                  if [[ $MAX32665_DATS_CONNECTED_TEST == 'true' ]]; then
+                      #conencted test launcher
+                      echo "Testing MAX32665_DATS_CONNECTED_TEST"
+                      set +e
+                      ./test_launcher.sh max32665 $dut_uart $dut_serial "dats"
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed_test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| MAX32665 Dats/c"
+                      fi
+                      set -e
+
+                  fi
+                  #------connected tests---------
+                  if [[ $MAX32665_OTAS_CONNECTED_TEST == 'true' ]]; then
+                      #conencted test launcher
+                      echo "Testing MAX32665_OTAS_CONNECTED_TEST"
+                      set +e
+                      #call test here
+                      #***************** uncomment actual test here *************
+                      ./test_launcher.sh max32665 $dut_uart $dut_serial "ota"
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| MAX32665 OTAS/C"
+                      fi
+                      set -e
+                  fi
+              else
+                  echo "Skipping all tests"
+              fi
+            echo "=============================================================================="
+            echo "=============================================================================="
+
+            if [[ $numOfFailedTests -ne 0 ]]; then
+                printf "Test completed with $numOfFailedTests failed tests located in: \r\n $failedTestList"
+            else
+                echo "Relax! ALL TESTS PASSED"
+            fi
+            echo
+            echo "=============================================================================="
+            echo "=============================================================================="
+            echo
+          fi
+          exit $numOfFailedTests
+      #----------------------------------------------------------------------------------------------
+      - name: Test MAX32655 #name used for display purposes on github webpage
+        if: steps.lock_max32655_b2.outcome == 'success'
+        id: Test_MAX32655 #id used to reference this step in other parts of the yml
+        run: |
+          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+          dut_uart=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['uart0'])")
+          dut_serial=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32655_board2']['daplink'])")
+          examples_to_test=(${MAX32655_EXAMPLES_TO_TEST[@]})
+          echo
+          echo
+          echo "Examples to be tested : ${examples_to_test[@]}"
+          echo "MAX32655_RUN_ALL_TEST        : $MAX32655_RUN_ALL_TEST"
+          echo "MAX32655_DATS_CONNECTED_TEST : $MAX32655_DATS_CONNECTED_TEST "
+          echo "MAX32655_OTAS_CONNECTED_TEST  : $MAX32655_OTAS_CONNECTED_TEST"
+          echo "MAX32655_BLE_FILES_CHANGED   : $MAX32655_BLE_FILES_CHANGED "
+          echo "LOCK_MAX32655_B2             : $LOCK_MAX32655_B2 "
+
+          cd .github/workflows/scripts
+
+          if [[ $MAX32655_RUN_ALL_TEST == 'true' ]]; then
+              echo "Testing all examples"
+              set +e
+              ./test_launcher.sh max32655 $dut_uart $dut_serial "all"
+              let "testResult=$?"
+              if [ "$testResult" -ne "0" ]; then
+                    # update failed test count
+                    let "numOfFailedTests+=$testResult"
+              fi
+              set -e
+          else
+              if [[ $MAX32655_BLE_FILES_CHANGED == 'true' ]]; then
+                  #------non connected tests---------
+                  for example in "${examples_to_test[@]}"; do
+                      # launch single tests
+                      echo "Running $example test on MAX32655"
+                      set +e
+                      ./test_launcher.sh max32655 $dut_uart $dut_serial $example
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| $example"
+                      fi
+                      set -e
+                  done
+
+                  #------connected tests---------
+                  if [[ $MAX32655_DATS_CONNECTED_TEST == 'true' ]]; then
+                      #conencted test launcher
+                      echo "Testing MAX32655_DATS_CONNECTED_TEST"
+                      set +e
+                      ./test_launcher.sh max32655 $dut_uart $dut_serial "dats"
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed_test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| MAX32655 Dats/c"
+                      fi
+                      set -e
+
+                  fi
+                  #------connected tests---------
+                  if [[ $MAX32655_OTAS_CONNECTED_TEST == 'true' ]]; then
+                      #conencted test launcher
+                      echo "Testing MAX32655_OTAS_CONNECTED_TEST"
+                      set +e
+                      #call test here
+                      #***************** uncomment actual test here *************
+                      ./test_launcher.sh max32655 $dut_uart $dut_serial "ota"
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| MAX32655 OTAS/C"
+                      fi
+                      set -e
+                  fi
+              else
+                  echo "Skipping all tests"
+              fi
+            echo "=============================================================================="
+            echo "=============================================================================="
+
+            if [[ $numOfFailedTests -ne 0 ]]; then
+                printf "Test completed with $numOfFailedTests failed tests located in: \r\n $failedTestList"
+            else
+                echo "Relax! ALL TESTS PASSED"
+            fi
+            echo
+            echo "=============================================================================="
+            echo "=============================================================================="
+            echo
+          fi
+
+          exit $numOfFailedTests
       #----------------------------------------------------------------------------------------------
       - name: Test MAX32690 #name used for display purposes on github webpage
         if: steps.lock_max32690_b1.outcome == 'success'
@@ -801,9 +753,12 @@ jobs:
           fi
 
           exit $numOfFailedTests
-
+      #----------------------------------------------------------------------------------------------
+      #----------------------------------------------------------------------------------------------
+      #------------------------------| Unock all required board at once |-----------------------------
+      #----------------------------------------------------------------------------------------------
       - name: Unlock MAX32655 B1
-        if: ${{ always() && steps.lock_max32655_b1_2.outcome == 'success'}}
+        if: ${{ always() && steps.lock_max32655_b1.outcome == 'success'}}
         run: |
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
           # leave board in known state if workflow should end early
@@ -811,7 +766,25 @@ jobs:
           echo "Erasing Main MAX32655"
           ./mass_erase_board.sh max32655 max32655_board1
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
-
+      #----------------------------------------------------------------------------------------------
+      - name: Unlock MAX32655 B2
+        if: ${{ always() && steps.lock_max32655_b2.outcome == 'success'}}
+        run: |
+          # leave board in known state if workflow should end early
+          cd .github/workflows/scripts
+          echo "Erasing MAX32655"
+          ./mass_erase_board.sh max32655 max32655_board2
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board2
+       #----------------------------------------------------------------------------------------------
+      - name: Unlock MAX32665 B1
+        if: ${{ always() && steps.lock_max32665_b1.outcome == 'success'}}
+        run: |
+          # leave board in known state if workflow should end early
+          cd .github/workflows/scripts
+          echo "Erasing MAX32665"
+          ./mass_erase_board.sh max32665 max32665_board1
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32665_board1
+      #----------------------------------------------------------------------------------------------
       - name: Unlock MAX32690 B1
         if: ${{ always() && steps.lock_max32690_b1.outcome == 'success'}}
         run: |
@@ -820,7 +793,7 @@ jobs:
           echo "Erasing MAX32690"
           ./mass_erase_board.sh max32690 max32690_board_w1
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32690_board_w1
-
+      #----------------------------------------------------------------------------------------------
       # Save test reports
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -305,21 +305,21 @@ jobs:
       - name: Unlock MAX32655 B1
         if: ${{ always() && steps.lock_max32655_b1_0.outcome == 'success'}}
         run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
           ./mass_erase_board.sh max32655 max32655_b1
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
 
       - name: Unlock MAX32655 B2
         if: ${{ always() && steps.lock_max32655_b2.outcome == 'success'}}
         run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board2
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing MAX32655"
           ./mass_erase_board.sh max32655 max32655_board2
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board2
 
 
  #----------------------------------------------------------------------------------------------
@@ -555,21 +555,21 @@ jobs:
       - name: Unlock MAX32655 B1
         if: ${{ always() && steps.lock_max32655_b1_1.outcome == 'success'}}
         run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
           ./mass_erase_board.sh max32655 max32655_b1
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
 
       - name: Unlock MAX32665 B1
         if: ${{ always() && steps.lock_max32665_b1.outcome == 'success'}}
         run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32665_board1
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing MAX32665"
           ./mass_erase_board.sh max32665 max32665_board1
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32665_board1
 
  #----------------------------------------------------------------------------------------------
  #------------------------------| MAX32690 |----------------------------------------------------
@@ -805,21 +805,21 @@ jobs:
       - name: Unlock MAX32655 B1
         if: ${{ always() && steps.lock_max32655_b1_2.outcome == 'success'}}
         run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
           ./mass_erase_board.sh max32655 max32655_b1
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
 
       - name: Unlock MAX32690 B1
         if: ${{ always() && steps.lock_max32690_b1.outcome == 'success'}}
         run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32690_board_w1
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing MAX32690"
           ./mass_erase_board.sh max32690 max32690_board_w1
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32690_board_w1
 
       # Save test reports
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -95,7 +95,8 @@ jobs:
 
           # Other directories to watch
           declare -a watched_other=(
-              .github/workflows
+              #To test changes this workflow push a commit with this uncommented
+              #.github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio
@@ -218,7 +219,8 @@ jobs:
 
           # Other directories to watch
           declare -a watched_other=(
-              .github/workflows
+              #To test changes this workflow push a commit with this uncommented
+              #.github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio
@@ -340,7 +342,8 @@ jobs:
 
           # Other directories to watch
           declare -a watched_other=(
-              .github/workflows
+              #To test changes this workflow push a commit with this uncommented
+              #.github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio
@@ -438,132 +441,22 @@ jobs:
           fi
 
       #----------------------------------------------------------------------------------------------
-      #------------------------------| Lock all required board at once |-----------------------------
+      #------------------------------| Lock all required boards at once |-----------------------------
       #----------------------------------------------------------------------------------------------
-      - name: Lock MAX32655 B1
-        if: env.LOCK_MAX32655_B1 == 'true'
-        id: lock_max32655_b1
+      - name: Lock Boards
+        if: env.LOCK_MAX32655_B1 == 'true' || env.LOCK_MAX32655_B2 == 'true' || env.LOCK_MAX32665_B1 == 'true' || env.LOCK_MAX32690_B1 == 'true'
+        id: lock_boards
         run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32655_board1
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share_multiboard.py -l -t 3600 -b max32655_board1 -b max32655_board2 -b max32665_board1 -b max32690_board_w1
       #----------------------------------------------------------------------------------------------
-      - name: Lock MAX32655 B2
-        if: env.LOCK_MAX32655_B2 == 'true'
-        id: lock_max32655_b2
-        run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32655_board2
-      #----------------------------------------------------------------------------------------------
-      - name: Lock MAX32665 B1
-        if: env.LOCK_MAX32665_B1 == 'true'
-        id: lock_max32665_b1
-        run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32665_board1
-      #----------------------------------------------------------------------------------------------
-      - name: Lock MAX32690 B1
-        if: env.LOCK_MAX32690_B1 == 'true'
-        id: lock_max32690_b1
-        run: |
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py -l -t 3600 max32690_board_w1
-      #----------------------------------------------------------------------------------------------
-      #----------------------------------------------------------------------------------------------
-      #------------------------------| Test all required board at once |-----------------------------
-      #----------------------------------------------------------------------------------------------
-      - name: Test MAX32665 #name used for display purposes on github webpage
-        if: steps.lock_max32665_b1.outcome == 'success'
-        id: Test_MAX32665 #id used to reference this step in other parts of the yml
-        run: |
-          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
-          dut_uart=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['uart1'])")
-          dut_serial=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])")
-          examples_to_test=(${MAX32665_EXAMPLES_TO_TEST[@]})
-          echo
-          echo
-          echo "Examples to be tested : ${examples_to_test[@]}"
-          echo "MAX32665_RUN_ALL_TEST        : $MAX32665_RUN_ALL_TEST"
-          echo "MAX32665_DATS_CONNECTED_TEST : $MAX32665_DATS_CONNECTED_TEST "
-          echo "MAX32665_OTAS_CONNECTED_TEST  : $MAX32665_OTAS_CONNECTED_TEST"
-          echo "MAX32665_BLE_FILES_CHANGED   : $MAX32665_BLE_FILES_CHANGED "
-          echo "LOCK_MAX32665_B1             : $LOCK_MAX32665_B1 "
 
-          cd .github/workflows/scripts
-
-          if [[ $MAX32665_RUN_ALL_TEST == 'true' ]]; then
-              echo "Testing all examples"
-               set +e
-               ./test_launcher.sh max32665 $dut_uart $dut_serial "all"
-               let "testResult=$?"
-               if [ "$testResult" -ne "0" ]; then
-                    # update failed test count
-                    let "numOfFailedTests+=$testResult"
-                fi
-                set -e
-          else
-              if [[ $MAX32665_BLE_FILES_CHANGED == 'true' ]]; then
-                  #------non connected tests---------
-                  for example in "${examples_to_test[@]}"; do
-                      # launch single tests
-                      echo "Running $example test on MAX32665"
-                      set +e
-                      ./test_launcher.sh max32665 $dut_uart $dut_serial $example
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| $example"
-                      fi
-                      set -e
-                  done
-
-                  #------connected tests---------
-                  if [[ $MAX32665_DATS_CONNECTED_TEST == 'true' ]]; then
-                      #conencted test launcher
-                      echo "Testing MAX32665_DATS_CONNECTED_TEST"
-                      set +e
-                      ./test_launcher.sh max32665 $dut_uart $dut_serial "dats"
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed_test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| MAX32665 Dats/c"
-                      fi
-                      set -e
-
-                  fi
-                  #------connected tests---------
-                  if [[ $MAX32665_OTAS_CONNECTED_TEST == 'true' ]]; then
-                      #conencted test launcher
-                      echo "Testing MAX32665_OTAS_CONNECTED_TEST"
-                      set +e
-                      #call test here
-                      #***************** uncomment actual test here *************
-                      ./test_launcher.sh max32665 $dut_uart $dut_serial "ota"
-                      let "testResult=$?"
-                      if [ "$testResult" -ne "0" ]; then
-                          # update failed test count
-                          let "numOfFailedTests+=$testResult"
-                          failedTestList+="| MAX32665 OTAS/C"
-                      fi
-                      set -e
-                  fi
-              else
-                  echo "Skipping all tests"
-              fi
-            echo "=============================================================================="
-            echo "=============================================================================="
-
-            if [[ $numOfFailedTests -ne 0 ]]; then
-                printf "Test completed with $numOfFailedTests failed tests located in: \r\n $failedTestList"
-            else
-                echo "Relax! ALL TESTS PASSED"
-            fi
-            echo
-            echo "=============================================================================="
-            echo "=============================================================================="
-            echo
-          fi
-          exit $numOfFailedTests
       #----------------------------------------------------------------------------------------------
+      #----------------------------------------------------------------------------------------------
+      #------------------------------| Test all required boards at once |-----------------------------
+      #----------------------------------------------------------------------------------------------
+           
       - name: Test MAX32655 #name used for display purposes on github webpage
-        if: steps.lock_max32655_b2.outcome == 'success'
+        if: steps.lock_boards.outcome == 'success' && env.LOCK_MAX32655_B2 == 'true'
         id: Test_MAX32655 #id used to reference this step in other parts of the yml
         run: |
           FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
@@ -658,8 +551,103 @@ jobs:
 
           exit $numOfFailedTests
       #----------------------------------------------------------------------------------------------
+      - name: Test MAX32665 #name used for display purposes on github webpage
+        if: steps.lock_boards.outcome == 'success' && env.LOCK_MAX32665_B1 == 'true'
+        id: Test_MAX32665 #id used to reference this step in other parts of the yml
+        run: |
+          FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+          dut_uart=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['uart1'])")
+          dut_serial=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['max32665_board1']['daplink'])")
+          examples_to_test=(${MAX32665_EXAMPLES_TO_TEST[@]})
+          echo
+          echo
+          echo "Examples to be tested : ${examples_to_test[@]}"
+          echo "MAX32665_RUN_ALL_TEST        : $MAX32665_RUN_ALL_TEST"
+          echo "MAX32665_DATS_CONNECTED_TEST : $MAX32665_DATS_CONNECTED_TEST "
+          echo "MAX32665_OTAS_CONNECTED_TEST  : $MAX32665_OTAS_CONNECTED_TEST"
+          echo "MAX32665_BLE_FILES_CHANGED   : $MAX32665_BLE_FILES_CHANGED "
+          echo "LOCK_MAX32665_B1             : $LOCK_MAX32665_B1 "
+
+          cd .github/workflows/scripts
+
+          if [[ $MAX32665_RUN_ALL_TEST == 'true' ]]; then
+              echo "Testing all examples"
+               set +e
+               ./test_launcher.sh max32665 $dut_uart $dut_serial "all"
+               let "testResult=$?"
+               if [ "$testResult" -ne "0" ]; then
+                    # update failed test count
+                    let "numOfFailedTests+=$testResult"
+                fi
+                set -e
+          else
+              if [[ $MAX32665_BLE_FILES_CHANGED == 'true' ]]; then
+                  #------non connected tests---------
+                  for example in "${examples_to_test[@]}"; do
+                      # launch single tests
+                      echo "Running $example test on MAX32665"
+                      set +e
+                      ./test_launcher.sh max32665 $dut_uart $dut_serial $example
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| $example"
+                      fi
+                      set -e
+                  done
+
+                  #------connected tests---------
+                  if [[ $MAX32665_DATS_CONNECTED_TEST == 'true' ]]; then
+                      #conencted test launcher
+                      echo "Testing MAX32665_DATS_CONNECTED_TEST"
+                      set +e
+                      ./test_launcher.sh max32665 $dut_uart $dut_serial "dats"
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed_test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| MAX32665 Dats/c"
+                      fi
+                      set -e
+
+                  fi
+                  #------connected tests---------
+                  if [[ $MAX32665_OTAS_CONNECTED_TEST == 'true' ]]; then
+                      #conencted test launcher
+                      echo "Testing MAX32665_OTAS_CONNECTED_TEST"
+                      set +e
+                      #call test here
+                      #***************** uncomment actual test here *************
+                      ./test_launcher.sh max32665 $dut_uart $dut_serial "ota"
+                      let "testResult=$?"
+                      if [ "$testResult" -ne "0" ]; then
+                          # update failed test count
+                          let "numOfFailedTests+=$testResult"
+                          failedTestList+="| MAX32665 OTAS/C"
+                      fi
+                      set -e
+                  fi
+              else
+                  echo "Skipping all tests"
+              fi
+            echo "=============================================================================="
+            echo "=============================================================================="
+
+            if [[ $numOfFailedTests -ne 0 ]]; then
+                printf "Test completed with $numOfFailedTests failed tests located in: \r\n $failedTestList"
+            else
+                echo "Relax! ALL TESTS PASSED"
+            fi
+            echo
+            echo "=============================================================================="
+            echo "=============================================================================="
+            echo
+          fi
+          exit $numOfFailedTests
+      #----------------------------------------------------------------------------------------------
       - name: Test MAX32690 #name used for display purposes on github webpage
-        if: steps.lock_max32690_b1.outcome == 'success'
+        if: steps.lock_max32690_b1.outcome == 'success' && env.LOCK_MAX32690_B1 == 'true'
         id: Test_MAX32690 #id used to reference this step in other parts of the yml
         run: |
           FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
@@ -755,44 +743,16 @@ jobs:
           exit $numOfFailedTests
       #----------------------------------------------------------------------------------------------
       #----------------------------------------------------------------------------------------------
-      #------------------------------| Unock all required board at once |-----------------------------
+      #------------------------------| Unlock all required boards at once |-----------------------------
       #----------------------------------------------------------------------------------------------
-      - name: Unlock MAX32655 B1
-        if: ${{ always() && steps.lock_max32655_b1.outcome == 'success'}}
+      - name: Unlock Boards
+        if: ${{ always() && steps.lock_boards.outcome == 'success'}}
         run: |
-          echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
           ./mass_erase_board.sh max32655 max32655_board1
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
-      #----------------------------------------------------------------------------------------------
-      - name: Unlock MAX32655 B2
-        if: ${{ always() && steps.lock_max32655_b2.outcome == 'success'}}
-        run: |
-          # leave board in known state if workflow should end early
-          cd .github/workflows/scripts
-          echo "Erasing MAX32655"
-          ./mass_erase_board.sh max32655 max32655_board2
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board2
-       #----------------------------------------------------------------------------------------------
-      - name: Unlock MAX32665 B1
-        if: ${{ always() && steps.lock_max32665_b1.outcome == 'success'}}
-        run: |
-          # leave board in known state if workflow should end early
-          cd .github/workflows/scripts
-          echo "Erasing MAX32665"
-          ./mass_erase_board.sh max32665 max32665_board1
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32665_board1
-      #----------------------------------------------------------------------------------------------
-      - name: Unlock MAX32690 B1
-        if: ${{ always() && steps.lock_max32690_b1.outcome == 'success'}}
-        run: |
-          # leave board in known state if workflow should end early
-          cd .github/workflows/scripts
-          echo "Erasing MAX32690"
-          ./mass_erase_board.sh max32690 max32690_board_w1
-          python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32690_board_w1
+          python3 /home/$USER/Workspace/Resource_Share/Resource_Share_multiboard.py -b max32655_board1 -b max32655_board2 -b max32665_board1 -b max32690_board_w1
       #----------------------------------------------------------------------------------------------
       # Save test reports
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -307,6 +307,7 @@ jobs:
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           # leave board in known state if workflow should end early
+          cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
           ./mass_erase_board.sh max32655 max32655_b1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
@@ -316,6 +317,7 @@ jobs:
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board2
           # leave board in known state if workflow should end early
+          cd .github/workflows/scripts
           echo "Erasing MAX32655"
           ./mass_erase_board.sh max32655 max32655_board2
 
@@ -556,6 +558,7 @@ jobs:
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
           # leave board in known state if workflow should end early
+          cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
           ./mass_erase_board.sh max32655 max32655_b1
 
@@ -564,6 +567,7 @@ jobs:
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32665_board1
           # leave board in known state if workflow should end early
+          cd .github/workflows/scripts
           echo "Erasing MAX32665"
           ./mass_erase_board.sh max32665 max32665_board1
 
@@ -803,7 +807,8 @@ jobs:
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
-           # leave board in known state if workflow should end early
+          # leave board in known state if workflow should end early
+          cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
           ./mass_erase_board.sh max32655 max32655_b1
 
@@ -812,6 +817,7 @@ jobs:
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32690_board_w1
           # leave board in known state if workflow should end early
+          cd .github/workflows/scripts
           echo "Erasing MAX32690"
           ./mass_erase_board.sh max32690 max32690_board_w1
 

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -96,7 +96,7 @@ jobs:
           # Other directories to watch
           declare -a watched_other=(
               #To test changes this workflow push a commit with this uncommented
-              #.github/workflows/
+              .github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio
@@ -220,7 +220,7 @@ jobs:
           # Other directories to watch
           declare -a watched_other=(
               #To test changes this workflow push a commit with this uncommented
-              #.github/workflows/
+              .github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio
@@ -343,7 +343,7 @@ jobs:
           # Other directories to watch
           declare -a watched_other=(
               #To test changes this workflow push a commit with this uncommented
-              #.github/workflows/
+              .github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -96,7 +96,7 @@ jobs:
           # Other directories to watch
           declare -a watched_other=(
               #To test changes this workflow push a commit with this uncommented
-              .github/workflows/
+              #.github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio
@@ -220,7 +220,7 @@ jobs:
           # Other directories to watch
           declare -a watched_other=(
               #To test changes this workflow push a commit with this uncommented
-              .github/workflows/
+              #.github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio
@@ -343,7 +343,7 @@ jobs:
           # Other directories to watch
           declare -a watched_other=(
               #To test changes this workflow push a commit with this uncommented
-              .github/workflows/
+              #.github/workflows/
               .github/workflows/ci-tests/Examples_tests
               Libraries/libs.mk
               Libraries/Cordio

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -308,7 +308,7 @@ jobs:
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
-          ./mass_erase_board.sh max32655 max32655_b1
+          ./mass_erase_board.sh max32655 max32655_board1
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
 
@@ -559,7 +559,7 @@ jobs:
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
-          ./mass_erase_board.sh max32655 max32655_b1
+          ./mass_erase_board.sh max32655 max32655_board1
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
 
       - name: Unlock MAX32665 B1
@@ -809,7 +809,7 @@ jobs:
           # leave board in known state if workflow should end early
           cd .github/workflows/scripts
           echo "Erasing Main MAX32655"
-          ./mass_erase_board.sh max32655 max32655_b1
+          ./mass_erase_board.sh max32655 max32655_board1
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
 
       - name: Unlock MAX32690 B1

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -647,7 +647,7 @@ jobs:
           exit $numOfFailedTests
       #----------------------------------------------------------------------------------------------
       - name: Test MAX32690 #name used for display purposes on github webpage
-        if: steps.lock_max32690_b1.outcome == 'success' && env.LOCK_MAX32690_B1 == 'true'
+        if: steps.lock_boards.outcome == 'success' && env.LOCK_MAX32690_B1 == 'true'
         id: Test_MAX32690 #id used to reference this step in other parts of the yml
         run: |
           FILE=/home/$USER/Workspace/Resource_Share/boards_config.json

--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -64,6 +64,7 @@ jobs:
           # give launcher script permission to execute
           cd .github/workflows/scripts
           chmod +x test_launcher.sh
+          chmod +x mass_erase_board.sh
       #----------------------------------------------------------------------------------------------
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
@@ -305,12 +306,18 @@ jobs:
         if: ${{ always() && steps.lock_max32655_b1_0.outcome == 'success'}}
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
+          # leave board in known state if workflow should end early
+          echo "Erasing Main MAX32655"
+          ./mass_erase_board.sh max32655 max32655_b1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
 
       - name: Unlock MAX32655 B2
         if: ${{ always() && steps.lock_max32655_b2.outcome == 'success'}}
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board2
+          # leave board in known state if workflow should end early
+          echo "Erasing MAX32655"
+          ./mass_erase_board.sh max32655 max32655_board2
 
 
  #----------------------------------------------------------------------------------------------
@@ -548,11 +555,17 @@ jobs:
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
+          # leave board in known state if workflow should end early
+          echo "Erasing Main MAX32655"
+          ./mass_erase_board.sh max32655 max32655_b1
 
       - name: Unlock MAX32665 B1
         if: ${{ always() && steps.lock_max32665_b1.outcome == 'success'}}
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32665_board1
+          # leave board in known state if workflow should end early
+          echo "Erasing MAX32665"
+          ./mass_erase_board.sh max32665 max32665_board1
 
  #----------------------------------------------------------------------------------------------
  #------------------------------| MAX32690 |----------------------------------------------------
@@ -790,11 +803,17 @@ jobs:
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32655_board1
           echo "LOCK_MAX32655_B1=false" >>  $GITHUB_ENV
+           # leave board in known state if workflow should end early
+          echo "Erasing Main MAX32655"
+          ./mass_erase_board.sh max32655 max32655_b1
 
       - name: Unlock MAX32690 B1
         if: ${{ always() && steps.lock_max32690_b1.outcome == 'success'}}
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share.py max32690_board_w1
+          # leave board in known state if workflow should end early
+          echo "Erasing MAX32690"
+          ./mass_erase_board.sh max32690 max32690_board_w1
 
       # Save test reports
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/scripts/mass_erase_board.sh
+++ b/.github/workflows/scripts/mass_erase_board.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#script accepts 2 arguments: device , device key in boards config
+
+#****************************************************************************************************
+# Function accepts parameters:device , CMSIS-DAP serial #
+function erase_with_openocd() {
+    echo "-----------------------------------------------------------------------------------------"
+    printf "> Erasing $1 : $2 \r\n"
+    echo "-----------------------------------------------------------------------------------------"
+    echo
+
+    $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$1.cfg -s $OPENOCD_TCL_PATH/ -c "cmsis_dap_serial  $2" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt; max32xxx mass_erase 0;" -c " exit" &
+    openocd_dapLink_pid=$!
+    # wait for openocd to finish
+    wait $openocd_dapLink_pid
+
+    # erase second bank of larger chips
+    if [[ $1 != "max32655" ]]; then
+        printf "> Erasing second bank of device: $1 with ID:$2 \r\n"
+        $OPENOCD -f $OPENOCD_TCL_PATH/interface/cmsis-dap.cfg -f $OPENOCD_TCL_PATH/target/$1.cfg -s $OPENOCD_TCL_PATH/ -c "cmsis_dap_serial  $2" -c "gdb_port 3333" -c "telnet_port 4444" -c "tcl_port 6666" -c "init; reset halt; max32xxx mass_erase 1;" -c " exit" &
+        openocd_dapLink_pid=$!
+        # wait for openocd to finish
+        wait $openocd_dapLink_pid
+    fi
+}
+if [ $(hostname) == "wall-e" ]; then
+    FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+    # WALL-E  paths
+    export OPENOCD_TCL_PATH=/home/btm-ci/Tools/openocd/tcl
+    export OPENOCD=/home/btm-ci/Tools/openocd/src/openocd
+elif [ $(hostname) == "yingcai-OptiPlex-790" ]; then
+    FILE=/home/$USER/Workspace/Resource_Share/boards_config.json
+    export OPENOCD_TCL_PATH=/home/$USER/Tools/openocd/tcl
+    export OPENOCD=/home/$USER/Tools/openocd/src/openocd
+else
+    FILE=/home/$USER/boards_config.json
+    export OPENOCD_TCL_PATH=/home/eddie/workspace/openocd/tcl
+    export OPENOCD=/home/eddie/workspace/openocd/src/openocd
+fi
+dut_serial=$(/usr/bin/python3 -c "import sys, json; print(json.load(open('$FILE'))['$2']['daplink'])")
+erase_with_openocd $1 $dut_serial
+


### PR DESCRIPTION
-check to see which boards needs testing
-if at least one needs testing it locks all 3 because its safer and a lot of issues arose when only locking one and waiting for others
-test all boards
-And lastly does a mass erase of any locked boards before unlocking. **Does this at the yaml level so if test script is interrupted because of a canceled workflow the board will still be left in a known state.** 
