### PR TITLE
refactor(PeriphDrivers): Update MXC_SYS_GetUSN to verify the checksum (and fix some minor bugs)

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32572/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/mxc_sys.h
@@ -193,8 +193,9 @@ typedef enum {
 #define MXC_SYS_SCACHE_CLK 1 // Enable SCACHE CLK
 #define MXC_SYS_CTB_CLK 1 // Enable CTB CLK
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32572/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/mxc_sys.h
@@ -193,6 +193,9 @@ typedef enum {
 #define MXC_SYS_SCACHE_CLK 1 // Enable SCACHE CLK
 #define MXC_SYS_CTB_CLK 1 // Enable CTB CLK
 
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
+
 /***** Function Prototypes *****/
 
 typedef struct {
@@ -368,12 +371,12 @@ void MXC_SYS_Reset_Periph(mxc_sys_reset_t reset);
 uint8_t MXC_SYS_GetRev(void);
 
 /**
- * @brief      Get the USN of the chip
- * @param      serialNumber buffer to store the USN
- * @param      len          length of the USN buffer
- * @returns    #E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
-int MXC_SYS_GetUSN(uint8_t *serialNumber, int len);
+int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 
 #ifdef __cplusplus
 }

--- a/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
@@ -198,7 +198,7 @@ typedef enum {
     MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
 } mxc_sys_system_clock_div_t;
 
-#define MXC_SYS_USN_LEN 16    
+#define MXC_SYS_USN_LEN 16
 #define MXC_SYS_USN_CHECKSUM_LEN 2
 
 /***** Function Prototypes *****/

--- a/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
@@ -198,8 +198,9 @@ typedef enum {
     MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
 } mxc_sys_system_clock_div_t;
 
-#define MXC_SYS_USN_LEN 16
-#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/mxc_sys.h
@@ -198,7 +198,8 @@ typedef enum {
     MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
 } mxc_sys_system_clock_div_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
+#define MXC_SYS_USN_LEN 16    
+#define MXC_SYS_USN_CHECKSUM_LEN 2
 
 /***** Function Prototypes *****/
 
@@ -304,10 +305,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX32662/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/mxc_sys.h
@@ -143,8 +143,8 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
-#define MXC_SYS_USN_LEN 13
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
 
 /***** Function Prototypes *****/
 
@@ -250,10 +250,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX32662/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/mxc_sys.h
@@ -143,8 +143,9 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32665/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/mxc_sys.h
@@ -212,8 +212,9 @@ typedef enum {
 #define MXC_SYS_SCACHE_CLK 1 // Enable SCACHE CLK
 #define MXC_SYS_CTB_CLK 1 // Enable CTB CLK
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32665/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/mxc_sys.h
@@ -212,8 +212,8 @@ typedef enum {
 #define MXC_SYS_SCACHE_CLK 1 // Enable SCACHE CLK
 #define MXC_SYS_CTB_CLK 1 // Enable CTB CLK
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
-#define MXC_SYS_USN_LEN 13
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
 
 /***** Function Prototypes *****/
 
@@ -319,9 +319,9 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
  * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);

--- a/Libraries/PeriphDrivers/Include/MAX32670/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/mxc_sys.h
@@ -137,7 +137,8 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
+#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 2
 
 /***** Function Prototypes *****/
 
@@ -243,10 +244,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX32670/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/mxc_sys.h
@@ -137,8 +137,9 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_LEN 16
-#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32672/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/mxc_sys.h
@@ -276,10 +276,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX32672/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/mxc_sys.h
@@ -169,8 +169,8 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
-#define MXC_SYS_USN_LEN 13
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32672/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/mxc_sys.h
@@ -169,8 +169,9 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32675/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/mxc_sys.h
@@ -161,8 +161,9 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Select the External RTC Crystal Oscillator */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32675/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/mxc_sys.h
@@ -161,7 +161,8 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Select the External RTC Crystal Oscillator */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
 
 /***** Function Prototypes *****/
 
@@ -267,10 +268,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h
@@ -198,8 +198,9 @@ typedef enum {
     MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
 } mxc_sys_system_clock_div_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/mxc_sys.h
@@ -198,7 +198,8 @@ typedef enum {
     MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
 } mxc_sys_system_clock_div_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
 
 /***** Function Prototypes *****/
 
@@ -304,10 +305,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -216,7 +216,8 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
 
 /***** Function Prototypes *****/
 
@@ -322,10 +323,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/mxc_sys.h
@@ -216,8 +216,9 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX78000/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/mxc_sys.h
@@ -198,8 +198,9 @@ typedef enum {
     MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
 } mxc_sys_system_clock_div_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Include/MAX78000/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/mxc_sys.h
@@ -198,7 +198,8 @@ typedef enum {
     MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
 } mxc_sys_system_clock_div_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
 
 /***** Function Prototypes *****/
 
@@ -304,10 +305,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX78002/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/mxc_sys.h
@@ -200,7 +200,8 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input. */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 2
+#define MXC_SYS_USN_LEN 16
 
 /***** Function Prototypes *****/
 
@@ -306,10 +307,10 @@ static inline int MXC_SYS_In_Crit_Section(void)
 // clang-format on
 
 /**
- * @brief Reads the device USN.
- * @param usn       Pointer to store the USN.
- * @param checksum  Optional pointer to store the AES checksum.
- * @returns       E_NO_ERROR if everything is successful.
+ * @brief Reads the device USN and verifies the checksum.
+ * @param usn       Pointer to store the USN. Array must be at least MXC_SYS_USN_LEN bytes long.
+ * @param checksum  Optional pointer to store the AES checksum. If not NULL, checksum is verified with AES engine.
+ * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum);
 

--- a/Libraries/PeriphDrivers/Include/MAX78002/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/mxc_sys.h
@@ -200,8 +200,9 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input. */
 } mxc_sys_system_clock_t;
 
-#define MXC_SYS_USN_CHECKSUM_LEN 2
-#define MXC_SYS_USN_LEN 16
+#define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
+#define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
+#define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
 
 /***** Function Prototypes *****/
 

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -77,7 +77,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_LEN);
+    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -95,8 +95,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     /* If requested, verify and return the checksum */
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_LEN];
-        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)
 
         // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
