### PR TITLE
MSDK-1167: Fix build issues

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/mxc_sys.h
@@ -133,7 +133,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32570/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/mxc_sys.h
@@ -246,7 +246,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32572/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/mxc_sys.h
@@ -200,7 +200,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32650/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/mxc_sys.h
@@ -248,7 +248,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
@@ -207,7 +207,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32660/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/mxc_sys.h
@@ -122,7 +122,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32662/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/mxc_sys.h
@@ -153,7 +153,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32665/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/mxc_sys.h
@@ -222,7 +222,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32670/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/mxc_sys.h
@@ -146,7 +146,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32672/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/mxc_sys.h
@@ -179,7 +179,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32675/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/mxc_sys.h
@@ -170,7 +170,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h
@@ -207,7 +207,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -225,7 +225,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX78000/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/mxc_sys.h
@@ -207,7 +207,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Include/MAX78002/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/mxc_sys.h
@@ -209,7 +209,7 @@ typedef struct {
     int in_critical;
 } mxc_crit_state_t;
 
-static mxc_crit_state_t _state = { .ie_status = 0xFFFFFFFF, .in_critical = 0 };
+static mxc_crit_state_t _state = { .ie_status = (int)0xFFFFFFFF, .in_critical = 0 };
 
 static inline void _mxc_crit_get_state()
 {

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -230,7 +230,7 @@ int MXC_UART_RevA_GetFrequency(mxc_uart_reva_regs_t *uart)
         decimalDiv += 3;
     }
 
-    uartDiv += decimalDiv / 128.0;
+    uartDiv += decimalDiv / (float)128;
     uartDiv *= (1 << (7 - (uart->baud0 & MXC_F_UART_REVA_BAUD0_FACTOR)));
 
     return (int)((float)periphClock / uartDiv);


### PR DESCRIPTION
This PR fix below issues:

#1

C:/MaximSDK/Libraries/PeriphDrivers/Include/MAX32650/mxc_sys.h:250:78: error: narrowing conversion of '4294967295' from 'unsigned int' to 'int' [-Wnarrowing]

#2

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/a22106c1-2c97-41e6-9b10-4bc34e239085)

