### PR TITLE
Building archives with text file arguments.

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/gcc.mk
@@ -326,13 +326,15 @@ endif
 
 # The rule for creating an object library.
 ${BUILD_DIR}/%.a:
+	@echo -cr $(call fixpath,${@}) $(call fixpath,${^})                          \
+	| sed -r -e 's/ \/([A-Za-z])\// \1:\//g' > ${BUILD_DIR}/ar_args.txt
 	@if [ 'x${VERBOSE}' = x ];                                                   \
 	 then                                                                        \
 	     echo "  AR    ${@}";                                                    \
 	 else                                                                        \
 	     echo ${AR} -cr $(call fixpath,${@}) $(call fixpath,${^});               \
 	 fi
-	@${AR} -cr $(call fixpath,${@}) $(call fixpath,${^})
+	@${AR} @${BUILD_DIR}/ar_args.txt
 
 # The rule for building the object file from binary source file.
 # Resulting object will have the following symbols

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/GCC/gcc.mk
@@ -326,13 +326,15 @@ endif
 
 # The rule for creating an object library.
 ${BUILD_DIR}/%.a:
+	@echo -cr $(call fixpath,${@}) $(call fixpath,${^})                          \
+	| sed -r -e 's/ \/([A-Za-z])\// \1:\//g' > ${BUILD_DIR}/ar_args.txt
 	@if [ 'x${VERBOSE}' = x ];                                                   \
 	 then                                                                        \
 	     echo "  AR    ${@}";                                                    \
 	 else                                                                        \
 	     echo ${AR} -cr $(call fixpath,${@}) $(call fixpath,${^});               \
 	 fi
-	@${AR} -cr $(call fixpath,${@}) $(call fixpath,${^})
+	@${AR} @${BUILD_DIR}/ar_args.txt
 
 # The rule for building the object file from binary source file.
 # Resulting object will have the following symbols

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/GCC/gcc.mk
@@ -326,13 +326,15 @@ endif
 
 # The rule for creating an object library.
 ${BUILD_DIR}/%.a:
+	@echo -cr $(call fixpath,${@}) $(call fixpath,${^})                          \
+	| sed -r -e 's/ \/([A-Za-z])\// \1:\//g' > ${BUILD_DIR}/ar_args.txt
 	@if [ 'x${VERBOSE}' = x ];                                                   \
 	 then                                                                        \
 	     echo "  AR    ${@}";                                                    \
 	 else                                                                        \
 	     echo ${AR} -cr $(call fixpath,${@}) $(call fixpath,${^});               \
 	 fi
-	@${AR} -cr $(call fixpath,${@}) $(call fixpath,${^})
+	@${AR} @${BUILD_DIR}/ar_args.txt
 
 # The rule for building the object file from binary source file.
 # Resulting object will have the following symbols

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/gcc.mk
@@ -323,13 +323,15 @@ endif
 
 # The rule for creating an object library.
 ${BUILD_DIR}/%.a:
+	@echo -cr $(call fixpath,${@}) $(call fixpath,${^})                          \
+	| sed -r -e 's/ \/([A-Za-z])\// \1:\//g' > ${BUILD_DIR}/ar_args.txt
 	@if [ 'x${VERBOSE}' = x ];                                                   \
 	 then                                                                        \
 	     echo "  AR    ${@}";                                                    \
 	 else                                                                        \
 	     echo ${AR} -cr $(call fixpath,${@}) $(call fixpath,${^});               \
 	 fi
-	@${AR} -cr $(call fixpath,${@}) $(call fixpath,${^})
+	@${AR} @${BUILD_DIR}/ar_args.txt
 
 # The rule for linking the application.
 ${BUILD_DIR}/%.elf:


### PR DESCRIPTION
This will address the same issue we had with linking the .elf files. The command line list of argmuents is too long on Windows machines. This will echo those arguments to a text file and use that file as the input the the archiver.