### PR TITLE
Temporary disable datc/s and otas/c connected state tests

### DIFF
--- a/.github/workflows/scripts/test_launcher.sh
+++ b/.github/workflows/scripts/test_launcher.sh
@@ -613,27 +613,30 @@ if [ $CURRENT_TEST == "all" ]; then
     erase_all_devices
     run_all_not_conencted_tests
     CURRENT_TEST="all"
-    run_datcs_conencted_tests
-    CURRENT_TEST="all"
-    run_ota_test 1 # arg 1= internal flash
-    if [[ $DUT_NAME_UPPER != "MAX32690" ]]; then
-        run_ota_test 0 # arg 0 = external flash
-    fi
+    # temp diasble datc/s and otas tests until new RF PHY is debugged with ME17B
+    # run_datcs_conencted_tests
+    # CURRENT_TEST="all"
+    # run_ota_test 1 # arg 1= internal flash
+    # if [[ $DUT_NAME_UPPER != "MAX32690" ]]; then
+    #     run_ota_test 0 # arg 0 = external flash
+    # fi
 
     echo
 elif [ $CURRENT_TEST == "dats" ]; then
     echo
     echo "Running Datc/s connected test"
     erase_all_devices
-    run_datcs_conencted_tests
+    # temp diasble datc/s and otas tests until new RF PHY is debugged with ME17B
+    #run_datcs_conencted_tests
     echo
 elif [ $CURRENT_TEST == "ota" ]; then
     echo
     echo "Running OTA test"
-    erase_all_devices
-    run_ota_test 1 # arg 1 = internal flash
-    if [[ $DUT_NAME_UPPER != "MAX32690" ]]; then
-    run_ota_test 0 # arg 0= external flash
+    # temp diasble datc/s and otas tests until new RF PHY is debugged with ME17B
+    # erase_all_devices
+    # run_ota_test 1 # arg 1 = internal flash
+    # if [[ $DUT_NAME_UPPER != "MAX32690" ]]; then
+    # run_ota_test 0 # arg 0= external flash
     fi
     echo
 else

--- a/.github/workflows/scripts/test_launcher.sh
+++ b/.github/workflows/scripts/test_launcher.sh
@@ -407,9 +407,8 @@ function run_all_not_conencted_tests() {
 
     done # end non connected tests
 
-
-
 }
+
 #****************************************************************************************************
 function run_datcs_conencted_tests() {
     echo
@@ -486,17 +485,17 @@ function run_ota_test() {
     fi
     echo "****************************************************************************************************"
     # ME18 evkit does not have external flash
-    
+
     # #make sure all files have correct settings
     cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas
     git restore .
-    
+
     cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/Bootloader
     git restore .
 
     # change advertising names
     change_advertising_names
-    
+
     # change the target the OTAC embedded firmware in the client is built for
     cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac
     #appends TARGET , TARGET_UC and TARGET_LC to the make commands and sets them to $DUT_NAME_UPPER and $DUT_NAME_LOWER
@@ -559,18 +558,18 @@ function run_ota_test() {
         let "numOfFailedTests+=$testResult"
         if [[ "$INTERNAL_FLASH_TEST" -ne "0" ]]; then
             failedTestList+="| BLE_ota_cs_int ($DUT_NAME_UPPER) "
-             # test failed, save elfs datc/s
+            # test failed, save elfs datc/s
             cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac/build
             cp $MAIN_DEVICE_NAME_LOWER.elf $EXAMPLE_TEST_PATH/results/failed_elfs/$MAIN_DEVICE_NAME_LOWER"_"$DUT_NAME_LOWER"_BLE_otacs_client_int.elf"
             cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas/build
             cp $DUT_NAME_LOWER.elf $EXAMPLE_TEST_PATH/results/failed_elfs/$DUT_NAME_LOWER"_BLE_otacs_server_int.elf"
         else
             failedTestList+="| BLE_ota_cs_ext ($DUT_NAME_UPPER) "
-             # test failed, save elfs datc/s
+            # test failed, save elfs datc/s
             cd $MSDK_DIR/Examples/$MAIN_DEVICE_NAME_UPPER/BLE_otac/build
             cp $MAIN_DEVICE_NAME_LOWER.elf $EXAMPLE_TEST_PATH/results/failed_elfs/$MAIN_DEVICE_NAME_LOWER"_"$DUT_NAME_LOWER"_BLE_otacs_client_ext.elf"
             cd $MSDK_DIR/Examples/$DUT_NAME_UPPER/BLE_otas/build
-            cp $DUT_NAME_LOWER.elf $EXAMPLE_TEST_PATH/results/failed_elfs/$DUT_NAME_LOWER"_BLE_otacs_server_ext.elf"    
+            cp $DUT_NAME_LOWER.elf $EXAMPLE_TEST_PATH/results/failed_elfs/$DUT_NAME_LOWER"_BLE_otacs_server_ext.elf"
         fi
 
     fi
@@ -580,9 +579,8 @@ function run_ota_test() {
     erase_with_openocd $DUT_NAME_LOWER $DUT_ID
     #   erase_with_openocd $MAIN_DEVICE_NAME_LOWER $MAIN_DEVICE_ID
 
-
     erase_all_devices
-   
+
 }
 
 #****************************************************************************************************
@@ -604,7 +602,6 @@ git checkout ME17B1-new
 cd MAX32655/build/gcc
 make clean
 make -j
-
 
 if [ $CURRENT_TEST == "all" ]; then
     echo
@@ -637,7 +634,7 @@ elif [ $CURRENT_TEST == "ota" ]; then
     # run_ota_test 1 # arg 1 = internal flash
     # if [[ $DUT_NAME_UPPER != "MAX32690" ]]; then
     # run_ota_test 0 # arg 0= external flash
-    fi
+    #fi
     echo
 else
     echo
@@ -645,7 +642,6 @@ else
     run_single_not_conencted_tests $CURRENT_TEST
     echo
 fi
-
 
 if [ $CURRENT_TEST == "all" ]; then
     echo "=============================================================================="
@@ -662,5 +658,3 @@ if [ $CURRENT_TEST == "all" ]; then
     echo
 fi
 exit $numOfFailedTests
-
-

--- a/Libraries/Cordio/ble-profiles/sources/af/app_disc.c
+++ b/Libraries/Cordio/ble-profiles/sources/af/app_disc.c
@@ -18,7 +18,7 @@
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
- *  limitations under the License test.
+ *  limitations under the License.
  */
 /*************************************************************************************************/
 

--- a/Libraries/Cordio/ble-profiles/sources/af/app_disc.c
+++ b/Libraries/Cordio/ble-profiles/sources/af/app_disc.c
@@ -18,7 +18,7 @@
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ *  limitations under the License test.
  */
 /*************************************************************************************************/
 


### PR DESCRIPTION
Currently RF PHY for ME17B needs debugging, datc/s and otac/s connected states  are unreliable right now.
Waiting for early next week to have Evkits reworked with ME17B to debug.