### PR TITLE
Adding Makefile targets for flashing.

### DIFF
--- a/Examples/MAX32655/Hello_World/Makefile
+++ b/Examples/MAX32655/Hello_World/Makefile
@@ -406,6 +406,3 @@ clean:
 
 # The rule to clean out all the build products.
 distclean: clean libclean
-
-# Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Examples/MAX32655/Hello_World/Makefile
+++ b/Examples/MAX32655/Hello_World/Makefile
@@ -406,3 +406,6 @@ clean:
 
 # The rule to clean out all the build products.
 distclean: clean libclean
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk
@@ -88,4 +88,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk
@@ -86,3 +86,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32570/Source/GCC/max32570.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32570/Source/GCC/max32570.mk
@@ -90,3 +90,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32570/Source/GCC/max32570.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32570/Source/GCC/max32570.mk
@@ -92,4 +92,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/GCC/max32572.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/GCC/max32572.mk
@@ -89,4 +89,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/GCC/max32572.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/GCC/max32572.mk
@@ -87,3 +87,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/GCC/max32650.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/GCC/max32650.mk
@@ -85,4 +85,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/MAX32650/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/MAX32650/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/GCC/max32650.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/GCC/max32650.mk
@@ -83,3 +83,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/MAX32650/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/MAX32650/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/max32655.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/max32655.mk
@@ -101,7 +101,7 @@ ifeq ($(RISCV_LOAD),1)
 LOADER_SCRIPT := $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/riscv-loader.S
 
 # Directory for RISCV code, defaults to Hello_World
-RISCV_APP ?= $(MAXIM_PATH)/Examples/$(TARGET_UC)/Hello_World
+RISCV_APP ?= $(CMSIS_ROOT)/../../Examples/$(TARGET_UC)/Hello_World
 
 # Build the RISC-V app inside of this project so that
 # "make clean" will catch it automatically.
@@ -158,4 +158,4 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/max32655.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/max32655.mk
@@ -156,3 +156,6 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 else
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Source/GCC/max32660.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Source/GCC/max32660.mk
@@ -83,4 +83,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/MAX32660/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/MAX32660/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Source/GCC/max32660.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Source/GCC/max32660.mk
@@ -81,3 +81,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/MAX32660/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/MAX32660/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Source/GCC/max32662.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Source/GCC/max32662.mk
@@ -85,4 +85,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/MAX32662/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/MAX32662/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Source/GCC/max32662.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Source/GCC/max32662.mk
@@ -83,3 +83,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/MAX32662/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/MAX32662/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Source/GCC/max32665.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Source/GCC/max32665.mk
@@ -91,4 +91,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/MAX32665/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/MAX32665/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Source/GCC/max32665.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Source/GCC/max32665.mk
@@ -89,3 +89,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/MAX32665/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/MAX32665/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670.mk
@@ -84,3 +84,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/max32670.mk
@@ -86,4 +86,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672.mk
@@ -88,4 +88,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/GCC/max32672.mk
@@ -86,3 +86,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675.mk
@@ -84,3 +84,6 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 
 # Include the rules and goals for building
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/GCC/max32675.mk
@@ -86,4 +86,4 @@ LIBPATH+=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/GCC/max32680.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/GCC/max32680.mk
@@ -101,7 +101,7 @@ ifeq ($(RISCV_LOAD),1)
 LOADER_SCRIPT := $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/riscv-loader.S
 
 # Directory for RISCV code, defaults to Hello_World
-RISCV_APP ?= $(MAXIM_PATH)/Examples/$(TARGET_UC)/Hello_World
+RISCV_APP ?= $(CMSIS_ROOT)/../../Examples/$(TARGET_UC)/Hello_World
 
 # Build the RISC-V app inside of this project so that
 # "make clean" will catch it automatically.
@@ -158,4 +158,4 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/GCC/max32680.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/GCC/max32680.mk
@@ -156,3 +156,6 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 else
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/GCC/max32690.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/GCC/max32690.mk
@@ -103,7 +103,7 @@ ifeq ($(RISCV_LOAD),1)
 LOADER_SCRIPT := $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/riscv-loader.S
 
 # Directory for RISCV code, defaults to Hello_World
-RISCV_APP ?= $(MAXIM_PATH)/Examples/$(TARGET_UC)/Hello_World
+RISCV_APP ?= $(CMSIS_ROOT)/../../Examples/$(TARGET_UC)/Hello_World
 
 # Build the RISC-V app inside of this project so that
 # "make clean" will catch it automatically.
@@ -160,4 +160,4 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/GCC/max32690.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/GCC/max32690.mk
@@ -158,3 +158,6 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 else
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.mk
@@ -107,3 +107,5 @@ else
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
 
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.mk
@@ -108,4 +108,4 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.mk
@@ -104,3 +104,6 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc.mk
 else
 include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
