### PR TITLE
feat(workflow): Add new workflow to check for stale Pull Requests

### DIFF
--- a/.github/workflows/Stale_PR.yml
+++ b/.github/workflows/Stale_PR.yml
@@ -1,0 +1,43 @@
+name: Check for Stale Pull Requests
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Schedule workflow on timer
+on:
+  schedule:
+    # 'min hr day-of-month month day-of-week'
+    # Current schedule to run is: Every two hours of every day.
+    - cron: '0 0/2 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  MSDK_DIR: msdk
+  
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # Check for stale PRs
+  stale:
+    # The type of runner that the job will run on
+    runs-on: [ ubuntu-latest ]
+
+    steps:
+      - name: Checking for Stale Pull Requests
+        uses: actions/stale@v8
+        with:
+          # Issues won't get stale
+          days-before-issue-stale: -1
+
+          days-before-pr-stale: 30
+
+          days-before-pr-close: 7
+
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. Remove stale label, commit, or comment or this will be closed in 7 days.'
+
+          close-pr-message: 'This pull request was closed because it has been stalled for 7 dys with no activity.'
+
+          exempt-pr-labels: 'WIP'

--- a/.github/workflows/Stale_PR.yml
+++ b/.github/workflows/Stale_PR.yml
@@ -38,6 +38,9 @@ jobs:
 
           stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. Remove stale label, commit, or comment or this will be closed in 7 days.'
 
-          close-pr-message: 'This pull request was closed because it has been stalled for 7 dys with no activity.'
+          close-pr-message: 'This pull request was closed because it has been stalled for 7 days with no activity.'
 
           exempt-pr-labels: 'WIP'
+
+          # False is default option, but adding to be explicit.
+          delete-branch: false


### PR DESCRIPTION
This new workflow will keep track of open PRs, mark them as stale after 30 days of inactivity, and closes them 7 days after the PR was marked as stale. Inactivity usually means no comments, commits, reviews, or label changes for 30 days. When a PR becomes stale, the action will comment a warning message and add a stale label to the PR. 

If the PR has a new comment, commit, review, or label change, then the stale label will be automatically removed and the PR's 30-day active interval will be reset. If no activity was detected, then the action will comment the PR has been inactive for 7 days before closing the PR.

Stale settings:
- Runs every 2 hrs every day (could change interval if needed)
- 30 Days before PR is stale
- 7 Days before PR is closed after 30-day stale warning
- PRs with `WIP` Label are exempt from this check