### PR TITLE
SPI Rev. A: Updating SetTXThreshold and SetRXThreshold to only accept valid threshold values.

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva.c
@@ -879,7 +879,7 @@ uint32_t MXC_SPI_RevA_TransHandler(mxc_spi_reva_regs_t *spi, mxc_spi_reva_req_t 
     // Write the FIFO //starting here
     if (remain) {
         if (remain >= MXC_SPI_FIFO_DEPTH) {
-            MXC_SPI_SetTXThreshold((mxc_spi_regs_t *)spi, MXC_SPI_FIFO_DEPTH-1);
+            MXC_SPI_SetTXThreshold((mxc_spi_regs_t *)spi, MXC_SPI_FIFO_DEPTH - 1);
         } else {
             MXC_SPI_SetTXThreshold((mxc_spi_regs_t *)spi, remain);
         }

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva.c
@@ -671,7 +671,7 @@ int MXC_SPI_RevA_SetRXThreshold(mxc_spi_reva_regs_t *spi, unsigned int numBytes)
 {
     MXC_ASSERT(MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi) >= 0);
 
-    if (numBytes > 32) {
+    if (numBytes > 30) {
         return E_BAD_PARAM;
     }
 
@@ -906,7 +906,7 @@ uint32_t MXC_SPI_RevA_TransHandler(mxc_spi_reva_regs_t *spi, mxc_spi_reva_req_t 
         remain = rx_length - req->rxCnt;
 
         if (remain) {
-            if (remain > MXC_SPI_FIFO_DEPTH) {
+            if (remain >= MXC_SPI_FIFO_DEPTH) {
                 MXC_SPI_SetRXThreshold((mxc_spi_regs_t *)spi, 2);
             } else {
                 MXC_SPI_SetRXThreshold((mxc_spi_regs_t *)spi, remain - 1);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva.c
@@ -691,7 +691,8 @@ int MXC_SPI_RevA_SetTXThreshold(mxc_spi_reva_regs_t *spi, unsigned int numBytes)
 {
     MXC_ASSERT(MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi) >= 0);
 
-    if (numBytes > 32) {
+    // Valid values for the threshold are 0x1 to 0x1F
+    if (numBytes > 31 || numBytes == 0) {
         return E_BAD_PARAM;
     }
 
@@ -877,8 +878,8 @@ uint32_t MXC_SPI_RevA_TransHandler(mxc_spi_reva_regs_t *spi, mxc_spi_reva_req_t 
     // Set the TX interrupts
     // Write the FIFO //starting here
     if (remain) {
-        if (remain > MXC_SPI_FIFO_DEPTH) {
-            MXC_SPI_SetTXThreshold((mxc_spi_regs_t *)spi, MXC_SPI_FIFO_DEPTH);
+        if (remain >= MXC_SPI_FIFO_DEPTH) {
+            MXC_SPI_SetTXThreshold((mxc_spi_regs_t *)spi, MXC_SPI_FIFO_DEPTH-1);
         } else {
             MXC_SPI_SetTXThreshold((mxc_spi_regs_t *)spi, remain);
         }


### PR DESCRIPTION
 A customer reported that the MXC_SPI_RevA_SetTXThreshold function would accept values 0 and 32 (which gets masked off to 0) for the threshold parameter. Setting the threshold value to 0 is invalid because both the TX_THD interrupt and DMA_TX transactions are triggered when the FIFO count drops BELOW the threshold, therefore the interrupt and DMA transaction will never get triggered with this setting.

This PR updates the MXC_SPI_RevA_SetTXThreshold to only allow threshold values between 0x1 and 0x1f and also updates the calls to SetTXThreshold to use valid values.

Additionally, while I was looking into this bug I discovered that the MXC_SPI_RevA_SetRXThreshold function allowed threshold values greater than 30 which is also an invalid setting. So I have also updated MXC_SPI_RevA_SetRXThreshold to limit the threshold parameter to 30 and have updated the calls to this function as well.