### PR TITLE
Add die type to part number conversion table to User Guide

### DIFF
--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -1706,8 +1706,8 @@ The _**implementation**_ files are further organized based on _**die type**_ and
       | MAX32690 | ME18 |
       | MAX78000 | AI85 |
       | MAX78002 | AI87 |
-      
-- The **_hardware** revision_ files follow the **`_revX`** naming convention.  
+
+- The **_hardware revision_** files follow the **`_revX`** naming convention.  
     - These files contain the _pure_ driver implementation for a peripheral block and typically interact with the hardware almost entirely at the register level.
 
 ## Examples

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -1687,8 +1687,26 @@ The Peripheral Driver API's source code is organized as follows:
 
 The _**implementation**_ files are further organized based on _**die type**_ and **_hardware revision_**. This is worth noting when browsing or debugging through the drivers.  
 
-- The **_die type_** files follow the **`_MEXX`** or **`_AIXX`** naming convention
+- The **_die type_** files follow the **`_ESXX`** , **`_MEXX`** , or **`_AIXX`** naming convention.
     - These files' responsibility is to manage microcontroller-specific implementation details that may interact with other peripheral APIs _before_ ultimately calling the revision-specific files.
+    - This table shows which part numbers correspond to each die type:
+
+      | Part Number | Die Type
+      | -------- | ----------- |
+      | MAX32520 | ES17 |
+      | MAX32570 | ME13 |
+      | MAX32650 | ME10 |
+      | MAX32655 | ME17 |
+      | MAX32660 | ME11 |
+      | MAX32665 | ME14 |
+      | MAX32670 | ME15 |
+      | MAX32672 | ME21 |
+      | MAX32675 | ME16 |
+      | MAX32680 | ME20 |
+      | MAX32690 | ME18 |
+      | MAX78000 | AI85 |
+      | MAX78002 | AI87 |
+      
 - The **_hardware** revision_ files follow the **`_revX`** naming convention.  
     - These files contain the _pure_ driver implementation for a peripheral block and typically interact with the hardware almost entirely at the register level.
 

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -1698,6 +1698,7 @@ The _**implementation**_ files are further organized based on _**die type**_ and
       | MAX32650 | ME10 |
       | MAX32655 | ME17 |
       | MAX32660 | ME11 |
+      | MAX32662 | ME12 |
       | MAX32665 | ME14 |
       | MAX32670 | ME15 |
       | MAX32672 | ME21 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,5 +14,6 @@ nav:
 theme:
   name: readthedocs
 markdown_extensions:
+  tables: {}
   codehilite:
     use_pygments: False


### PR DESCRIPTION
The VSCode-Maxim repo used to have a page in the wiki that showed the die type to part number conversion, which was useful for navigating the peripheral driver code. 

When the wiki was moved and its content merged with the User Guide, that section appears to have not been migrated. This PR adds the same conversion table from the old wiki to [the 'Peripheral Driver API > Organization' section of the User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#organization). 

To build properly, `mkdocs.yml` was also modified slightly to enable the markdown table extension. 

The `Documentation\build.py` script was run locally and a screenshot of the relevant section from the generated `docs\USERGUIDE\index.html` is shown below:

![userguide_table](https://github.com/Analog-Devices-MSDK/msdk/assets/11401637/cca17e0f-e569-4fca-b373-36309f410c51)