@@ -113,7 +113,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         // Compute Checksum
         mxc_aes_req_t aes_req;
-        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
         aes_req.inputData = (uint32_t *)usn;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -70,6 +70,10 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     int err = E_NO_ERROR;
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
+    if (usn == NULL) {
+        return E_NULL_PTR;
+    }
+
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -67,12 +67,13 @@
 /* ************************************************************************** */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 {
+    int err = E_NO_ERROR;
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -88,10 +89,46 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     usn[9] = (infoblock[3] & 0x00007F80) >> 7;
     usn[10] = (infoblock[3] & 0x007F8000) >> 15;
 
-    /* If requested, return the checksum */
+    /* If requested, verify and return the checksum */
     if (checksum != NULL) {
+        uint8_t check_csum[MXC_SYS_USN_LEN];
+        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+
+        // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+
+        err = MXC_AES_Init();
+        if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return E_BAD_STATE;
+        }
+
+        // Set NULL Key
+        MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
+
+        // Compute Checksum
+        mxc_aes_req_t aes_req;
+        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.inputData = (uint32_t *)usn;
+        aes_req.resultData = (uint32_t *)check_csum;
+        aes_req.keySize = MXC_AES_128BITS;
+        aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;
+        aes_req.callback = NULL;
+
+        err = MXC_AES_Generic(&aes_req);
+        if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return E_BAD_STATE;
+        }
+
+        MXC_AES_Shutdown();
+
+        // Verify Checksum
+        if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return E_INVALID;
+        }
     }
 
     /* Add the info block checksum to the USN */
@@ -100,7 +137,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    return E_NO_ERROR;
+    return err;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -105,7 +105,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         err = MXC_AES_Init();
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
-            return E_BAD_STATE;
+            return err;
         }
 
         // Set NULL Key
@@ -123,7 +123,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         err = MXC_AES_Generic(&aes_req);
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
-            return E_BAD_STATE;
+            return err;
         }
 
         MXC_AES_Shutdown();

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
@@ -77,7 +77,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_LEN);
+    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -95,8 +95,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     /* If requested, verify and return the checksum */
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_LEN];
-        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)
 
         // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
@@ -113,7 +113,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         // Compute Checksum
         mxc_aes_req_t aes_req;
-        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
         aes_req.inputData = (uint32_t *)usn;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
@@ -70,6 +70,10 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     int err = E_NO_ERROR;
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
+    if (usn == NULL) {
+        return E_NULL_PTR;
+    }
+
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
@@ -67,12 +67,13 @@
 /* ************************************************************************** */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 {
+    int err = E_NO_ERROR;
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -88,10 +89,46 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     usn[9] = (infoblock[3] & 0x00007F80) >> 7;
     usn[10] = (infoblock[3] & 0x007F8000) >> 15;
 
-    /* If requested, return the checksum */
+    /* If requested, verify and return the checksum */
     if (checksum != NULL) {
+        uint8_t check_csum[MXC_SYS_USN_LEN];
+        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+
+        // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+
+        err = MXC_AES_Init();
+        if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return err;
+        }
+
+        // Set NULL Key
+        MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
+
+        // Compute Checksum
+        mxc_aes_req_t aes_req;
+        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.inputData = (uint32_t *)usn;
+        aes_req.resultData = (uint32_t *)check_csum;
+        aes_req.keySize = MXC_AES_128BITS;
+        aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;
+        aes_req.callback = NULL;
+
+        err = MXC_AES_Generic(&aes_req);
+        if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return err;
+        }
+
+        MXC_AES_Shutdown();
+
+        // Verify Checksum
+        if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return E_INVALID;
+        }
     }
 
     /* Add the info block checksum to the USN */