+
+# Include rules for flashing
+include $(MAXIM_PATH)/Tools/Flash/flash.mk

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.mk
@@ -106,4 +106,4 @@ include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/gcc_riscv.mk
 endif
 
 # Include rules for flashing
-include $(MAXIM_PATH)/Tools/Flash/flash.mk
+include $(CMSIS_ROOT)/../../Tools/Flash/flash.mk

--- a/Tools/Flash/flash.mk
+++ b/Tools/Flash/flash.mk
@@ -1,0 +1,81 @@
+################################################################################
+ # Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a
+ # copy of this software and associated documentation files (the "Software"),
+ # to deal in the Software without restriction, including without limitation
+ # the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ # and/or sell copies of the Software, and to permit persons to whom the
+ # Software is furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included
+ # in all copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ # IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ # OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ #
+ # Except as contained in this notice, the name of Maxim Integrated
+ # Products, Inc. shall not be used except as stated in the Maxim Integrated
+ # Products, Inc. Branding Policy.
+ #
+ # The mere transfer of this software does not imply any licenses
+ # of trade secrets, proprietary technology, copyrights, patents,
+ # trademarks, maskwork rights, or any other form of intellectual
+ # property whatsoever. Maxim Integrated Products, Inc. retains all
+ # ownership rights.
+ #
+###############################################################################
+
+# Makefile targets to flash with JLinkExe or OpenOCD
+
+# ADAPTER_SN is debugger serial number
+# This variable is optional, useful when multiple debuggers are connected
+# It can be defined as an environment variable or in the Makefiles
+# 
+# Example for JLINK: 229002239
+# Example for CMSIS-DAP: 04090000068682d300000000000000000000000097969906
+# 
+# ADAPTER_SN=229002239
+# ADAPTER_SN=04090000068682d300000000000000000000000097969906
+
+# Location of the OpenOCD install directory, tcl or scripts folder
+OPENOCD_SCRIPTS ?= ${MAXIM_PATH}/Tools/OpenOCD/scripts
+
+# Update with the connected debugger
+OPENOCD_ADAPTER ?= cmsis-dap.cfg
+# OPENOCD_ADAPTER ?= jlink.cfg
+
+HEX_FILE        := ${BUILD_DIR}/${PROJECT}.hex
+
+ifeq ($(OS),Windows_NT)
+JLINKEXE        := JLink.exe
+ECHO            := echo -e
+OPENOCDEXE      := openocd.exe
+HEX_FILE_PATH   := $(shell cygpath -wa $(HEX_FILE))
+HEX_FILE_PATH   := $(subst \,/, $(HEX_FILE_PATH))
+else
+JLINKEXE        := JLinkExe
+ECHO            := echo
+OPENOCDEXE      := openocd
+HEX_FILE_PATH   := ${HEX_FILE}
+endif
+
+JLINKEXE     += -if SWD -device ${TARGET_UC} -speed 10000
+COMMAND_FILE := flash.jlinkexe
+
+PHONY: flash.jlink
+flash.jlink: mkbuildir ${HEX_FILE}
+	@$(ECHO) "$(if $(ADAPTER_SN), "SelectEmuBySN $(ADAPTER_SN)",)\nr\nhalt\nLoadFile \
+		${HEX_FILE_PATH},0\nr\ng\nexit\n" > ${COMMAND_FILE}
+	@$(JLINKEXE) -NoGui 1 -CommandFile ${COMMAND_FILE}
+
+PHONY: flash.openocd
+flash.openocd: mkbuildir ${HEX_FILE}
+	@$(OPENOCDEXE) -s ${OPENOCD_SCRIPTS} -f interface/${OPENOCD_ADAPTER} -f target/${TARGET_LC}.cfg \
+		$(if $(ADAPTER_SN), "-c adapter serial $(ADAPTER_SN)",) \
+		-c "program ${HEX_FILE_PATH} verify reset exit"

--- a/Tools/Flash/flash.mk
+++ b/Tools/Flash/flash.mk
@@ -58,9 +58,9 @@ OPENOCD_ADAPTER ?= cmsis-dap.cfg
 HEX_FILE        := ${BUILD_DIR}/${PROJECT}.hex
 HEX_FILE_PATH   := ${HEX_FILE}
 ifeq ($(OS),Windows_NT)
-JLINKEXE        := JLink.exe
-ECHO            := echo -e
-OPENOCDEXE      := openocd.exe
+JLINKEXE        ?= JLink.exe
+ECHO            ?= echo -e
+OPENOCDEXE      ?= openocd.exe
 
 # Determine if we can use cygpath to convert the path name
 CYGPATH_AVAILABLE := 0
@@ -86,9 +86,9 @@ endif
 
 else
 # Not Windows_NT
