### PR TITLE
Modifying MAX32672 LP example to get lowest current measurements.

### DIFF
--- a/Examples/MAX32672/LP/README.md
+++ b/Examples/MAX32672/LP/README.md
@@ -19,8 +19,8 @@ This example uses a special linkerfile (either lp-nonsecure.ld or lp-sla.ld depe
 ## Required Connections
 
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
--   Select RX0 and TX0 on Headers JP10 and JP11 (UART 0).
 -   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   To achieve lowest current measurements, remove jumpers JP2-JP11 and disconnect the LCD.
 
 ## Expected Output
 

--- a/Examples/MAX32672/LP/main.c
+++ b/Examples/MAX32672/LP/main.c
@@ -204,7 +204,8 @@ void configure_gpios(void)
 
 int main(void)
 {
-    // Delay to prevent bricks
+    // Delay to provide the debugger with a window to connect.
+    // Low-power modes shut down SWD
     MXC_Delay(MXC_DELAY_SEC(2));
 
     PRINT("\n************ Low Power Mode Example ************\n\n");

--- a/Examples/MAX32672/LP/main.c
+++ b/Examples/MAX32672/LP/main.c
@@ -167,45 +167,45 @@ void setTrigger(int waitForTrigger)
 
 void configure_gpios(void)
 {
-	mxc_gpio_cfg_t out_clr;
-	mxc_gpio_cfg_t out_set;
+    mxc_gpio_cfg_t out_clr;
+    mxc_gpio_cfg_t out_set;
 
-	// Create list of pins that are in use (the "do not modify" list)
-	uint32_t dnm = MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1 | MXC_GPIO_PIN_10;
+    // Create list of pins that are in use (the "do not modify" list)
+    uint32_t dnm = MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1 | MXC_GPIO_PIN_10;
 
-	// Add UART TX pin (P0.9) to do not modify list if the console is being used
-  #if USE_CONSOLE
-	dnm |= MXC_GPIO_PIN_9;
-  #endif // USE_CONSOLE
+    // Add UART TX pin (P0.9) to do not modify list if the console is being used
+#if USE_CONSOLE
+    dnm |= MXC_GPIO_PIN_9;
+#endif // USE_CONSOLE
 
-	// Add Push Button pin (P0.18) to the do not modify list if it's being used as the wakeup source
-  #if USE_BUTTON
-	dnm |= MXC_GPIO_PIN_18;
-  #endif // USE_BUTTON
+    // Add Push Button pin (P0.18) to the do not modify list if it's being used as the wakeup source
+#if USE_BUTTON
+    dnm |= MXC_GPIO_PIN_18;
+#endif // USE_BUTTON
 
-	// Set all GPIO pins low except for SWD (P0.0/P0.1), and P0.10 (and push button and UART pins if they're being used)
-	out_clr.port = MXC_GPIO0;
-	out_clr.mask = ~dnm;
-	out_clr.func = MXC_GPIO_FUNC_OUT;
-	out_clr.pad = MXC_GPIO_PAD_NONE;
-	out_clr.vssel = MXC_GPIO_VSSEL_VDDIOH;
-	MXC_GPIO_Config(&out_clr);
-	MXC_GPIO_OutClr(out_clr.port, out_clr.mask);
+    // Set all GPIO pins low except for SWD (P0.0/P0.1), and P0.10 (and push button and UART pins if they're being used)
+    out_clr.port = MXC_GPIO0;
+    out_clr.mask = ~dnm;
+    out_clr.func = MXC_GPIO_FUNC_OUT;
+    out_clr.pad = MXC_GPIO_PAD_NONE;
+    out_clr.vssel = MXC_GPIO_VSSEL_VDDIOH;
+    MXC_GPIO_Config(&out_clr);
+    MXC_GPIO_OutClr(out_clr.port, out_clr.mask);
 
-	// Set GPIO P0.10 high (it's connected to an external pullup resistor)
-	out_set.port = MXC_GPIO0;
-	out_set.mask = MXC_GPIO_PIN_10;
-	out_set.func = MXC_GPIO_FUNC_OUT;
-	out_set.pad = MXC_GPIO_PAD_NONE;
-	out_set.vssel = MXC_GPIO_VSSEL_VDDIOH;
-	MXC_GPIO_Config(&out_set);
-	MXC_GPIO_OutSet(out_set.port, out_set.mask);
+    // Set GPIO P0.10 high (it's connected to an external pullup resistor)
+    out_set.port = MXC_GPIO0;
+    out_set.mask = MXC_GPIO_PIN_10;
+    out_set.func = MXC_GPIO_FUNC_OUT;
+    out_set.pad = MXC_GPIO_PAD_NONE;
+    out_set.vssel = MXC_GPIO_VSSEL_VDDIOH;
+    MXC_GPIO_Config(&out_set);
+    MXC_GPIO_OutSet(out_set.port, out_set.mask);
 }
 
 int main(void)
 {
-	// Delay to prevent bricks
-	MXC_Delay(MXC_DELAY_SEC(2));
+    // Delay to prevent bricks
+    MXC_Delay(MXC_DELAY_SEC(2));
 
     PRINT("\n************ Low Power Mode Example ************\n\n");
 
@@ -222,7 +222,7 @@ int main(void)
     PB_RegisterCallback(0, buttonHandler);
 #endif // USE_BUTTON
 
-	// Set GPIO pins to known state
+    // Set GPIO pins to known state
     configure_gpios();
 
     PRINT("Running in ACTIVE mode.\n");

--- a/Examples/MAX32672/LP/main.c
+++ b/Examples/MAX32672/LP/main.c
@@ -53,15 +53,17 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include "board.h"
+#include "gpio.h"
+#include "icc.h"
+#include "lp.h"
+#include "mxc_delay.h"
 #include "mxc_device.h"
 #include "mxc_errors.h"
+#include "nvic_table.h"
 #include "pb.h"
-#include "board.h"
-#include "lp.h"
-#include "icc.h"
 #include "rtc.h"
 #include "uart.h"
-#include "nvic_table.h"
 
 #define DELAY_IN_SEC 2
 #define USE_CONSOLE 1
@@ -163,8 +165,48 @@ void setTrigger(int waitForTrigger)
 }
 #endif // USE_BUTTON
 
+void configure_gpios(void)
+{
+	mxc_gpio_cfg_t out_clr;
+	mxc_gpio_cfg_t out_set;
+
+	// Create list of pins that are in use (the "do not modify" list)
+	uint32_t dnm = MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1 | MXC_GPIO_PIN_10;
+
+	// Add UART TX pin (P0.9) to do not modify list if the console is being used
+  #if USE_CONSOLE
+	dnm |= MXC_GPIO_PIN_9;
+  #endif // USE_CONSOLE
+
+	// Add Push Button pin (P0.18) to the do not modify list if it's being used as the wakeup source
+  #if USE_BUTTON
+	dnm |= MXC_GPIO_PIN_18;
+  #endif // USE_BUTTON
+
+	// Set all GPIO pins low except for SWD (P0.0/P0.1), and P0.10 (and push button and UART pins if they're being used)
+	out_clr.port = MXC_GPIO0;
+	out_clr.mask = ~dnm;
+	out_clr.func = MXC_GPIO_FUNC_OUT;
+	out_clr.pad = MXC_GPIO_PAD_NONE;
+	out_clr.vssel = MXC_GPIO_VSSEL_VDDIOH;
+	MXC_GPIO_Config(&out_clr);
+	MXC_GPIO_OutClr(out_clr.port, out_clr.mask);
+
+	// Set GPIO P0.10 high (it's connected to an external pullup resistor)
+	out_set.port = MXC_GPIO0;
+	out_set.mask = MXC_GPIO_PIN_10;
+	out_set.func = MXC_GPIO_FUNC_OUT;
+	out_set.pad = MXC_GPIO_PAD_NONE;
+	out_set.vssel = MXC_GPIO_VSSEL_VDDIOH;
+	MXC_GPIO_Config(&out_set);
+	MXC_GPIO_OutSet(out_set.port, out_set.mask);
+}
+
 int main(void)
 {
+	// Delay to prevent bricks
+	MXC_Delay(MXC_DELAY_SEC(2));
+
     PRINT("\n************ Low Power Mode Example ************\n\n");
 
 #if USE_ALARM
@@ -179,6 +221,9 @@ int main(void)
           "from each mode and enter the next.\n\n");
     PB_RegisterCallback(0, buttonHandler);
 #endif // USE_BUTTON
+
+	// Set GPIO pins to known state
+    configure_gpios();
 
     PRINT("Running in ACTIVE mode.\n");
 #if !USE_CONSOLE


### PR DESCRIPTION
This PR adds instructions in the MAX32672 LP example README on how to configure the EV kit to achieve low power measurements that match what is listed in the datasheet. Additionally, a function was added in the example code that sets all GPIOs low except for the SWD pins, and the push button/UART pins if they are in use.