@@ -100,7 +137,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    return E_NO_ERROR;
+    return err;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_es17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_es17.c
@@ -258,18 +258,20 @@ int MXC_SYS_GetUSN(uint8_t *serialNumber, int len)
 {
     if (len != 13) {
         return E_BAD_PARAM;
+    } else if (serialNumber == NULL) {
+        return E_NULL_PTR;
     }
 
     uint32_t infoblock[6];
 
-    MXC_FLC_UnlockInfoBlock(0x0000);
+    MXC_FLC_UnlockInfoBlock(MXC_INFO_MEM_BASE);
     infoblock[0] = *(uint32_t *)MXC_INFO_MEM_BASE;
     infoblock[1] = *(uint32_t *)(MXC_INFO_MEM_BASE + 4);
     infoblock[2] = *(uint32_t *)(MXC_INFO_MEM_BASE + 8);
     infoblock[3] = *(uint32_t *)(MXC_INFO_MEM_BASE + 12);
     infoblock[4] = *(uint32_t *)(MXC_INFO_MEM_BASE + 16);
     infoblock[5] = *(uint32_t *)(MXC_INFO_MEM_BASE + 20);
-    MXC_FLC_LockInfoBlock(0x0000);
+    MXC_FLC_LockInfoBlock(MXC_INFO_MEM_BASE);
 
     serialNumber[0] = (infoblock[0] & 0x007F8000) >> 15;
     serialNumber[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me10.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me10.c
@@ -373,6 +373,8 @@ int MXC_SYS_GetUSN(uint8_t *serialNumber, int len)
 {
     if (len != 13) {
         return E_BAD_PARAM;
+    } else if (serialNumber == NULL) {
+        return E_NULL_PTR;
     }
 
     uint32_t infoblock[6];

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me11.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me11.c
@@ -65,6 +65,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, int len, int part)
 {
     if (len != MXC_SYS_USN_LEN) {
         return E_BAD_PARAM;
+    } else if (usn == NULL) {
+        return E_NULL_PTR;
     }
 
     uint32_t infoblock[6];
@@ -83,7 +85,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, int len, int part)
         usn[1] = (infoblock[0] & 0x0000FF00) >> 8;
         usn[2] = (infoblock[0] & 0x00FF0000) >> 16;
         usn[3] = (infoblock[0] & 0x3F000000) >> 24;
-        usn[3] |= (infoblock[1] & 0x00000003) << 30;
+        usn[3] |= (infoblock[1] & 0x00000003) << 6;
         usn[4] = (infoblock[1] & 0x000003FC) >> 2;
         usn[5] = (infoblock[1] & 0x0003FC00) >> 10;
         usn[6] = (infoblock[1] & 0x03FC0000) >> 18;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me11.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me11.c
@@ -71,14 +71,14 @@ int MXC_SYS_GetUSN(uint8_t *usn, int len, int part)
 
     uint32_t infoblock[6];
 
-    MXC_FLC_UnlockInfoBlock(0x0000);
+    MXC_FLC_UnlockInfoBlock(MXC_INFO_MEM_BASE);
     infoblock[0] = *(uint32_t *)MXC_INFO_MEM_BASE;
     infoblock[1] = *(uint32_t *)(MXC_INFO_MEM_BASE + 4);
     infoblock[2] = *(uint32_t *)(MXC_INFO_MEM_BASE + 8);
     infoblock[3] = *(uint32_t *)(MXC_INFO_MEM_BASE + 12);
     infoblock[4] = *(uint32_t *)(MXC_INFO_MEM_BASE + 16);
     infoblock[5] = *(uint32_t *)(MXC_INFO_MEM_BASE + 20);
-    MXC_FLC_LockInfoBlock(0x0000);
+    MXC_FLC_LockInfoBlock(MXC_INFO_MEM_BASE);
 
     if (part == 0) {
         usn[0] = (infoblock[0] & 0x000000FF);

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -40,15 +40,16 @@
 /* **** Includes **** */
 #include <stddef.h>
 #include <string.h>
-#include "mxc_device.h"
-#include "mxc_assert.h"
-#include "mxc_sys.h"
-#include "mxc_delay.h"
-#include "gcr_regs.h"
-#include "fcr_regs.h"
-#include "mcr_regs.h"
-#include "pwrseq_regs.h"
+#include "aes.h"
 #include "flc.h"
+#include "fcr_regs.h"
+#include "gcr_regs.h"
+#include "mcr_regs.h"
+#include "mxc_assert.h"
+#include "mxc_delay.h"
+#include "mxc_device.h"
+#include "mxc_sys.h"
+#include "pwrseq_regs.h"
 
 /**
  * @ingroup mxc_sys
@@ -68,6 +69,7 @@ extern uint32_t _binary_riscv_bin_start;
 /* ************************************************************************** */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 {
+    int err = E_NO_ERROR;
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
     /* Read the USN from the info block */
@@ -89,13 +91,54 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     usn[9] = (infoblock[3] & 0x00007F80) >> 7;
     usn[10] = (infoblock[3] & 0x007F8000) >> 15;
 
+    if (checksum != NULL) {
+        uint8_t check_csum[MXC_SYS_USN_LEN];
+        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+
+        // Read Checksum from the infoblock
+        checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
+        checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+
+        err = MXC_AES_Init();
+        if (err) {
+        	MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return E_BAD_STATE;
+        }
+
+        // Set NULL Key
+        MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
+
+        // Compute Checksum
+        mxc_aes_req_t aes_req;
+        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.inputData = (uint32_t *)usn;
+        aes_req.resultData = (uint32_t *)check_csum;
+        aes_req.keySize = MXC_AES_128BITS;
+        aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;
+        aes_req.callback = NULL;
+
+        err = MXC_AES_Generic(&aes_req);
+        if (err) {
+        	MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return E_BAD_STATE;
+        }
+
+        MXC_AES_Shutdown();
+
+        // Verify Checksum
+        if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
+        	MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return E_INVALID;
+        }
+    }
+
     /* Add the info block checksum to the USN */
     usn[11] = ((infoblock[3] & 0x7F800000) >> 23);
     usn[12] = ((infoblock[4] & 0x007F8000) >> 15);
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    return E_NO_ERROR;
+    return err;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -101,8 +101,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         err = MXC_AES_Init();
         if (err) {
-        	MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
-            return E_BAD_STATE;
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return err;
         }
 
         // Set NULL Key
@@ -119,15 +119,15 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         err = MXC_AES_Generic(&aes_req);
         if (err) {
-        	MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
-            return E_BAD_STATE;
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return err;
         }
 
         MXC_AES_Shutdown();
 
         // Verify Checksum
         if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
-        	MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_INVALID;
         }
     }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -72,10 +72,14 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     int err = E_NO_ERROR;
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
+    if (usn == NULL) {
+        return E_NULL_PTR;
+    }
+
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_LEN);
+    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -92,8 +96,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     usn[10] = (infoblock[3] & 0x007F8000) >> 15;
 
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_LEN];
-        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)
 
         // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
