### PR TITLE
RTC RevA: Resolving warnings in TrimCrystal function when testing if unsigned integer is negative.

### DIFF
--- a/Libraries/PeriphDrivers/Source/RTC/rtc_reva.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_reva.c
@@ -361,9 +361,9 @@ int MXC_RTC_RevA_TrimCrystal(mxc_rtc_reva_regs_t *rtc, mxc_tmr_regs_t *tmr)
 
     if (!(rtc->ctrl & MXC_F_RTC_REVA_CTRL_EN)) { // If RTC not enable, initialize it
         rtc_en = false;
-        while ((sec = MXC_RTC_RevA_GetSecond(rtc)) < 0) {}
+
         // Save state
-        while ((ssec = MXC_RTC_RevA_GetSubSecond(rtc)) < 0) {}
+        while (MXC_RTC_RevA_GetTime(rtc, &sec, &ssec) < 0) {}
         while (rtc->ctrl & MXC_F_RTC_CTRL_BUSY) {}
         ctrl = rtc->ctrl;
 
@@ -375,16 +375,14 @@ int MXC_RTC_RevA_TrimCrystal(mxc_rtc_reva_regs_t *rtc, mxc_tmr_regs_t *tmr)
 
     MXC_TMR_ClearFlags(tmr);
     MXC_TMR_Start(tmr); // Sample the RTC ticks in MXC_RTC_REVA_TRIM_PERIODS number of periods
-    while ((sec_sample[0] = MXC_RTC_RevA_GetSecond(rtc)) < 0) {}
-    while ((ssec_sample[0] = MXC_RTC_RevA_GetSubSecond(rtc)) < 0) {}
+    while (MXC_RTC_RevA_GetTime(rtc, &sec_sample[0], &ssec_sample[0]) < 0) {}
 
     for (int i = 1; i < (MXC_RTC_REVA_TRIM_PERIODS + 1); i++) {
-        while (!(MXC_TMR_GetFlags(tmr) & MXC_RTC_TRIM_TMR_IRQ)) {}
         // Wait for time trim period to elapse
+        while (!(MXC_TMR_GetFlags(tmr) & MXC_RTC_TRIM_TMR_IRQ)) {}
 
-        while ((sec_sample[i] = MXC_RTC_RevA_GetSecond(rtc)) < 0) {}
         // Take time sample
-        while ((ssec_sample[i] = MXC_RTC_RevA_GetSubSecond(rtc)) < 0) {}
+        while (MXC_RTC_RevA_GetTime(rtc, &sec_sample[i], &ssec_sample[i]) < 0) {}
 
         MXC_TMR_ClearFlags(tmr);
     }

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_reva.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_reva.c
@@ -354,9 +354,10 @@ int MXC_RTC_RevA_GetTime(mxc_rtc_reva_regs_t *rtc, uint32_t *sec, uint32_t *subs
 int MXC_RTC_RevA_TrimCrystal(mxc_rtc_reva_regs_t *rtc, mxc_tmr_regs_t *tmr)
 {
     int err, ppm = 0;
-    uint32_t sec = 0, ssec = 0, ctrl = 0;
-    uint32_t sec_sample[MXC_RTC_REVA_TRIM_PERIODS + 1] = { 0 };
-    uint32_t ssec_sample[MXC_RTC_REVA_TRIM_PERIODS + 1] = { 0 };
+    int sec = 0, ssec = 0;
+    uint32_t ctrl = 0;
+    int sec_sample[MXC_RTC_REVA_TRIM_PERIODS + 1] = { 0 };
+    int ssec_sample[MXC_RTC_REVA_TRIM_PERIODS + 1] = { 0 };
     bool rtc_en = true;
 
     if (!(rtc->ctrl & MXC_F_RTC_REVA_CTRL_EN)) { // If RTC not enable, initialize it
@@ -403,8 +404,8 @@ int MXC_RTC_RevA_TrimCrystal(mxc_rtc_reva_regs_t *rtc, mxc_tmr_regs_t *tmr)
         rtc->ctrl = ctrl;
     }
 
-    for (int i = 0; i < MXC_RTC_REVA_TRIM_PERIODS;
-         i++) { // Get total error in RTC ticks over MXC_RTC_REVA_TRIM_PERIODS number of sample periods
+    // Get total error in RTC ticks over MXC_RTC_REVA_TRIM_PERIODS number of sample periods
+    for (int i = 0; i < MXC_RTC_REVA_TRIM_PERIODS; i++) {
         if (sec_sample[i] < sec_sample[i + 1]) {
             ppm += MXC_RTC_REVA_TICKS_PER_PERIOD -
                    ((MXC_RTC_MAX_SSEC - ssec_sample[i]) + ssec_sample[i + 1]);

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_reva.c
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_reva.c
@@ -354,10 +354,9 @@ int MXC_RTC_RevA_GetTime(mxc_rtc_reva_regs_t *rtc, uint32_t *sec, uint32_t *subs
 int MXC_RTC_RevA_TrimCrystal(mxc_rtc_reva_regs_t *rtc, mxc_tmr_regs_t *tmr)
 {
     int err, ppm = 0;
-    int sec = 0, ssec = 0;
-    uint32_t ctrl = 0;
-    int sec_sample[MXC_RTC_REVA_TRIM_PERIODS + 1] = { 0 };
-    int ssec_sample[MXC_RTC_REVA_TRIM_PERIODS + 1] = { 0 };
+    uint32_t sec = 0, ssec = 0, ctrl = 0;
+    uint32_t sec_sample[MXC_RTC_REVA_TRIM_PERIODS + 1] = { 0 };
+    uint32_t ssec_sample[MXC_RTC_REVA_TRIM_PERIODS + 1] = { 0 };
     bool rtc_en = true;
 
     if (!(rtc->ctrl & MXC_F_RTC_REVA_CTRL_EN)) { // If RTC not enable, initialize it
@@ -404,8 +403,8 @@ int MXC_RTC_RevA_TrimCrystal(mxc_rtc_reva_regs_t *rtc, mxc_tmr_regs_t *tmr)
         rtc->ctrl = ctrl;
     }
 
-    // Get total error in RTC ticks over MXC_RTC_REVA_TRIM_PERIODS number of sample periods
-    for (int i = 0; i < MXC_RTC_REVA_TRIM_PERIODS; i++) {
+    for (int i = 0; i < MXC_RTC_REVA_TRIM_PERIODS;
+         i++) { // Get total error in RTC ticks over MXC_RTC_REVA_TRIM_PERIODS number of sample periods
         if (sec_sample[i] < sec_sample[i + 1]) {
             ppm += MXC_RTC_REVA_TICKS_PER_PERIOD -
                    ((MXC_RTC_MAX_SSEC - ssec_sample[i]) + ssec_sample[i + 1]);


### PR DESCRIPTION
This PR resolves the build warnings reported by GEHC where we were testing whether a uint32_t was less than 0. The variables which were involved in these comparison are now changed to type int.