### PR TITLE
Removed wrong instruction

### DIFF
--- a/Examples/MAX32665/UART/README.md
+++ b/Examples/MAX32665/UART/README.md
@@ -18,7 +18,6 @@ Universal instructions on building, flashing, and debugging this project can be 
 -   Connect a USB cable between the PC and the CN2 (USB/PWR) connector.
 -   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
      - For EvKit
-        -   Connect the jumper (JP7) to UART0.
         -   Connect the jumper (JP9) to RX0 and the jumper (JP10) to TX1.
 -   Connect RX1 to TX0 with a wire.
 


### PR DESCRIPTION
Removed extra instruction from the UART example file.
"Connect the jumper (JP7) to UART0." 