@@ -110,7 +114,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         // Compute Checksum
         mxc_aes_req_t aes_req;
-        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
         aes_req.inputData = (uint32_t *)usn;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me13.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me13.c
@@ -356,18 +356,20 @@ int MXC_SYS_GetUSN(uint8_t *serialNumber, int len)
 {
     if (len != 13) {
         return E_BAD_PARAM;
+    } else if (serialNumber == NULL) {
+        return E_NULL_PTR;
     }
 
     uint32_t infoblock[6];
 
-    MXC_FLC_UnlockInfoBlock(0x0000);
+    MXC_FLC_UnlockInfoBlock(MXC_INFO_MEM_BASE);
     infoblock[0] = *(uint32_t *)MXC_INFO_MEM_BASE;
     infoblock[1] = *(uint32_t *)(MXC_INFO_MEM_BASE + 4);
     infoblock[2] = *(uint32_t *)(MXC_INFO_MEM_BASE + 8);
     infoblock[3] = *(uint32_t *)(MXC_INFO_MEM_BASE + 12);
     infoblock[4] = *(uint32_t *)(MXC_INFO_MEM_BASE + 16);
     infoblock[5] = *(uint32_t *)(MXC_INFO_MEM_BASE + 20);
-    MXC_FLC_LockInfoBlock(0x0000);
+    MXC_FLC_LockInfoBlock(MXC_INFO_MEM_BASE);
 
     serialNumber[0] = (infoblock[0] & 0x007F8000) >> 15;
     serialNumber[1] = (infoblock[0] & 0x7F800000) >> 23;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me14.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me14.c
@@ -73,7 +73,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_LEN);
+    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -91,16 +91,16 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     // Compute the checksum
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_LEN];
-        uint8_t key[MXC_SYS_USN_LEN];
+        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint8_t key[MXC_SYS_USN_CHECKSUM_LEN];
 
         /* Initialize the remainder of the USN and key */
-        memset(key, 0, MXC_SYS_USN_LEN);
-        memset(checksum, 0, MXC_SYS_USN_CHECKSUM_LEN);
+        memset(key, 0, MXC_SYS_USN_CHECKSUM_LEN);
+        memset(checksum, 0, MXC_SYS_USN_CSUM_FIELD_LEN);
 
         /* Read the checksum from the info block */
-        checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
-        checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+        checksum[1] = ((infoblock[3] & 0x7F800000) >> 23);
+        checksum[0] = ((infoblock[4] & 0x007F8000) >> 15);
 
         MXC_TPU_Cipher_Config(MXC_TPU_MODE_ECB, MXC_TPU_CIPHER_AES128);
         MXC_TPU_Cipher_AES_Encrypt((const char *)usn, NULL, (const char *)key,
@@ -108,7 +108,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
                                    (char *)check_csum);
 
         /* Verify the checksum */
-        if ((checksum[1] != check_csum[0]) || (checksum[0] != check_csum[1])) {
+        if ((checksum[0] != check_csum[0]) || (checksum[1] != check_csum[1])) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_UNKNOWN;
         }
