### PR TITLE
Allow Overriding Linkerfile for SBT Projects

### DIFF
--- a/Examples/MAX32520/AES/Makefile
+++ b/Examples/MAX32520/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32520/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/CRC/Makefile
+++ b/Examples/MAX32520/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/Coremark/Makefile
+++ b/Examples/MAX32520/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/DMA/Makefile
+++ b/Examples/MAX32520/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ECDSA/Makefile
+++ b/Examples/MAX32520/ECDSA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32520/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/Flash/Makefile
+++ b/Examples/MAX32520/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/Flash_CLI/Makefile
+++ b/Examples/MAX32520/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32520/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/GPIO/Makefile
+++ b/Examples/MAX32520/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/Hello_World/Makefile
+++ b/Examples/MAX32520/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/I2C_MNGR/Makefile
+++ b/Examples/MAX32520/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/I2C_SCAN/Makefile
+++ b/Examples/MAX32520/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/I2C_Sensor/Makefile
+++ b/Examples/MAX32520/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/ICC/Makefile
+++ b/Examples/MAX32520/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/LP/Makefile
+++ b/Examples/MAX32520/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/Library_Generate/Makefile
+++ b/Examples/MAX32520/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/Library_Use/Makefile
+++ b/Examples/MAX32520/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/LockDebug/Makefile
+++ b/Examples/MAX32520/LockDebug/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/OTP_Dump/Makefile
+++ b/Examples/MAX32520/OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32520/SCPA_OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/SFE/Makefile
+++ b/Examples/MAX32520/SFE/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/SFE_Host/Makefile
+++ b/Examples/MAX32520/SFE_Host/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/SMON/Makefile
+++ b/Examples/MAX32520/SMON/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/SPI/Makefile
+++ b/Examples/MAX32520/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32520/SPI_MasterSlave/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/TMR/Makefile
+++ b/Examples/MAX32520/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/TRNG/Makefile
+++ b/Examples/MAX32520/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32520/Watchdog/Makefile
+++ b/Examples/MAX32520/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ADC/Makefile
+++ b/Examples/MAX32650/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ADC_MAX11261/Makefile
+++ b/Examples/MAX32650/ADC_MAX11261/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/AES/Makefile
+++ b/Examples/MAX32650/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32650/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/CLCD/Makefile
+++ b/Examples/MAX32650/CLCD/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/CRC/Makefile
+++ b/Examples/MAX32650/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Coremark/Makefile
+++ b/Examples/MAX32650/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/DES/Makefile
+++ b/Examples/MAX32650/DES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/DMA/Makefile
+++ b/Examples/MAX32650/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32650/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/EMCC/Makefile
+++ b/Examples/MAX32650/EMCC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Flash/Makefile
+++ b/Examples/MAX32650/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Flash_CLI/Makefile
+++ b/Examples/MAX32650/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32650/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/GPIO/Makefile
+++ b/Examples/MAX32650/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/HBMC/Makefile
+++ b/Examples/MAX32650/HBMC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Hello_World/Makefile
+++ b/Examples/MAX32650/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/I2C/Makefile
+++ b/Examples/MAX32650/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/I2C_MNGR/Makefile
+++ b/Examples/MAX32650/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/I2C_SCAN/Makefile
+++ b/Examples/MAX32650/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/I2C_Sensor/Makefile
+++ b/Examples/MAX32650/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/I2S/Makefile
+++ b/Examples/MAX32650/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/ICC/Makefile
+++ b/Examples/MAX32650/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/LP/Makefile
+++ b/Examples/MAX32650/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Library_Generate/Makefile
+++ b/Examples/MAX32650/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Library_Use/Makefile
+++ b/Examples/MAX32650/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/MAA/Makefile
+++ b/Examples/MAX32650/MAA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/OTP_Dump/Makefile
+++ b/Examples/MAX32650/OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/OWM/Makefile
+++ b/Examples/MAX32650/OWM/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Pulse_Train/Makefile
+++ b/Examples/MAX32650/Pulse_Train/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/RTC/Makefile
+++ b/Examples/MAX32650/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/RTC_Backup/Makefile
+++ b/Examples/MAX32650/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32650/SCPA_OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SDHC_FAT/Makefile
+++ b/Examples/MAX32650/SDHC_FAT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SDHC_Raw/Makefile
+++ b/Examples/MAX32650/SDHC_Raw/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SPI/Makefile
+++ b/Examples/MAX32650/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SPIMSS/Makefile
+++ b/Examples/MAX32650/SPIMSS/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SPIXF/Makefile
+++ b/Examples/MAX32650/SPIXF/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SPIXF_ICC/Makefile
+++ b/Examples/MAX32650/SPIXF_ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SPIXR/Makefile
+++ b/Examples/MAX32650/SPIXR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32650/SPI_MasterSlave/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Semaphore/Makefile
+++ b/Examples/MAX32650/Semaphore/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/SysTick/Makefile
+++ b/Examples/MAX32650/SysTick/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/TMR/Makefile
+++ b/Examples/MAX32650/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/TRNG/Makefile
+++ b/Examples/MAX32650/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Temp_Monitor/Makefile
+++ b/Examples/MAX32650/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/UART/Makefile
+++ b/Examples/MAX32650/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/USB_CDCACM/Makefile
+++ b/Examples/MAX32650/USB_CDCACM/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX32650/USB_CompositeDevice_MSC_CDC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX32650/USB_CompositeDevice_MSC_HID/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX32650/USB_HIDKeyboard/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/USB_MassStorage/Makefile
+++ b/Examples/MAX32650/USB_MassStorage/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/Watchdog/Makefile
+++ b/Examples/MAX32650/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32650/WearLeveling/Makefile
+++ b/Examples/MAX32650/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ADC/Makefile
+++ b/Examples/MAX32655/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/AES/Makefile
+++ b/Examples/MAX32655/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32655/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE4_ctr/Makefile
+++ b/Examples/MAX32655/BLE4_ctr/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE5_ctr/Makefile
+++ b/Examples/MAX32655/BLE5_ctr/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_FreeRTOS/Makefile
+++ b/Examples/MAX32655/BLE_FreeRTOS/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_datc/Makefile
+++ b/Examples/MAX32655/BLE_datc/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_dats/Makefile
+++ b/Examples/MAX32655/BLE_dats/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_fcc/Makefile
+++ b/Examples/MAX32655/BLE_fcc/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_fit/Makefile
+++ b/Examples/MAX32655/BLE_fit/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_fit_FreeRTOS/Makefile
+++ b/Examples/MAX32655/BLE_fit_FreeRTOS/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_mcs/Makefile
+++ b/Examples/MAX32655/BLE_mcs/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_otac/Makefile
+++ b/Examples/MAX32655/BLE_otac/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_otas/Makefile
+++ b/Examples/MAX32655/BLE_otas/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/BLE_periph/Makefile
+++ b/Examples/MAX32655/BLE_periph/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Bootloader/Makefile
+++ b/Examples/MAX32655/Bootloader/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/CRC/Makefile
+++ b/Examples/MAX32655/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Coremark/Makefile
+++ b/Examples/MAX32655/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/DMA/Makefile
+++ b/Examples/MAX32655/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/Makefile
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/Makefile
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32655/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/External_Flash/Makefile
+++ b/Examples/MAX32655/External_Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/FTHR_I2C/Makefile
+++ b/Examples/MAX32655/FTHR_I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Flash/Makefile
+++ b/Examples/MAX32655/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Flash_CLI/Makefile
+++ b/Examples/MAX32655/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32655/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/GPIO/Makefile
+++ b/Examples/MAX32655/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Hello_World/Makefile
+++ b/Examples/MAX32655/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/I2C/Makefile
+++ b/Examples/MAX32655/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/I2C_MNGR/Makefile
+++ b/Examples/MAX32655/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/I2C_SCAN/Makefile
+++ b/Examples/MAX32655/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/I2C_Sensor/Makefile
+++ b/Examples/MAX32655/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/I2S/Makefile
+++ b/Examples/MAX32655/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/I2S_Playback/Makefile
+++ b/Examples/MAX32655/I2S_Playback/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/ICC/Makefile
+++ b/Examples/MAX32655/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/LP/Makefile
+++ b/Examples/MAX32655/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/LPCMP/Makefile
+++ b/Examples/MAX32655/LPCMP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Library_Generate/Makefile
+++ b/Examples/MAX32655/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Library_Use/Makefile
+++ b/Examples/MAX32655/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Pulse_Train/Makefile
+++ b/Examples/MAX32655/Pulse_Train/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/RF_Test/Makefile
+++ b/Examples/MAX32655/RF_Test/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/RTC/Makefile
+++ b/Examples/MAX32655/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/RTC_Backup/Makefile
+++ b/Examples/MAX32655/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/SPI/Makefile
+++ b/Examples/MAX32655/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/TFT_Demo/Makefile
+++ b/Examples/MAX32655/TFT_Demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/TMR/Makefile
+++ b/Examples/MAX32655/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/TRNG/Makefile
+++ b/Examples/MAX32655/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Temp_Monitor/Makefile
+++ b/Examples/MAX32655/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/UART/Makefile
+++ b/Examples/MAX32655/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/WUT/Makefile
+++ b/Examples/MAX32655/WUT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/Watchdog/Makefile
+++ b/Examples/MAX32655/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32655/WearLeveling/Makefile
+++ b/Examples/MAX32655/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32660/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Bootloader_Host/Makefile
+++ b/Examples/MAX32660/Bootloader_Host/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Coremark/Makefile
+++ b/Examples/MAX32660/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/DMA/Makefile
+++ b/Examples/MAX32660/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32660/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Flash/Makefile
+++ b/Examples/MAX32660/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Flash_CLI/Makefile
+++ b/Examples/MAX32660/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32660/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/GPIO/Makefile
+++ b/Examples/MAX32660/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Hello_World/Makefile
+++ b/Examples/MAX32660/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/I2C/Makefile
+++ b/Examples/MAX32660/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/I2C_MNGR/Makefile
+++ b/Examples/MAX32660/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/I2C_SCAN/Makefile
+++ b/Examples/MAX32660/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/I2C_Sensor/Makefile
+++ b/Examples/MAX32660/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/I2S/Makefile
+++ b/Examples/MAX32660/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/ICC/Makefile
+++ b/Examples/MAX32660/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Info_Block_Usecase/Makefile
+++ b/Examples/MAX32660/Info_Block_Usecase/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/LP/Makefile
+++ b/Examples/MAX32660/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Library_Generate/Makefile
+++ b/Examples/MAX32660/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Library_Use/Makefile
+++ b/Examples/MAX32660/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/RTC/Makefile
+++ b/Examples/MAX32660/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/RTC_Backup/Makefile
+++ b/Examples/MAX32660/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/SPI/Makefile
+++ b/Examples/MAX32660/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/SPIMSS/Makefile
+++ b/Examples/MAX32660/SPIMSS/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32660/SPI_MasterSlave/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/SecureROM_BL_Host/Makefile
+++ b/Examples/MAX32660/SecureROM_BL_Host/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/TMR/Makefile
+++ b/Examples/MAX32660/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Temp_Monitor/Makefile
+++ b/Examples/MAX32660/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/UART/Makefile
+++ b/Examples/MAX32660/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/UART_Wakeup/Makefile
+++ b/Examples/MAX32660/UART_Wakeup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/Watchdog/Makefile
+++ b/Examples/MAX32660/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32660/WearLeveling/Makefile
+++ b/Examples/MAX32660/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ADC/Makefile
+++ b/Examples/MAX32662/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32662/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Bootloader_Host/Makefile
+++ b/Examples/MAX32662/Bootloader_Host/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/CAN/Makefile
+++ b/Examples/MAX32662/CAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Coremark/Makefile
+++ b/Examples/MAX32662/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/DMA/Makefile
+++ b/Examples/MAX32662/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Demo/Makefile
+++ b/Examples/MAX32662/Demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32662/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Flash/Makefile
+++ b/Examples/MAX32662/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Flash_CLI/Makefile
+++ b/Examples/MAX32662/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/GPIO/Makefile
+++ b/Examples/MAX32662/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Hello_World/Makefile
+++ b/Examples/MAX32662/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/I2C/Makefile
+++ b/Examples/MAX32662/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/I2C_MNGR/Makefile
+++ b/Examples/MAX32662/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/I2C_SCAN/Makefile
+++ b/Examples/MAX32662/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/I2C_Sensor/Makefile
+++ b/Examples/MAX32662/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/I2S/Makefile
+++ b/Examples/MAX32662/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/ICC/Makefile
+++ b/Examples/MAX32662/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Info_Block_Usecase/Makefile
+++ b/Examples/MAX32662/Info_Block_Usecase/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/LP/Makefile
+++ b/Examples/MAX32662/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Library_Generate/Makefile
+++ b/Examples/MAX32662/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Library_Use/Makefile
+++ b/Examples/MAX32662/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/RTC/Makefile
+++ b/Examples/MAX32662/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/RTC_Backup/Makefile
+++ b/Examples/MAX32662/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32662/SCPA_OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/SPI/Makefile
+++ b/Examples/MAX32662/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32662/SPI_MasterSlave/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/TMR/Makefile
+++ b/Examples/MAX32662/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Temp_Monitor/Makefile
+++ b/Examples/MAX32662/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/UART/Makefile
+++ b/Examples/MAX32662/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/UART_Wakeup/Makefile
+++ b/Examples/MAX32662/UART_Wakeup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/Watchdog/Makefile
+++ b/Examples/MAX32662/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32662/WearLeveling/Makefile
+++ b/Examples/MAX32662/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ADC/Makefile
+++ b/Examples/MAX32665/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/AES/Makefile
+++ b/Examples/MAX32665/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32665/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE4_ctr/Makefile
+++ b/Examples/MAX32665/BLE4_ctr/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE5_ctr/Makefile
+++ b/Examples/MAX32665/BLE5_ctr/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_FreeRTOS/Makefile
+++ b/Examples/MAX32665/BLE_FreeRTOS/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_datc/Makefile
+++ b/Examples/MAX32665/BLE_datc/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_dats/Makefile
+++ b/Examples/MAX32665/BLE_dats/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_fcc/Makefile
+++ b/Examples/MAX32665/BLE_fcc/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_fit/Makefile
+++ b/Examples/MAX32665/BLE_fit/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_mcs/Makefile
+++ b/Examples/MAX32665/BLE_mcs/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_otac/Makefile
+++ b/Examples/MAX32665/BLE_otac/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_otas/Makefile
+++ b/Examples/MAX32665/BLE_otas/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/BLE_periph/Makefile
+++ b/Examples/MAX32665/BLE_periph/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Bootloader/Makefile
+++ b/Examples/MAX32665/Bootloader/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Bootloader_Host/Makefile
+++ b/Examples/MAX32665/Bootloader_Host/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/CRC/Makefile
+++ b/Examples/MAX32665/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Coremark/Makefile
+++ b/Examples/MAX32665/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/DES/Makefile
+++ b/Examples/MAX32665/DES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/DMA/Makefile
+++ b/Examples/MAX32665/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Demo/Makefile
+++ b/Examples/MAX32665/Demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Display/Makefile
+++ b/Examples/MAX32665/Display/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ECC/Makefile
+++ b/Examples/MAX32665/ECC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32665/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Flash/Makefile
+++ b/Examples/MAX32665/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Flash_CLI/Makefile
+++ b/Examples/MAX32665/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32665/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/GPIO/Makefile
+++ b/Examples/MAX32665/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/HTMR/Makefile
+++ b/Examples/MAX32665/HTMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Hash/Makefile
+++ b/Examples/MAX32665/Hash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Hello_World/Makefile
+++ b/Examples/MAX32665/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/I2C/Makefile
+++ b/Examples/MAX32665/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/I2C_MNGR/Makefile
+++ b/Examples/MAX32665/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/I2C_SCAN/Makefile
+++ b/Examples/MAX32665/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/I2C_Sensor/Makefile
+++ b/Examples/MAX32665/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/ICC/Makefile
+++ b/Examples/MAX32665/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/LP/Makefile
+++ b/Examples/MAX32665/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Library_Generate/Makefile
+++ b/Examples/MAX32665/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Library_Use/Makefile
+++ b/Examples/MAX32665/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/MAA/Makefile
+++ b/Examples/MAX32665/MAA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/OTP_Dump/Makefile
+++ b/Examples/MAX32665/OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/OWM/Makefile
+++ b/Examples/MAX32665/OWM/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Pulse_Train/Makefile
+++ b/Examples/MAX32665/Pulse_Train/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/RF_Test/Makefile
+++ b/Examples/MAX32665/RF_Test/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/RPU/Makefile
+++ b/Examples/MAX32665/RPU/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/RTC/Makefile
+++ b/Examples/MAX32665/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/RTC_Backup/Makefile
+++ b/Examples/MAX32665/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32665/SCPA_OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/SDHC_FAT/Makefile
+++ b/Examples/MAX32665/SDHC_FAT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/SDHC_Raw/Makefile
+++ b/Examples/MAX32665/SDHC_Raw/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/SPI/Makefile
+++ b/Examples/MAX32665/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/SPIXF/Makefile
+++ b/Examples/MAX32665/SPIXF/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/SPIXF_SFCC/Makefile
+++ b/Examples/MAX32665/SPIXF_SFCC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/SPIXR/Makefile
+++ b/Examples/MAX32665/SPIXR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/SRCC/Makefile
+++ b/Examples/MAX32665/SRCC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Semaphore/Makefile
+++ b/Examples/MAX32665/Semaphore/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/TMR/Makefile
+++ b/Examples/MAX32665/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/TRNG/Makefile
+++ b/Examples/MAX32665/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Temp_Monitor/Makefile
+++ b/Examples/MAX32665/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/UART/Makefile
+++ b/Examples/MAX32665/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/USB_CDCACM/Makefile
+++ b/Examples/MAX32665/USB_CDCACM/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX32665/USB_CompositeDevice_MSC_CDC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX32665/USB_CompositeDevice_MSC_HID/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX32665/USB_HIDKeyboard/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/USB_MassStorage/Makefile
+++ b/Examples/MAX32665/USB_MassStorage/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/WUT/Makefile
+++ b/Examples/MAX32665/WUT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/Watchdog/Makefile
+++ b/Examples/MAX32665/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32665/WearLeveling/Makefile
+++ b/Examples/MAX32665/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/AES/Makefile
+++ b/Examples/MAX32670/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32670/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/CRC/Makefile
+++ b/Examples/MAX32670/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/Coremark/Makefile
+++ b/Examples/MAX32670/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/DMA/Makefile
+++ b/Examples/MAX32670/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32670/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/EXT_CLK/Makefile
+++ b/Examples/MAX32670/EXT_CLK/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/Flash/Makefile
+++ b/Examples/MAX32670/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/Flash_CLI/Makefile
+++ b/Examples/MAX32670/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32670/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/GPIO/Makefile
+++ b/Examples/MAX32670/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/Hello_World/Makefile
+++ b/Examples/MAX32670/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/I2C/Makefile
+++ b/Examples/MAX32670/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/I2C_MNGR/Makefile
+++ b/Examples/MAX32670/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/I2C_SCAN/Makefile
+++ b/Examples/MAX32670/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/I2C_Sensor/Makefile
+++ b/Examples/MAX32670/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/I2S/Makefile
+++ b/Examples/MAX32670/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/ICC/Makefile
+++ b/Examples/MAX32670/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/LP/Makefile
+++ b/Examples/MAX32670/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/Library_Generate/Makefile
+++ b/Examples/MAX32670/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/Library_Use/Makefile
+++ b/Examples/MAX32670/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/RTC/Makefile
+++ b/Examples/MAX32670/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/RTC_Backup/Makefile
+++ b/Examples/MAX32670/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/SPI/Makefile
+++ b/Examples/MAX32670/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32670/SPI_MasterSlave/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/SPI_Usecase/Makefile
+++ b/Examples/MAX32670/SPI_Usecase/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/SecureROM_BL_Host/Makefile
+++ b/Examples/MAX32670/SecureROM_BL_Host/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/TMR/Makefile
+++ b/Examples/MAX32670/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/TRNG/Makefile
+++ b/Examples/MAX32670/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/Temp_Monitor/Makefile
+++ b/Examples/MAX32670/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/UART/Makefile
+++ b/Examples/MAX32670/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/Watchdog/Makefile
+++ b/Examples/MAX32670/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32670/WearLeveling/Makefile
+++ b/Examples/MAX32670/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ADC/Makefile
+++ b/Examples/MAX32672/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/AES/Makefile
+++ b/Examples/MAX32672/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32672/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/CRC/Makefile
+++ b/Examples/MAX32672/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/CTB_AES/Makefile
+++ b/Examples/MAX32672/CTB_AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Comparator/Makefile
+++ b/Examples/MAX32672/Comparator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Coremark/Makefile
+++ b/Examples/MAX32672/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/DMA/Makefile
+++ b/Examples/MAX32672/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Demo/Makefile
+++ b/Examples/MAX32672/Demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Display/Makefile
+++ b/Examples/MAX32672/Display/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32672/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Flash/Makefile
+++ b/Examples/MAX32672/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Flash_CLI/Makefile
+++ b/Examples/MAX32672/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32672/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/GPIO/Makefile
+++ b/Examples/MAX32672/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Hello_World/Makefile
+++ b/Examples/MAX32672/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/I2C/Makefile
+++ b/Examples/MAX32672/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/I2C_MNGR/Makefile
+++ b/Examples/MAX32672/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/I2C_SCAN/Makefile
+++ b/Examples/MAX32672/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/I2C_Sensor/Makefile
+++ b/Examples/MAX32672/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/I2S/Makefile
+++ b/Examples/MAX32672/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/ICC/Makefile
+++ b/Examples/MAX32672/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/LP/Makefile
+++ b/Examples/MAX32672/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Library_Generate/Makefile
+++ b/Examples/MAX32672/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Library_Use/Makefile
+++ b/Examples/MAX32672/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/OLED_Demo/Makefile
+++ b/Examples/MAX32672/OLED_Demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/QDEC/Makefile
+++ b/Examples/MAX32672/QDEC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/RTC/Makefile
+++ b/Examples/MAX32672/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/RTC_Backup/Makefile
+++ b/Examples/MAX32672/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32672/SCPA_OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/SPI/Makefile
+++ b/Examples/MAX32672/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/SPI_MasterSlave/Makefile
+++ b/Examples/MAX32672/SPI_MasterSlave/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/TMR/Makefile
+++ b/Examples/MAX32672/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/TRNG/Makefile
+++ b/Examples/MAX32672/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Temp_Monitor/Makefile
+++ b/Examples/MAX32672/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/UART/Makefile
+++ b/Examples/MAX32672/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/Watchdog/Makefile
+++ b/Examples/MAX32672/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32672/WearLeveling/Makefile
+++ b/Examples/MAX32672/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ADC/Makefile
+++ b/Examples/MAX32675/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/AES/Makefile
+++ b/Examples/MAX32675/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/AFE_DAC/Makefile
+++ b/Examples/MAX32675/AFE_DAC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32675/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/CRC/Makefile
+++ b/Examples/MAX32675/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/Coremark/Makefile
+++ b/Examples/MAX32675/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/DMA/Makefile
+++ b/Examples/MAX32675/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32675/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/Flash/Makefile
+++ b/Examples/MAX32675/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/Flash_CLI/Makefile
+++ b/Examples/MAX32675/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32675/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/GPIO/Makefile
+++ b/Examples/MAX32675/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/HART_UART/Makefile
+++ b/Examples/MAX32675/HART_UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/Hello_World/Makefile
+++ b/Examples/MAX32675/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/I2C/Makefile
+++ b/Examples/MAX32675/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/I2C_MNGR/Makefile
+++ b/Examples/MAX32675/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/I2C_SCAN/Makefile
+++ b/Examples/MAX32675/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/I2C_Sensor/Makefile
+++ b/Examples/MAX32675/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/I2S/Makefile
+++ b/Examples/MAX32675/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/ICC/Makefile
+++ b/Examples/MAX32675/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/LP/Makefile
+++ b/Examples/MAX32675/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/Library_Generate/Makefile
+++ b/Examples/MAX32675/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/Library_Use/Makefile
+++ b/Examples/MAX32675/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/SPI/Makefile
+++ b/Examples/MAX32675/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/TMR/Makefile
+++ b/Examples/MAX32675/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/TRNG/Makefile
+++ b/Examples/MAX32675/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/UART/Makefile
+++ b/Examples/MAX32675/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/Watchdog/Makefile
+++ b/Examples/MAX32675/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32675/WearLeveling/Makefile
+++ b/Examples/MAX32675/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ADC/Makefile
+++ b/Examples/MAX32680/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/AES/Makefile
+++ b/Examples/MAX32680/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/AFE_ADC/Makefile
+++ b/Examples/MAX32680/AFE_ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32680/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/BLE4_ctr/Makefile
+++ b/Examples/MAX32680/BLE4_ctr/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/BLE_dats/Makefile
+++ b/Examples/MAX32680/BLE_dats/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/CRC/Makefile
+++ b/Examples/MAX32680/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Coremark/Makefile
+++ b/Examples/MAX32680/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/DMA/Makefile
+++ b/Examples/MAX32680/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32680/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Flash/Makefile
+++ b/Examples/MAX32680/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Flash_CLI/Makefile
+++ b/Examples/MAX32680/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32680/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/GPIO/Makefile
+++ b/Examples/MAX32680/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/HART_UART/Makefile
+++ b/Examples/MAX32680/HART_UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Hello_World/Makefile
+++ b/Examples/MAX32680/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/I2C/Makefile
+++ b/Examples/MAX32680/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/I2C_MNGR/Makefile
+++ b/Examples/MAX32680/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/I2C_SCAN/Makefile
+++ b/Examples/MAX32680/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/I2C_Sensor/Makefile
+++ b/Examples/MAX32680/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/I2S/Makefile
+++ b/Examples/MAX32680/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/ICC/Makefile
+++ b/Examples/MAX32680/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/LP/Makefile
+++ b/Examples/MAX32680/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Library_Generate/Makefile
+++ b/Examples/MAX32680/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Library_Use/Makefile
+++ b/Examples/MAX32680/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Pulse_Train/Makefile
+++ b/Examples/MAX32680/Pulse_Train/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/SPI/Makefile
+++ b/Examples/MAX32680/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/TMR/Makefile
+++ b/Examples/MAX32680/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/TRNG/Makefile
+++ b/Examples/MAX32680/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Temp_Monitor/Makefile
+++ b/Examples/MAX32680/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/UART/Makefile
+++ b/Examples/MAX32680/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/WUT/Makefile
+++ b/Examples/MAX32680/WUT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/Watchdog/Makefile
+++ b/Examples/MAX32680/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32680/WearLeveling/Makefile
+++ b/Examples/MAX32680/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ADC/Makefile
+++ b/Examples/MAX32690/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX32690/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE4_ctr/Makefile
+++ b/Examples/MAX32690/BLE4_ctr/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE5_ctr/Makefile
+++ b/Examples/MAX32690/BLE5_ctr/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_FreeRTOS/Makefile
+++ b/Examples/MAX32690/BLE_FreeRTOS/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_datc/Makefile
+++ b/Examples/MAX32690/BLE_datc/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_dats/Makefile
+++ b/Examples/MAX32690/BLE_dats/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_fcc/Makefile
+++ b/Examples/MAX32690/BLE_fcc/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_fit/Makefile
+++ b/Examples/MAX32690/BLE_fit/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_mcs/Makefile
+++ b/Examples/MAX32690/BLE_mcs/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_otac/Makefile
+++ b/Examples/MAX32690/BLE_otac/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_otas/Makefile
+++ b/Examples/MAX32690/BLE_otas/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/BLE_periph/Makefile
+++ b/Examples/MAX32690/BLE_periph/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Bootloader/Makefile
+++ b/Examples/MAX32690/Bootloader/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/CAN/Makefile
+++ b/Examples/MAX32690/CAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/CRC/Makefile
+++ b/Examples/MAX32690/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/CTB_AES/Makefile
+++ b/Examples/MAX32690/CTB_AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Coremark/Makefile
+++ b/Examples/MAX32690/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/DMA/Makefile
+++ b/Examples/MAX32690/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/EEPROM_Emulator/Makefile
+++ b/Examples/MAX32690/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Flash/Makefile
+++ b/Examples/MAX32690/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Flash_CLI/Makefile
+++ b/Examples/MAX32690/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/FreeRTOSDemo/Makefile
+++ b/Examples/MAX32690/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/GPIO/Makefile
+++ b/Examples/MAX32690/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/HBMC/Makefile
+++ b/Examples/MAX32690/HBMC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Hash/Makefile
+++ b/Examples/MAX32690/Hash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Hello_World/Makefile
+++ b/Examples/MAX32690/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/I2C/Makefile
+++ b/Examples/MAX32690/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/I2C_MNGR/Makefile
+++ b/Examples/MAX32690/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/I2C_SCAN/Makefile
+++ b/Examples/MAX32690/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/I2C_Sensor/Makefile
+++ b/Examples/MAX32690/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/I2S/Makefile
+++ b/Examples/MAX32690/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/ICC/Makefile
+++ b/Examples/MAX32690/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/LP/Makefile
+++ b/Examples/MAX32690/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/LPCMP/Makefile
+++ b/Examples/MAX32690/LPCMP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Library_Generate/Makefile
+++ b/Examples/MAX32690/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Library_Use/Makefile
+++ b/Examples/MAX32690/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Pulse_Train/Makefile
+++ b/Examples/MAX32690/Pulse_Train/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/RF_Test/Makefile
+++ b/Examples/MAX32690/RF_Test/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/RTC/Makefile
+++ b/Examples/MAX32690/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/RTC_Backup/Makefile
+++ b/Examples/MAX32690/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/SCPA_OTP_Dump/Makefile
+++ b/Examples/MAX32690/SCPA_OTP_Dump/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/SPI/Makefile
+++ b/Examples/MAX32690/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/TFT_Demo/Makefile
+++ b/Examples/MAX32690/TFT_Demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/TMR/Makefile
+++ b/Examples/MAX32690/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/TRNG/Makefile
+++ b/Examples/MAX32690/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Temp_Monitor/Makefile
+++ b/Examples/MAX32690/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/UART/Makefile
+++ b/Examples/MAX32690/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/USB_CDCACM/Makefile
+++ b/Examples/MAX32690/USB_CDCACM/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX32690/USB_CompositeDevice_MSC_CDC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX32690/USB_CompositeDevice_MSC_HID/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX32690/USB_HIDKeyboard/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/USB_MassStorage/Makefile
+++ b/Examples/MAX32690/USB_MassStorage/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/WUT/Makefile
+++ b/Examples/MAX32690/WUT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/Watchdog/Makefile
+++ b/Examples/MAX32690/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX32690/WearLeveling/Makefile
+++ b/Examples/MAX32690/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ADC/Makefile
+++ b/Examples/MAX78000/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/AES/Makefile
+++ b/Examples/MAX78000/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/UNet-demo/Makefile
+++ b/Examples/MAX78000/CNN/UNet-demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/UNet-highres-demo/Makefile
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/Makefile
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/aisegment_unet/Makefile
+++ b/Examples/MAX78000/CNN/aisegment_unet/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/asl/Makefile
+++ b/Examples/MAX78000/CNN/asl/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/asl_demo/Makefile
+++ b/Examples/MAX78000/CNN/asl_demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/camvid_unet/Makefile
+++ b/Examples/MAX78000/CNN/camvid_unet/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/cats-dogs/Makefile
+++ b/Examples/MAX78000/CNN/cats-dogs/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/cats-dogs_demo/Makefile
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/Makefile
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/cifar-10/Makefile
+++ b/Examples/MAX78000/CNN/cifar-10/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/cifar-100-mixed/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/cifar-100-residual/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-residual/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/cifar-100/Makefile
+++ b/Examples/MAX78000/CNN/cifar-100/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/digit-detection-demo/Makefile
+++ b/Examples/MAX78000/CNN/digit-detection-demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/faceid/Makefile
+++ b/Examples/MAX78000/CNN/faceid/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/faceid_demo/Makefile
+++ b/Examples/MAX78000/CNN/faceid_demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/faceid_evkit/Makefile
+++ b/Examples/MAX78000/CNN/faceid_evkit/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/kws20_demo/Makefile
+++ b/Examples/MAX78000/CNN/kws20_demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/kws20_v3/Makefile
+++ b/Examples/MAX78000/CNN/kws20_v3/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/mnist/Makefile
+++ b/Examples/MAX78000/CNN/mnist/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/rps-demo/Makefile
+++ b/Examples/MAX78000/CNN/rps-demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/rps/Makefile
+++ b/Examples/MAX78000/CNN/rps/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/snake_game_demo/Makefile
+++ b/Examples/MAX78000/CNN/snake_game_demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CNN/svhn_tinierssd/Makefile
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CRC/Makefile
+++ b/Examples/MAX78000/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CameraIF/Makefile
+++ b/Examples/MAX78000/CameraIF/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/CameraIF_Debayer/Makefile
+++ b/Examples/MAX78000/CameraIF_Debayer/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Coremark/Makefile
+++ b/Examples/MAX78000/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/DMA/Makefile
+++ b/Examples/MAX78000/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ECC/Makefile
+++ b/Examples/MAX78000/ECC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/EEPROM_Emulator/Makefile
+++ b/Examples/MAX78000/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/FTHR_I2C/Makefile
+++ b/Examples/MAX78000/FTHR_I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Flash/Makefile
+++ b/Examples/MAX78000/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Flash_CLI/Makefile
+++ b/Examples/MAX78000/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/FreeRTOSDemo/Makefile
+++ b/Examples/MAX78000/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/GPIO/Makefile
+++ b/Examples/MAX78000/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Hello_World/Makefile
+++ b/Examples/MAX78000/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/I2C_ADXL343/Makefile
+++ b/Examples/MAX78000/I2C_ADXL343/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/I2C_MNGR/Makefile
+++ b/Examples/MAX78000/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/I2C_SCAN/Makefile
+++ b/Examples/MAX78000/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/I2C_Sensor/Makefile
+++ b/Examples/MAX78000/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/I2S/Makefile
+++ b/Examples/MAX78000/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/I2S_DMA/Makefile
+++ b/Examples/MAX78000/I2S_DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/I2S_DMA_Target/Makefile
+++ b/Examples/MAX78000/I2S_DMA_Target/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ICC/Makefile
+++ b/Examples/MAX78000/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/ImgCapture/Makefile
+++ b/Examples/MAX78000/ImgCapture/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/LP/Makefile
+++ b/Examples/MAX78000/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/LPCMP/Makefile
+++ b/Examples/MAX78000/LPCMP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Library_Generate/Makefile
+++ b/Examples/MAX78000/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Library_Use/Makefile
+++ b/Examples/MAX78000/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Pulse_Train/Makefile
+++ b/Examples/MAX78000/Pulse_Train/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/RTC/Makefile
+++ b/Examples/MAX78000/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/RTC_Backup/Makefile
+++ b/Examples/MAX78000/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/SDHC_FTHR/Makefile
+++ b/Examples/MAX78000/SDHC_FTHR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/SPI/Makefile
+++ b/Examples/MAX78000/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/TFT_Demo/Makefile
+++ b/Examples/MAX78000/TFT_Demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/TMR/Makefile
+++ b/Examples/MAX78000/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/TRNG/Makefile
+++ b/Examples/MAX78000/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Temp_Monitor/Makefile
+++ b/Examples/MAX78000/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/UART/Makefile
+++ b/Examples/MAX78000/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/WUT/Makefile
+++ b/Examples/MAX78000/WUT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/Watchdog/Makefile
+++ b/Examples/MAX78000/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78000/WearLeveling/Makefile
+++ b/Examples/MAX78000/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ADC/Makefile
+++ b/Examples/MAX78002/ADC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/AES/Makefile
+++ b/Examples/MAX78002/AES/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/Makefile
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/Makefile
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CNN/faceid/Makefile
+++ b/Examples/MAX78002/CNN/faceid/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CNN/faceid_evkit/Makefile
+++ b/Examples/MAX78002/CNN/faceid_evkit/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CNN/imagenet/Makefile
+++ b/Examples/MAX78002/CNN/imagenet/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CNN/kws20_demo/Makefile
+++ b/Examples/MAX78002/CNN/kws20_demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CRC/Makefile
+++ b/Examples/MAX78002/CRC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CSI2/Makefile
+++ b/Examples/MAX78002/CSI2/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CameraIF/Makefile
+++ b/Examples/MAX78002/CameraIF/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/CameraIF_Debayer/Makefile
+++ b/Examples/MAX78002/CameraIF_Debayer/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Coremark/Makefile
+++ b/Examples/MAX78002/Coremark/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/DMA/Makefile
+++ b/Examples/MAX78002/DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ECC/Makefile
+++ b/Examples/MAX78002/ECC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/EEPROM_Emulator/Makefile
+++ b/Examples/MAX78002/EEPROM_Emulator/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Flash/Makefile
+++ b/Examples/MAX78002/Flash/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Flash_CLI/Makefile
+++ b/Examples/MAX78002/Flash_CLI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/FreeRTOSDemo/Makefile
+++ b/Examples/MAX78002/FreeRTOSDemo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/GPIO/Makefile
+++ b/Examples/MAX78002/GPIO/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Hello_World/Makefile
+++ b/Examples/MAX78002/Hello_World/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/I2C/Makefile
+++ b/Examples/MAX78002/I2C/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/I2C_MNGR/Makefile
+++ b/Examples/MAX78002/I2C_MNGR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/I2C_SCAN/Makefile
+++ b/Examples/MAX78002/I2C_SCAN/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/I2C_Sensor/Makefile
+++ b/Examples/MAX78002/I2C_Sensor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/I2S/Makefile
+++ b/Examples/MAX78002/I2S/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/I2S_DMA/Makefile
+++ b/Examples/MAX78002/I2S_DMA/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ICC/Makefile
+++ b/Examples/MAX78002/ICC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/ImgCapture/Makefile
+++ b/Examples/MAX78002/ImgCapture/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/LP/Makefile
+++ b/Examples/MAX78002/LP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/LPCMP/Makefile
+++ b/Examples/MAX78002/LPCMP/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Library_Generate/Makefile
+++ b/Examples/MAX78002/Library_Generate/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Library_Use/Makefile
+++ b/Examples/MAX78002/Library_Use/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Pulse_Train/Makefile
+++ b/Examples/MAX78002/Pulse_Train/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/RTC/Makefile
+++ b/Examples/MAX78002/RTC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/RTC_Backup/Makefile
+++ b/Examples/MAX78002/RTC_Backup/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/SDHC_FAT/Makefile
+++ b/Examples/MAX78002/SDHC_FAT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/SDHC_Raw/Makefile
+++ b/Examples/MAX78002/SDHC_Raw/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/SPI/Makefile
+++ b/Examples/MAX78002/SPI/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/SPI_MasterSlave/Makefile
+++ b/Examples/MAX78002/SPI_MasterSlave/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/TFT_Demo/Makefile
+++ b/Examples/MAX78002/TFT_Demo/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/TMR/Makefile
+++ b/Examples/MAX78002/TMR/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/TRNG/Makefile
+++ b/Examples/MAX78002/TRNG/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Temp_Monitor/Makefile
+++ b/Examples/MAX78002/Temp_Monitor/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/UART/Makefile
+++ b/Examples/MAX78002/UART/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/USB_CDCACM/Makefile
+++ b/Examples/MAX78002/USB_CDCACM/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/Makefile
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_HID/Makefile
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_HID/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/USB_HIDKeyboard/Makefile
+++ b/Examples/MAX78002/USB_HIDKeyboard/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/USB_MassStorage/Makefile
+++ b/Examples/MAX78002/USB_MassStorage/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/USB_MassStorage_ThroughPut/Makefile
+++ b/Examples/MAX78002/USB_MassStorage_ThroughPut/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/WUT/Makefile
+++ b/Examples/MAX78002/WUT/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/Watchdog/Makefile
+++ b/Examples/MAX78002/Watchdog/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Examples/MAX78002/WearLeveling/Makefile
+++ b/Examples/MAX78002/WearLeveling/Makefile
@@ -252,22 +252,6 @@ MFLOAT_ABI ?= softfp
 # MFLOAT_ABI must be exported to other Makefiles
 export MFLOAT_ABI
 
