### PR TITLE
MSDK-1116: Preventing MAX32570 applications from hanging in MXC_FLC_ME13_Flash_Operation.

### DIFF
--- a/Libraries/PeriphDrivers/Source/FLC/flc_me13.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_me13.c
@@ -69,13 +69,13 @@ void MXC_FLC_ME13_Flash_Operation(void)
     */
 
     /* Flush all instruction caches if cache is enabled */
-	if (MXC_ICC->cache_ctrl & MXC_F_ICC_CACHE_CTRL_EN) {
-		MXC_ICC_Flush();
-	}
+    if (MXC_ICC->cache_ctrl & MXC_F_ICC_CACHE_CTRL_EN) {
+        MXC_ICC_Flush();
+    }
 
-	if (MXC_SFCC->cache_ctrl & MXC_F_ICC_CACHE_CTRL_EN) {
-		MXC_SFCC_Enable();
-	}
+    if (MXC_SFCC->cache_ctrl & MXC_F_ICC_CACHE_CTRL_EN) {
+        MXC_SFCC_Enable();
+    }
 
     // Clear the line fill buffer by reading 2 pages from flash
     volatile uint32_t *line_addr;

--- a/Libraries/PeriphDrivers/Source/FLC/flc_me13.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_me13.c
@@ -47,7 +47,9 @@
 #include "flc.h"
 #include "flc_reva.h"
 #include "flc_common.h"
+#include "icc.h"
 #include "mcr_regs.h" // For ECCEN registers.
+#include "sfcc.h"
 
 //******************************************************************************
 void MXC_FLC_ME13_Flash_Operation(void)
@@ -66,11 +68,14 @@ void MXC_FLC_ME13_Flash_Operation(void)
     It's flushed by reading 2 pages of flash.
     */
 
-    /* Flush all instruction caches */
-    MXC_GCR->sysctrl |= MXC_F_GCR_SYSCTRL_ICC0_FLUSH;
+    /* Flush all instruction caches if cache is enabled */
+	if (MXC_ICC->cache_ctrl & MXC_F_ICC_CACHE_CTRL_EN) {
+		MXC_ICC_Flush();
+	}
 
-    /* Wait for flush to complete */
-    while (MXC_GCR->sysctrl & MXC_F_GCR_SYSCTRL_ICC0_FLUSH) {}
+	if (MXC_SFCC->cache_ctrl & MXC_F_ICC_CACHE_CTRL_EN) {
+		MXC_SFCC_Enable();
+	}
 
     // Clear the line fill buffer by reading 2 pages from flash
     volatile uint32_t *line_addr;


### PR DESCRIPTION
When updating the Flash and WearLeveling examples for the MAX32570, I discovered the examples would hang in MXC_FLC_ME13_Flash_Operation while waiting for the ICC0_Flush flag to clear. This PR fixes this bug by flushing the SFCC and ICC individually with their respective flush functions, instead of using the global cache invalidation bit in the GCR registers.