@@ -399,7 +399,7 @@ void MXC_SYS_Reset_Periph(mxc_sys_reset_t reset)
 /* ************************************************************************** */
 uint8_t MXC_SYS_GetRev(void)
 {
-    uint8_t serialNumber[MXC_SYS_USN_LEN];
+    uint8_t serialNumber[MXC_SYS_USN_CHECKSUM_LEN];
     MXC_SYS_GetUSN(serialNumber, NULL);
 
     if ((serialNumber[0] < 0x9F) | ((serialNumber[0] & 0x0F) > 0x09)) {

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -72,12 +72,19 @@
 /* ************************************************************************** */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 {
-    uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
+    uint32_t *infoblock;
+    int err = E_NO_ERROR;
+
+    if (usn == NULL) {
+        return E_BAD_PARAM;
+    }
+
+    infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -93,10 +100,44 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     usn[9] = (infoblock[3] & 0x00007F80) >> 7;
     usn[10] = (infoblock[3] & 0x007F8000) >> 15;
 
-    /* If requested, return the checksum */
+    /* If requested, verify and return the checksum */
     if (checksum != NULL) {
+        uint8_t check_csum[MXC_SYS_USN_LEN];
+        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+
+        // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+
+
+        err = MXC_AES_Init();
+        if (err) {
+            return E_BAD_STATE;
+        }
+
+        // Set NULL Key
+        MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
+
+        // Compute Checksum
+        mxc_aes_req_t aes_req;
+        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.inputData = (uint32_t *)usn;
+        aes_req.resultData = (uint32_t *)check_csum;
+        aes_req.keySize = MXC_AES_128BITS;
+        aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;
+        aes_req.callback = NULL;
+
+        err = MXC_AES_Generic(&aes_req);
+        if (err) {
+            return E_BAD_STATE;
+        }
+
+        MXC_AES_Shutdown();
+
+        // Verify Checksum
+        if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
+            return E_INVALID;
+        }
     }
 
     /* Add the info block checksum to the USN */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -112,6 +112,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         err = MXC_AES_Init();
         if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_BAD_STATE;
         }
 
@@ -129,6 +130,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         err = MXC_AES_Generic(&aes_req);
         if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_BAD_STATE;
         }
 
@@ -136,6 +138,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         // Verify Checksum
         if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_INVALID;
         }
     }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -109,7 +109,6 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
 
-
         err = MXC_AES_Init();
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -84,7 +84,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_LEN);
+    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -102,8 +102,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     /* If requested, verify and return the checksum */
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_LEN];
-        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)
 
         // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
@@ -120,7 +120,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         // Compute Checksum
         mxc_aes_req_t aes_req;
-        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
         aes_req.inputData = (uint32_t *)usn;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -113,7 +113,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         err = MXC_AES_Init();
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
-            return E_BAD_STATE;
+            return err;
         }
 
         // Set NULL Key
@@ -131,7 +131,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         err = MXC_AES_Generic(&aes_req);
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
-            return E_BAD_STATE;
+            return err;
         }
 
         MXC_AES_Shutdown();

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -80,7 +80,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_LEN);
+    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -98,8 +98,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     /* If requested, verify and return the checksum */
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_LEN];
-        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)
 
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
@@ -115,7 +115,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         // Compute Checksum
         mxc_aes_req_t aes_req;
-        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
         aes_req.inputData = (uint32_t *)usn;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -70,12 +70,17 @@ extern uint32_t _binary_riscv_bin_start;
 /* ************************************************************************** */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 {
+    int err = E_NO_ERROR;
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
+
+    if (usn == NULL) {
+        return E_NULL_PTR;
+    }
 
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -91,10 +96,42 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     usn[9] = (infoblock[3] & 0x00007F80) >> 7;
     usn[10] = (infoblock[3] & 0x007F8000) >> 15;
 
-    /* If requested, return the checksum */
+    /* If requested, verify and return the checksum */
     if (checksum != NULL) {
+        uint8_t check_csum[MXC_SYS_USN_LEN];
+        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+
+        err = MXC_AES_Init();
+        if (err) {
+            return E_BAD_STATE;
+        }
+
+        // Set NULL Key
+        MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
+
+        // Compute Checksum
+        mxc_aes_req_t aes_req;
+        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.inputData = (uint32_t *)usn;
+        aes_req.resultData = (uint32_t *)check_csum;
+        aes_req.keySize = MXC_AES_128BITS;
+        aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;
+        aes_req.callback = NULL;
+
+        err = MXC_AES_Generic(&aes_req);
+        if (err) {
+            return E_BAD_STATE;
+        }
+
+        MXC_AES_Shutdown();
+
+        // Verify Checksum
+        if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
+            return E_INVALID;
+        }
     }
 
     /* Add the info block checksum to the USN */
@@ -103,7 +140,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    return E_NO_ERROR;
+    return err;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -107,7 +107,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         err = MXC_AES_Init();
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
-            return E_BAD_STATE;
+            return err;
         }
 
         // Set NULL Key
@@ -125,7 +125,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         err = MXC_AES_Generic(&aes_req);
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
-            return E_BAD_STATE;
+            return err;
         }
 
         MXC_AES_Shutdown();

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me17.c
@@ -106,6 +106,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         err = MXC_AES_Init();
         if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_BAD_STATE;
         }
 
@@ -123,6 +124,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         err = MXC_AES_Generic(&aes_req);
         if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_BAD_STATE;
         }
 
@@ -130,6 +132,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         // Verify Checksum
         if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_INVALID;
         }
     }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -79,7 +79,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_LEN);
+    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -100,16 +100,16 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         uint32_t key[4];
         uint32_t pt32[4];
         uint32_t check_csum32[4];
-        uint8_t check_csum[MXC_SYS_USN_LEN];
+        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
 
         /* Initialize key and plaintext */
