### PR TITLE
MSDK-1118: FLC:  Fix Null Pointer Bug for MAX32660 Flash Base Address

### DIFF
--- a/Libraries/PeriphDrivers/Source/FLC/flc_me11.c
+++ b/Libraries/PeriphDrivers/Source/FLC/flc_me11.c
@@ -71,9 +71,9 @@ void MXC_FLC_ME11_Flash_Operation(void)
     // Clear the line fill buffer by reading 2 pages from flash
     volatile uint32_t *line_addr;
     volatile uint32_t __unused line; // __unused attribute removes warning
-    line_addr = (uint32_t *)(MXC_FLASH_MEM_BASE);
-    line = *line_addr;
     line_addr = (uint32_t *)(MXC_FLASH_MEM_BASE + MXC_FLASH_PAGE_SIZE);
+    line = *line_addr;
+    line_addr = (uint32_t *)(MXC_FLASH_MEM_BASE + (2 * MXC_FLASH_PAGE_SIZE));
     line = *line_addr;
 }
 


### PR DESCRIPTION
MAX32660 base address is 0x0, casting it to a pointer causes null pointer access
So that instead of reading page 0-1 read page 1-2 to update cache
