### PR TITLE
Erase ext flash on failed status

### DIFF
--- a/Examples/MAX32655/BLE_otas/wdxs_file_ext.c
+++ b/Examples/MAX32655/BLE_otas/wdxs_file_ext.c
@@ -320,8 +320,10 @@ static uint8_t wsfFileHandle(uint8_t cmd, uint32_t param)
         APP_TRACE_INFO1("CRC Calculated: 0x%08X", crcResult);
 
         /* Check the calculated CRC32 against what was received, 32 bits is 4 bytes */
-        if (fileHeader.fileCRC != crcResult) {
+        if (fileHeader.fileCRC != crcResult+1) {
             APP_TRACE_INFO0("Update file verification failure");
+            APP_TRACE_INFO0("Erasing first sector of external flash");
+            Ext_Flash_Erase(HEADER_LOCATION, Ext_Flash_Erase_4K);
             crcResult = 0;
             return WDX_FTC_ST_VERIFICATION;
         }

--- a/Examples/MAX32655/BLE_otas/wdxs_file_ext.c
+++ b/Examples/MAX32655/BLE_otas/wdxs_file_ext.c
@@ -320,7 +320,7 @@ static uint8_t wsfFileHandle(uint8_t cmd, uint32_t param)
         APP_TRACE_INFO1("CRC Calculated: 0x%08X", crcResult);
 
         /* Check the calculated CRC32 against what was received, 32 bits is 4 bytes */
-        if (fileHeader.fileCRC != crcResult+1) {
+        if (fileHeader.fileCRC != crcResult) {
             APP_TRACE_INFO0("Update file verification failure");
             APP_TRACE_INFO0("Erasing first sector of external flash");
             Ext_Flash_Erase(HEADER_LOCATION, Ext_Flash_Erase_4K);

--- a/Examples/MAX32665/BLE_otas/wdxs_file_ext.c
+++ b/Examples/MAX32665/BLE_otas/wdxs_file_ext.c
@@ -322,6 +322,8 @@ static uint8_t wsfFileHandle(uint8_t cmd, uint32_t param)
         /* Check the calculated CRC32 against what was received, 32 bits is 4 bytes */
         if (fileHeader.fileCRC != crcResult) {
             APP_TRACE_INFO0("Update file verification failure");
+            APP_TRACE_INFO0("Erasing first sector of external flash");
+            Ext_Flash_Erase(HEADER_LOCATION, Ext_Flash_Erase_4K);
             crcResult = 0;
             return WDX_FTC_ST_VERIFICATION;
         }


### PR DESCRIPTION
If CRC fails for some reason erase external flash so that on next boot the device does not find a fw update. 