-        memset(key, 0, MXC_SYS_USN_LEN);
-        memset(pt32, 0, MXC_SYS_USN_LEN);
-        memcpy(pt32, usn, MXC_SYS_USN_LEN);
+        memset(key, 0, MXC_SYS_USN_CHECKSUM_LEN);
+        memset(pt32, 0, MXC_SYS_USN_CHECKSUM_LEN);
+        memcpy(pt32, usn, MXC_SYS_USN_CHECKSUM_LEN);
 
         /* Read the checksum from the info block */
-        checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
-        checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+        checksum[1] = ((infoblock[3] & 0x7F800000) >> 23);
+        checksum[0] = ((infoblock[4] & 0x007F8000) >> 15);
 
         MXC_CTB_Init(MXC_CTB_FEATURE_CIPHER);
 
@@ -153,10 +153,10 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         check_csum32[2] = MXC_CTB->dout[2];
         check_csum32[3] = MXC_CTB->dout[3];
 
-        memcpy(check_csum, check_csum32, MXC_SYS_USN_LEN);
+        memcpy(check_csum, check_csum32, MXC_SYS_USN_CHECKSUM_LEN);
 
         /* Verify the checksum */
-        if ((checksum[1] != check_csum[0]) || (checksum[0] != check_csum[1])) {
+        if ((checksum[0] != check_csum[0]) || (checksum[1] != check_csum[1])) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_UNKNOWN;
         }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -75,7 +75,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    memset(usn, 0, MXC_SYS_USN_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -93,19 +93,19 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     // Compute the checksum
     if (checksum != NULL) {
-        uint8_t info_checksum[2];
         uint32_t key[4];
         uint32_t pt32[4];
-        uint32_t checksum32[4];
+        uint32_t check_csum32[4];
+        uint8_t check_csum[MXC_SYS_USN_LEN];
 
         /* Initialize key and plaintext */
-        memset(key, 0, 16);
-        memset(pt32, 0, 16);
-        memcpy(pt32, usn, MXC_SYS_USN_CHECKSUM_LEN);
+        memset(key, 0, MXC_SYS_USN_LEN);
+        memset(pt32, 0, MXC_SYS_USN_LEN);
+        memcpy(pt32, usn, MXC_SYS_USN_LEN);
 
         /* Read the checksum from the info block */
-        info_checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
-        info_checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+        checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
+        checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
 
         MXC_CTB_Init(MXC_CTB_FEATURE_CIPHER);
 
@@ -144,15 +144,15 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         MXC_CTB->ctrl |= MXC_F_CTB_CTRL_CPH_DONE;
 
         /* Copy out the cipher text */
-        checksum32[0] = MXC_CTB->dout[0];
-        checksum32[1] = MXC_CTB->dout[1];
-        checksum32[2] = MXC_CTB->dout[2];
-        checksum32[3] = MXC_CTB->dout[3];
+        check_csum32[0] = MXC_CTB->dout[0];
+        check_csum32[1] = MXC_CTB->dout[1];
+        check_csum32[2] = MXC_CTB->dout[2];
+        check_csum32[3] = MXC_CTB->dout[3];
 
-        memcpy(checksum, checksum32, MXC_SYS_USN_CHECKSUM_LEN);
+        memcpy(check_csum, check_csum32, MXC_SYS_USN_LEN);
 
         /* Verify the checksum */
-        if ((checksum[1] != info_checksum[0]) || (checksum[0] != info_checksum[1])) {
+        if ((checksum[1] != check_csum[0]) || (checksum[0] != check_csum[1])) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_UNKNOWN;
         }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -73,7 +73,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     if (usn == NULL) {
         return E_NULL_PTR;
     }
-    
+
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
     /* Read the USN from the info block */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me18.c
@@ -70,6 +70,10 @@ extern uint32_t _binary_riscv_bin_start;
 /* ************************************************************************** */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 {
+    if (usn == NULL) {
+        return E_NULL_PTR;
+    }
+    
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
     /* Read the USN from the info block */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -66,7 +66,12 @@
 /* ************************************************************************** */
 int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 {
+    int err = E_NO_ERROR;
     uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
+
+    if (usn == NULL) {
+        return E_NULL_PTR;
+    }
 
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
@@ -89,8 +94,45 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     /* If requested, return the checksum */
     if (checksum != NULL) {
+        uint8_t check_csum[MXC_SYS_USN_LEN];
+        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+
+        // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+
+
+        err = MXC_AES_Init();
+        if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return err;
+        }
+
+        // Set NULL Key
+        MXC_AES_SetExtKey((const void *)aes_key, MXC_AES_128BITS);
+
+        // Compute Checksum
+        mxc_aes_req_t aes_req;
+        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.inputData = (uint32_t *)usn;
+        aes_req.resultData = (uint32_t *)check_csum;
+        aes_req.keySize = MXC_AES_128BITS;
+        aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;
+        aes_req.callback = NULL;
+
+        err = MXC_AES_Generic(&aes_req);
+        if (err) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return err;
+        }
+
+        MXC_AES_Shutdown();
+
+        // Verify Checksum
+        if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
+            MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+            return E_INVALID;
+        }
     }
 
     /* Add the info block checksum to the USN */
@@ -99,7 +141,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    return E_NO_ERROR;
+    return err;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -76,7 +76,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_LEN);
+    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -94,8 +94,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     /* If requested, return the checksum */
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_LEN];
-        uint8_t aes_key[MXC_SYS_USN_LEN] = { 0 }; // NULL Key (per checksum spec)
+        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)
 
         // Read Checksum from the infoblock
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
@@ -112,7 +112,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
         // Compute Checksum
         mxc_aes_req_t aes_req;
