### PR TITLE
ME17 SPI pins on JH6 not JH7

### DIFF
--- a/Examples/MAX32655/SPI/README.md
+++ b/Examples/MAX32655/SPI/README.md
@@ -28,7 +28,7 @@ If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.
 -   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--   Connect pins labeled  5 and 6 on JH7 (GPIO PORT 0) together.
+-   Connect pins labeled  5 and 6 on JH6 (GPIO PORT 0) together.
 
 If using the Featherboard (FTHR\_Apps\_P1):
 -   Connect a USB cable between the PC and the J4 (USB/PWR) connector.


### PR DESCRIPTION
P0.5 and P0.6 are on JH6 not JH7 for ME17 EvKit REV A/B.