### PR TITLE
Erase boards  to start from known state

### DIFF
--- a/.github/workflows/BLE_Examples_Test.yml
+++ b/.github/workflows/BLE_Examples_Test.yml
@@ -448,6 +448,16 @@ jobs:
         id: lock_boards
         run: |
           python3 /home/$USER/Workspace/Resource_Share/Resource_Share_multiboard.py -l -t 3600 -b max32655_board1 -b max32655_board2 -b max32665_board1 -b max32690_board_w1
+          # start with boards in known state
+          cd .github/workflows/scripts
+          echo "Erasing Main MAX32655 B1"
+          ./mass_erase_board.sh max32655 max32655_board1
+          echo "Erasing Main MAX32655 B2"
+          ./mass_erase_board.sh max32655 max32655_board2
+          echo "Erasing Main MAX32665 B1"
+          ./mass_erase_board.sh max32665 max32665_board1
+          echo "Erasing Main MAX32690"
+          ./mass_erase_board.sh max32690 max32690_board_w1
       #----------------------------------------------------------------------------------------------
 
       #----------------------------------------------------------------------------------------------

--- a/.github/workflows/scripts/test_launcher.sh
+++ b/.github/workflows/scripts/test_launcher.sh
@@ -291,48 +291,48 @@ function print_project_banner() {
     printf "> Start of testing $DUT_NAME_LOWER ($DUT_NAME_UPPER) \r\n> ID:$DUT_ID \r\n> Port:$DUT_SERIAL_PORT \r\n\r\n"
 }
 #****************************************************************************************************
-function change_advertising_names_walle() {
-    # change advertising name for projects under test to avoid
-    # connections with office devices
-    printf "> changing advertising names : $MSDK_DIR/Examples/$DUT_NAME_UPPER\r\n\r\n"
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_dats
-    perl -i -pe "s/\'D\'/\'X\'/g" dats_main.c
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_datc
-    perl -i -pe "s/\'D\'/\'X\'/g" datc_main.c
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otac
-    perl -i -pe "s/\'S\'/\'X\'/g" datc_main.c
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas
-    perl -i -pe "s/\'S\'/\'X\'/g" dats_main.c
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_FreeRTOS
-    perl -i -pe "s/\'S\'/\'X\'/g" dats_main.c
-    # change advertising name to scan for on the main device client apps
-    cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_datc
-    perl -i -pe "s/\'D\'/\'X\'/g" datc_main.c
-    cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
-    perl -i -pe "s/\'S\'/\'X\'/g" datc_main.c
-    # build BLE examples
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER
-}
-#****************************************************************************************************
-function change_advertising_names_local() {
-    # change advertising name for projects under test to avoid
-    # connections with office devices
-    printf "> changing advertising names : $MSDK_DIR/Examples/$DUT_NAME_UPPER\r\n\r\n"
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_dats
-    perl -i -pe "s/\'D\'/\'Z\'/g" dats_main.c
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_datc
-    perl -i -pe "s/\'D\'/\'Z\'/g" datc_main.c
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otac
-    perl -i -pe "s/\'S\'/\'Z\'/g" datc_main.c
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas
-    perl -i -pe "s/\'S\'/\'Z\'/g" dats_main.c
-    cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_FreeRTOS
-    perl -i -pe "s/\'S\'/\'Z\'/g" dats_main.c
-    # change advertising name to scan for on the main device client apps
-    cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_datc
-    perl -i -pe "s/\'D\'/\'Z\'/g" datc_main.c
-    cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
-    perl -i -pe "s/\'S\'/\'Z\'/g" datc_main.c
+function change_advertising_names() {
+    if [ $(hostname) == "wall-e" ]; then
+        # change advertising name for projects under test to avoid
+        # connections with office devices
+        printf "> changing advertising names : $MSDK_DIR/Examples/$DUT_NAME_UPPER\r\n\r\n"
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_dats
+        perl -i -pe "s/\'D\'/\'X\'/g" dats_main.c
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_datc
+        perl -i -pe "s/\'D\'/\'X\'/g" datc_main.c
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otac
+        perl -i -pe "s/\'S\'/\'X\'/g" datc_main.c
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas
+        perl -i -pe "s/\'S\'/\'X\'/g" dats_main.c
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_FreeRTOS
+        perl -i -pe "s/\'S\'/\'X\'/g" dats_main.c
+        # change advertising name to scan for on the main device client apps
+        cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_datc
+        perl -i -pe "s/\'D\'/\'X\'/g" datc_main.c
+        cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
+        perl -i -pe "s/\'S\'/\'X\'/g" datc_main.c
+        # build BLE examples
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER
+    else
+        # change advertising name for projects under test to avoid
+        # connections with office devices
+        printf "> changing advertising names : $MSDK_DIR/Examples/$DUT_NAME_UPPER\r\n\r\n"
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_dats
+        perl -i -pe "s/\'D\'/\'Z\'/g" dats_main.c
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_datc
+        perl -i -pe "s/\'D\'/\'Z\'/g" datc_main.c
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otac
+        perl -i -pe "s/\'S\'/\'Z\'/g" datc_main.c
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas
+        perl -i -pe "s/\'S\'/\'Z\'/g" dats_main.c
+        cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_FreeRTOS
+        perl -i -pe "s/\'S\'/\'Z\'/g" dats_main.c
+        # change advertising name to scan for on the main device client apps
+        cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_datc
+        perl -i -pe "s/\'D\'/\'Z\'/g" datc_main.c
+        cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
+        perl -i -pe "s/\'S\'/\'Z\'/g" datc_main.c
+    fi
 }
 
 #****************************************************************************************************


### PR DESCRIPTION
Since these boards are now shared with more workflows than before, it could be a failed workflow leaves the boards in some unknown state so I am going to also erase  them  on start of test and end of test which was previously merged. 