-        aes_req.length = MXC_SYS_USN_LEN / 4;
+        aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
         aes_req.inputData = (uint32_t *)usn;
         aes_req.resultData = (uint32_t *)check_csum;
         aes_req.keySize = MXC_AES_128BITS;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me21.c
@@ -101,7 +101,6 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
         checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
 
-
         err = MXC_AES_Init();
         if (err) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me55.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me55.c
@@ -363,7 +363,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     // /* Read the USN from the info block */
     // MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    // memset(usn, 0, MXC_SYS_USN_LEN);
+    // memset(usn, 0, MXC_SYS_CHECKSUM_LEN);
 
     // usn[0] = (infoblock[0] & 0x007F8000) >> 15;
     // usn[1] = (infoblock[0] & 0x7F800000) >> 23;
@@ -384,12 +384,12 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     //     uint32_t key[4];
     //     uint32_t pt32[4];
     //     uint32_t check_csum32[4];
-    //     uint8_t check_csum[MXC_SYS_USN_LEN];
+    //     uint8_t check_csum[MXC_SYS_CHECKSUM_LEN];
 
     //     /* Initialize key and plaintext */
-    //     memset(key, 0, MXC_SYS_USN_LEN);
-    //     memset(pt32, 0, MXC_SYS_USN_LEN);
-    //     memcpy(pt32, usn, MXC_SYS_USN_LEN);
+    //     memset(key, 0, MXC_SYS_CHECKSUM_LEN);
+    //     memset(pt32, 0, MXC_SYS_CHECKSUM_LEN);
+    //     memcpy(pt32, usn, MXC_SYS_CHECKSUM_LEN);
 
     //     /* Read the checksum from the info block */
     //     checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
@@ -437,7 +437,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     //     check_csum32[2] = MXC_CTB->dout[2];
     //     check_csum32[3] = MXC_CTB->dout[3];
 
-    //     memcpy(check_csum, check_csum32, MXC_SYS_USN_LEN);
+    //     memcpy(check_csum, check_csum32, MXC_SYS_CHECKSUM_LEN);
 
     //     /* Verify the checksum */
     //     if ((checksum[1] != check_csum[0]) || (checksum[0] != check_csum[1])) {

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me55.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me55.c
@@ -349,40 +349,108 @@ void MXC_SYS_Reset_Periph(mxc_sys_reset_t reset)
 }
 
 /* ************************************************************************** */