-ifeq "$(RISCV_CORE)" ""
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-# Check if linkerfile exists
-ifeq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","")
-# Doesn't exists, attempt to use root project folder.
-LINKERPATH:=.
-endif
-
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE:=$(LINKERPATH)/$(LINKERFILE)
-endif
-
 # This path contains system-level intialization files for the target micro.  Add to the build.
 VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk
@@ -47,9 +47,26 @@ ifeq "$(STARTUPFILE)" ""
 STARTUPFILE=startup_$(TARGET_LC).S
 endif
 
-ifeq "$(LINKERFILE)" ""
-LINKERFILE=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/$(TARGET_LC).ld
-endif
+ifeq "$(RISCV_CORE)" "" # RISCV
+# Default linkerfile is only specified for standard Arm-core projects.
+# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
+LINKERFILE ?= $(TARGET_LC).ld
+LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+
+ifeq ("$(wildcard $(LINKERFILE))","") # Check if linkerfile exists
+# Doesn't exist...
+
+ifneq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","") # Search GCC folder
+$(info Auto-located linkerfile: $(LINKERPATH)/$(LINKERFILE))
+# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
+LINKERFILE := $(LINKERPATH)/$(LINKERFILE)
+else
+$(warning Failed to locate linkerfile: $(LINKERFILE))
+endif # End search GCC folder
+
+endif # End check if linkerfile exists
+
+endif # End RISCV
 
 ifeq "$(ENTRY)" ""
 ENTRY=Reset_Handler

