### PR TITLE
Build Workflow:  Update Check Watch Files Implementation

### DIFF
--- a/.github/workflows/Build_Examples.yml
+++ b/.github/workflows/Build_Examples.yml
@@ -69,7 +69,7 @@ jobs:
           for watch_file in $WATCH_FILES; do 
               for change_file in $CHANGE_FILES; do 
                   if [[ "${change_file,,}" == *"${watch_file,,}" ]]; then
-                      echo "MATCH CI Iterate. Watch type: $watch_file, File: $change_file"
+                      echo "Match found. Watch type: $watch_file, File: $change_file"
                       RUN_TEST=1
                   fi
               done

--- a/.github/workflows/Build_Examples.yml
+++ b/.github/workflows/Build_Examples.yml
@@ -66,11 +66,13 @@ jobs:
           echo "Checking the following changes"
           echo $CHANGE_FILES
 
-          # Assume we want to actually run the workflow if no files changed
           for watch_file in $WATCH_FILES; do 
-            if [[ "$CHANGE_FILES" == *"$watch_file" ]]; then
-              RUN_TEST=1
-            fi
+              for change_file in $CHANGE_FILES; do 
+                  if [[ "${change_file,,}" == *"${watch_file,,}" ]]; then
+                      echo "MATCH CI Iterate. Watch type: $watch_file, File: $change_file"
+                      RUN_TEST=1
+                  fi
+              done
           done
 
           # End the test early if there wasn't a significant change

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/gcr_regs.h
@@ -4,6 +4,8 @@
  * @note    This file is @generated.
  */
 
+// Testing 1 2 3
+
 /******************************************************************************
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/gcr_regs.h
@@ -4,8 +4,6 @@
  * @note    This file is @generated.
  */
 
-// Testing 1 2 3
-
 /******************************************************************************
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *


### PR DESCRIPTION
The old "check watch files" implementation seemed to have some issues with case sensitivity.  The new implementation from @jdk-maxim seems to be much more reliable.

Fixes #566 

Manual run on fork works great:  https://github.com/Jake-Carter/msdk/actions/runs/4886879634/jobs/8722797077

This PR should trigger a build based on its test commit as well.