-int MXC_SYS_GetUSN(uint8_t *serialNumber, int len)
+int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 {
     //FIXME: No flash for ME55
     return E_NOT_SUPPORTED;
-    // if (len != 13) {
-    //     return E_BAD_PARAM;
+
+    // if (usn == NULL) {
+    //     return E_NOT_SUPPORTED;
     // }
 
-    // uint32_t infoblock[6];
+    // uint32_t *infoblock = (uint32_t *)MXC_INFO0_MEM_BASE;
 
-    // MXC_FLC_UnlockInfoBlock(0x0000);
-    // infoblock[0] = * (uint32_t*) MXC_INFO_MEM_BASE;
-    // infoblock[1] = * (uint32_t*)(MXC_INFO_MEM_BASE + 4);
-    // infoblock[2] = * (uint32_t*)(MXC_INFO_MEM_BASE + 8);
-    // infoblock[3] = * (uint32_t*)(MXC_INFO_MEM_BASE + 12);
-    // infoblock[4] = * (uint32_t*)(MXC_INFO_MEM_BASE + 16);
-    // infoblock[5] = * (uint32_t*)(MXC_INFO_MEM_BASE + 20);
-    // MXC_FLC_LockInfoBlock(0x0000);
+    // /* Read the USN from the info block */
+    // MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    // serialNumber[0]  = (infoblock[0] & 0x007F8000) >> 15;
-    // serialNumber[1]  = (infoblock[0] & 0x7F800000) >> 23;
-    // serialNumber[2]  = (infoblock[0] & 0x80000000) >> 31;
-    // serialNumber[2] |= (infoblock[1] & 0x0000007F) << 1;
-    // serialNumber[3]  = (infoblock[1] & 0x00007F80) >> 7;
-    // serialNumber[4]  = (infoblock[1] & 0x007F8000) >> 15;
-    // serialNumber[5]  = (infoblock[1] & 0x7F800000) >> 23;
-    // serialNumber[6]  = (infoblock[2] & 0x007F8000) >> 15;
-    // serialNumber[7]  = (infoblock[2] & 0x7F800000) >> 23;
-    // serialNumber[8]  = (infoblock[2] & 0x80000000) >> 31;
-    // serialNumber[8] |= (infoblock[3] & 0x0000007F) << 1;
-    // serialNumber[9]  = (infoblock[3] & 0x00007F80) >> 7;
-    // serialNumber[10] = (infoblock[3] & 0x007F8000) >> 15;
-    // serialNumber[11] = (infoblock[3] & 0x7F800000) >> 23;
-    // serialNumber[12] = (infoblock[4] & 0x007F8000) >> 15;
+    // memset(usn, 0, MXC_SYS_USN_LEN);
+
+    // usn[0] = (infoblock[0] & 0x007F8000) >> 15;
+    // usn[1] = (infoblock[0] & 0x7F800000) >> 23;
+    // usn[2] = (infoblock[1] & 0x0000007F) << 1;
+    // usn[2] |= (infoblock[0] & 0x80000000) >> 31;
+    // usn[3] = (infoblock[1] & 0x00007F80) >> 7;
+    // usn[4] = (infoblock[1] & 0x007F8000) >> 15;
+    // usn[5] = (infoblock[1] & 0x7F800000) >> 23;
+    // usn[6] = (infoblock[2] & 0x007F8000) >> 15;
+    // usn[7] = (infoblock[2] & 0x7F800000) >> 23;
+    // usn[8] = (infoblock[3] & 0x0000007F) << 1;
+    // usn[8] |= (infoblock[2] & 0x80000000) >> 31;
+    // usn[9] = (infoblock[3] & 0x00007F80) >> 7;
+    // usn[10] = (infoblock[3] & 0x007F8000) >> 15;
+
+    // // Compute the checksum
+    // if (checksum != NULL) {
+    //     uint32_t key[4];
+    //     uint32_t pt32[4];
+    //     uint32_t check_csum32[4];
+    //     uint8_t check_csum[MXC_SYS_USN_LEN];
+
+    //     /* Initialize key and plaintext */
+    //     memset(key, 0, MXC_SYS_USN_LEN);
+    //     memset(pt32, 0, MXC_SYS_USN_LEN);
+    //     memcpy(pt32, usn, MXC_SYS_USN_LEN);
+
+    //     /* Read the checksum from the info block */
+    //     checksum[0] = ((infoblock[3] & 0x7F800000) >> 23);
+    //     checksum[1] = ((infoblock[4] & 0x007F8000) >> 15);
+
+    //     MXC_CTB_Init(MXC_CTB_FEATURE_CIPHER);
+
+    //     /* Reset the CTB */
+    //     MXC_CTB->ctrl = MXC_F_CTB_CTRL_RST;
+
+    //     /* Set the legacy bit */
+    //     MXC_CTB->ctrl |= MXC_F_CTB_CTRL_FLAG_MODE;
+
+    //     /* Clear interrupt flags */
+    //     MXC_CTB->ctrl |= MXC_F_CTB_CTRL_CPH_DONE;
+
+    //     /* Setup the key source */
+    //     MXC_CTB->cipher_ctrl = MXC_S_CTB_CIPHER_CTRL_SRC_CIPHERKEY;
+
+    //     /* Setup the CT calculation */
+    //     MXC_CTB->cipher_ctrl |= MXC_S_CTB_CIPHER_CTRL_CIPHER_AES128;
+
+    //     /* Load the key */
+    //     MXC_CTB->cipher_key[0] = key[0];
+    //     MXC_CTB->cipher_key[1] = key[1];
+    //     MXC_CTB->cipher_key[2] = key[2];
+    //     MXC_CTB->cipher_key[3] = key[3];
+
+    //     /* Wait for the ready flag */
+    //     while (!(MXC_CTB->ctrl & MXC_F_CTB_CTRL_RDY)) {}
+
+    //     /* Copy data to start the operation */
+    //     MXC_CTB->din[0] = pt32[0];
+    //     MXC_CTB->din[1] = pt32[1];
+    //     MXC_CTB->din[2] = pt32[2];
+    //     MXC_CTB->din[3] = pt32[3];
+
+    //     /* Wait for and clear the done flag */
+    //     while (!(MXC_CTB->ctrl & MXC_F_CTB_CTRL_CPH_DONE)) {}
+    //     MXC_CTB->ctrl |= MXC_F_CTB_CTRL_CPH_DONE;
+
+    //     /* Copy out the cipher text */
+    //     check_csum32[0] = MXC_CTB->dout[0];
+    //     check_csum32[1] = MXC_CTB->dout[1];
+    //     check_csum32[2] = MXC_CTB->dout[2];
+    //     check_csum32[3] = MXC_CTB->dout[3];
+
+    //     memcpy(check_csum, check_csum32, MXC_SYS_USN_LEN);
+
+    //     /* Verify the checksum */
+    //     if ((checksum[1] != check_csum[0]) || (checksum[0] != check_csum[1])) {
+    //         MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+    //         return E_UNKNOWN;
+    //     }
+    // }
+
+    // /* Add the info block checksum to the USN */
+    // usn[11] = ((infoblock[3] & 0x7F800000) >> 23);
+    // usn[12] = ((infoblock[4] & 0x007F8000) >> 15);
+
+    // MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
 
     // return E_NO_ERROR;
 }


### PR DESCRIPTION
This PR includes improvements to the MXC_SYS_GetUSN function for all micros.

Changes in this PR include:
1. Adding code that verifies the checksum.
2. Adds a check for NULL usn/serialNumber pointers.
3. Fixes invalid calls MXC_FLC_UnlockInfoblock.