--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk
@@ -47,26 +47,9 @@ ifeq "$(STARTUPFILE)" ""
 STARTUPFILE=startup_$(TARGET_LC).S
 endif
 
-ifeq "$(RISCV_CORE)" "" # RISCV
-# Default linkerfile is only specified for standard Arm-core projects.
-# Otherwise, gcc_riscv.mk sets the appropriate riscv linkerfile.
-LINKERFILE ?= $(TARGET_LC).ld
-LINKERPATH ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
-
-ifeq ("$(wildcard $(LINKERFILE))","") # Check if linkerfile exists
-# Doesn't exist...
-
-ifneq ("$(wildcard $(LINKERPATH)/$(LINKERFILE))","") # Search GCC folder
-$(info Auto-located linkerfile: $(LINKERPATH)/$(LINKERFILE))
-# Form full path to linkerfile.  Works around MSYS2 edge case from (see MSDK-903).
-LINKERFILE := $(LINKERPATH)/$(LINKERFILE)
-else
-$(warning Failed to locate linkerfile: $(LINKERFILE))
-endif # End search GCC folder
-
-endif # End check if linkerfile exists
-
-endif # End RISCV
+ifeq "$(LINKERFILE)" ""
+LINKERFILE=$(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/$(TARGET_LC).ld
+endif
 
 ifeq "$(ENTRY)" ""
 ENTRY=Reset_Handler

--- a/Tools/SBT/SBT-config.mk
+++ b/Tools/SBT/SBT-config.mk
@@ -48,8 +48,7 @@ SRCS += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/header_$(TARGET_UC).c
 # definitions and files.  Additionally, the linkerfile may need to be changed.
 ifeq ($(MAKECMDGOALS),sla)
 PROJ_CFLAGS += -D__SLA_FWK__
-LINKERFILE = $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/$(TARGET_LC)_sla.ld
-$(info Overriding LINKERFILE to $(LINKERFILE))
+LINKERFILE ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/$(TARGET_LC)_sla.ld
 endif
 
 ifeq ($(MAKECMDGOALS), scpa)
@@ -58,6 +57,5 @@ SCPA_MEM_SIZE ?= 1024
 
 PROJ_CFLAGS += -D__SCPA_FWK__
 PROJ_CFLAGS += -DSCPA_MEM_BASE_ADDR=$(SCPA_MEM_BASE_ADDR) -DSCPA_MEM_SIZE=$(SCPA_MEM_SIZE)
-LINKERFILE = $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/$(TARGET_LC)_scpa.ld
-$(info Overriding LINKERFILE to $(LINKERFILE))
+LINKERFILE ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/$(TARGET_LC)_scpa.ld
 endif

--- a/Tools/SBT/SBT-config.mk
+++ b/Tools/SBT/SBT-config.mk
@@ -51,7 +51,7 @@ PROJ_CFLAGS += -D__SLA_FWK__
 LINKERFILE ?= $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC/$(TARGET_LC)_sla.ld
 endif
 
-ifeq ($(MAKECMDGOALS), scpa)
+ifeq ($(MAKECMDGOALS),scpa)
 SCPA_MEM_BASE_ADDR ?= 0xC0000000
 SCPA_MEM_SIZE ?= 1024
 


### PR DESCRIPTION
This PR allows setting the `LINKERFILE` build config variable when SBT=1.

Ex:
```shell
 ~/repos/fork/msdk/Examples/MAX32520/Hello_World
❯ make LINKERFILE=max32520_ram.ld
Loaded project.mk
Auto-located linkerfile: /home/jakecarter/repos/fork/msdk/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520_ram.ld
arm-none-eabi-size --format=berkeley /home/jakecarter/repos/fork/msdk/Examples/MAX32520/Hello_World/build/max32520.elf
   text    data     bss     dec     hex filename
  34572    2580     372   37524    9294 /home/jakecarter/repos/fork/msdk/Examples/MAX32520/Hello_World/build/max32520.elf
```

Ex: (Trying to set a non-existent linkerfile)
```shell
 ~/repos/fork/msdk/Examples/MAX32520/Hello_World
❯ make LINKERFILE=myfile.ld
Loaded project.mk
/home/jakecarter/repos/fork/msdk/Libraries/CMSIS/Device/Maxim/MAX32520/Source/GCC/max32520.mk:64: Failed to locate linkerfile: myfile.ld
make: *** No rule to make target 'myfile.ld', needed by '/home/jakecarter/repos/fork/msdk/Examples/MAX32520/Hello_World/build/max32520.elf'.  Stop.
```

The changes have been applied to the Hello_World project for the MAX32520 for easier testing/review.  The same changes will be applied to all micros on approval.

- Move default `LINKERFILE` selection to part-specific makefile (ex: max32520.mk).
- Use `?=` in sbt-config.mk to allow user override

Resolves https://jira.maxim-ic.com/browse/MSDK-1100