-JLINKEXE        := JLinkExe
-ECHO            := echo
-OPENOCDEXE      := openocd
+JLINKEXE        ?= JLinkExe
+ECHO            ?= echo
+OPENOCDEXE      ?= openocd
 endif
 
 JLINKEXE     += -if SWD -device ${TARGET_UC} -speed 10000
@@ -96,12 +96,12 @@ COMMAND_FILE := flash.jlinkexe
 
 PHONY: flash.jlink
 flash.jlink: mkbuildir ${HEX_FILE}
-    @$(ECHO) "$(if $(ADAPTER_SN), "SelectEmuBySN $(ADAPTER_SN)",)\nr\nhalt\nLoadFile \
-        ${HEX_FILE_PATH},0\nr\ng\nexit\n" > ${COMMAND_FILE}
-    @$(JLINKEXE) -NoGui 1 -CommandFile ${COMMAND_FILE}
+	@$(ECHO) "$(if $(ADAPTER_SN), "SelectEmuBySN $(ADAPTER_SN)",)\nr\nhalt\nLoadFile \
+		${HEX_FILE_PATH},0\nr\ng\nexit\n" > ${COMMAND_FILE}
+	@$(JLINKEXE) -NoGui 1 -CommandFile ${COMMAND_FILE}
 
 PHONY: flash.openocd
 flash.openocd: mkbuildir ${HEX_FILE}
-    @$(OPENOCDEXE) -s ${OPENOCD_SCRIPTS} -f interface/${OPENOCD_ADAPTER} -f target/${TARGET_LC}.cfg \
-        $(if $(ADAPTER_SN), "-c adapter serial $(ADAPTER_SN)",) \
-        -c "program ${HEX_FILE_PATH} verify reset exit"
+	@$(OPENOCDEXE) -s ${OPENOCD_SCRIPTS} -f interface/${OPENOCD_ADAPTER} -f target/${TARGET_LC}.cfg \
+		$(if $(ADAPTER_SN), "-c adapter serial $(ADAPTER_SN)",) \
+		-c "program ${HEX_FILE_PATH} verify reset exit"

--- a/Tools/Flash/flash.mk
+++ b/Tools/Flash/flash.mk
@@ -44,14 +44,9 @@
 # ADAPTER_SN=04090000068682d300000000000000000000000097969906
 
 # Location of the OpenOCD install directory, tcl or scripts folder
+OPENOCD_SCRIPTS ?= ${MAXIM_PATH}/Tools/OpenOCD/scripts
 
-OPENOCD_SCRIPTS_DEFAULT = ${MAXIM_PATH}/Tools/OpenOCD/scripts
-ifeq ($(OPENOCD_SCRIPTS),)
-$(warning Warning: OPENOCD_SCRIPTS undefined, using ${OPENOCD_SCRIPTS_DEFAULT})
-endif
-OPENOCD_SCRIPTS ?= ${OPENOCD_SCRIPTS_DEFAULT}
-
-# Update with the connected debugger
+# Update with the connected adapter
 OPENOCD_ADAPTER ?= cmsis-dap.cfg
 # OPENOCD_ADAPTER ?= jlink.cfg
 
@@ -81,7 +76,7 @@ ifeq ($(CYGPATH_AVAILABLE),1)
 HEX_FILE_PATH   := $(shell cygpath -wa $(HEX_FILE))
 HEX_FILE_PATH   := $(subst \,/, $(HEX_FILE_PATH))
 else
-$(warning Warning: cygpath unavailable to convert path name to Windows format)
+# $(warning Warning: cygpath unavailable to convert path name to Windows format)
 endif
 
 else

--- a/Tools/Flash/flash.mk
+++ b/Tools/Flash/flash.mk
@@ -44,7 +44,12 @@
 # ADAPTER_SN=04090000068682d300000000000000000000000097969906
 
 # Location of the OpenOCD install directory, tcl or scripts folder
-OPENOCD_SCRIPTS ?= ${MAXIM_PATH}/Tools/OpenOCD/scripts
+
+OPENOCD_SCRIPTS_DEFAULT = ${MAXIM_PATH}/Tools/OpenOCD/scripts
+ifeq ($(OPENOCD_SCRIPTS),)
+$(warning Warning: OPENOCD_SCRIPTS undefined, attempting to use ${OPENOCD_SCRIPTS_DEFAULT})    
+endif
+OPENOCD_SCRIPTS ?= ${OPENOCD_SCRIPTS_DEFAULT}
 
 # Update with the connected debugger
 OPENOCD_ADAPTER ?= cmsis-dap.cfg


### PR DESCRIPTION
This will allow us to ```make flash.openocd```.

I added another target for JLink ```make flash.jlink```. This isn't a part of our SDK, but I know that some of our customers prefer this to OpenOCD. 

What do we think of the file path and include in the Makefile? 