### PR TITLE
MSDK-1170: Add include guard for __weak

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Include/max32520.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Include/max32520.h
@@ -52,7 +52,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32570/Include/max32570.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32570/Include/max32570.h
@@ -55,7 +55,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Include/max32572.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Include/max32572.h
@@ -55,7 +55,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Include/max32650.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Include/max32650.h
@@ -55,7 +55,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.h
@@ -52,7 +52,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Include/max32660.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Include/max32660.h
@@ -60,7 +60,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__) /* GCC */
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM) /* Keil */
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.h
@@ -60,7 +60,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__) /* GCC */
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM) /* Keil */
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/max32665.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/max32665.h
@@ -58,7 +58,9 @@
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
 
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.h
@@ -52,7 +52,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
@@ -59,7 +59,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.h
@@ -52,7 +52,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.h
@@ -52,7 +52,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
@@ -52,7 +52,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.h
@@ -52,7 +52,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.h
@@ -52,7 +52,9 @@
 
 /* COMPILER SPECIFIC DEFINES (IAR, ARMCC and GNUC) */
 #if defined(__GNUC__)
+#ifndef __weak
 #define __weak __attribute__((weak))
+#endif
 
 #elif defined(__CC_ARM)
 


### PR DESCRIPTION
Some third party libraries/stack has __weak define.
While using SDK files with third party stack/libs, redefinition cases occurs.

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/a105b4cd-b1b1-407a-988e-7310d259d0e0)

