### PR TITLE
Add MXC_I2C_AsyncStop and MXC_I2C_AbortAsync Functions

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/i2c.h
@@ -830,6 +830,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32570/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/i2c.h
@@ -834,6 +834,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32572/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/i2c.h
@@ -834,6 +834,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32650/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/i2c.h
@@ -822,6 +822,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32655/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/i2c.h
@@ -830,6 +830,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32660/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/i2c.h
@@ -822,6 +822,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32662/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/i2c.h
@@ -830,6 +830,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32665/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/i2c.h
@@ -824,6 +824,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32670/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/i2c.h
@@ -832,6 +832,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32672/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/i2c.h
@@ -835,6 +835,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32675/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/i2c.h
@@ -832,6 +832,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32680/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/i2c.h
@@ -830,6 +830,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX32690/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/i2c.h
@@ -830,6 +830,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX78000/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/i2c.h
@@ -828,6 +828,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Include/MAX78002/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/i2c.h
@@ -834,6 +834,16 @@ int MXC_I2C_SetTXThreshold(mxc_i2c_regs_t *i2c, unsigned int numBytes);
 int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c);
 
 /**
+ * @brief   Stop any asynchronous requests in progress.
+ *
+ * Stop any asynchronous requests in progress. Any callbacks associated with
+ * the active transaction will be NOT executed.
+ *
+ * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
+ */
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c);
+
+/**
  * @brief   Abort any asynchronous requests in progress.
  *
  * Abort any asynchronous requests in progress. Any callbacks associated with

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_ai87.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_ai87.c
@@ -368,6 +368,16 @@ int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_es17.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_es17.c
@@ -365,6 +365,16 @@ unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me11.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me11.c
@@ -382,6 +382,16 @@ unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me12.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me12.c
@@ -364,6 +364,16 @@ int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me13.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me13.c
@@ -363,6 +363,16 @@ unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me14.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me14.c
@@ -383,6 +383,16 @@ unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me15.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me15.c
@@ -396,6 +396,16 @@ unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me16.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me16.c
@@ -363,6 +363,16 @@ unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold(i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler(i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me17.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me17.c
@@ -384,6 +384,16 @@ int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me18.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me18.c
@@ -368,6 +368,16 @@ int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me21.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me21.c
@@ -410,6 +410,16 @@ unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me55.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me55.c
@@ -356,6 +356,16 @@ unsigned int MXC_I2C_GetTXThreshold(mxc_i2c_regs_t *i2c)
     return MXC_I2C_RevA_GetTXThreshold((mxc_i2c_reva_regs_t *)i2c);
 }
 
+void MXC_I2C_AsyncStop(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AsyncStop((mxc_i2c_reva_regs_t *)i2c);
+}
+
+void MXC_I2C_AbortAsync(mxc_i2c_regs_t *i2c)
+{
+    MXC_I2C_RevA_AbortAsync((mxc_i2c_reva_regs_t *)i2c);
+}
+
 void MXC_I2C_AsyncHandler(mxc_i2c_regs_t *i2c)
 {
     MXC_I2C_RevA_AsyncHandler((mxc_i2c_reva_regs_t *)i2c, interruptCheck);


### PR DESCRIPTION
MXC_I2C_RevA_AsyncStop and MXC_I2C_RevA_AbortAsync were already implemented; support for calling these functions from each of the chip specific header/source files is added in this PR.