### PR TITLE
feat(Examples): MSDK-1184 Add Local Echo to WearLeveling Examples

### DIFF
--- a/Examples/MAX32572/WearLeveling/src/cli.c
+++ b/Examples/MAX32572/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32572/WearLeveling/src/cli.c
+++ b/Examples/MAX32572/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32650/WearLeveling/src/cli.c
+++ b/Examples/MAX32650/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32650/WearLeveling/src/cli.c
+++ b/Examples/MAX32650/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32655/WearLeveling/src/cli.c
+++ b/Examples/MAX32655/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32655/WearLeveling/src/cli.c
+++ b/Examples/MAX32655/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32660/WearLeveling/src/cli.c
+++ b/Examples/MAX32660/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32660/WearLeveling/src/cli.c
+++ b/Examples/MAX32660/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32662/WearLeveling/src/cli.c
+++ b/Examples/MAX32662/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32662/WearLeveling/src/cli.c
+++ b/Examples/MAX32662/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32665/WearLeveling/src/cli.c
+++ b/Examples/MAX32665/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32665/WearLeveling/src/cli.c
+++ b/Examples/MAX32665/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32670/WearLeveling/src/cli.c
+++ b/Examples/MAX32670/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32670/WearLeveling/src/cli.c
+++ b/Examples/MAX32670/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32672/WearLeveling/src/cli.c
+++ b/Examples/MAX32672/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32672/WearLeveling/src/cli.c
+++ b/Examples/MAX32672/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32675/WearLeveling/src/cli.c
+++ b/Examples/MAX32675/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32675/WearLeveling/src/cli.c
+++ b/Examples/MAX32675/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32680/WearLeveling/src/cli.c
+++ b/Examples/MAX32680/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32680/WearLeveling/src/cli.c
+++ b/Examples/MAX32680/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32690/WearLeveling/src/cli.c
+++ b/Examples/MAX32690/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX32690/WearLeveling/src/cli.c
+++ b/Examples/MAX32690/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX78000/WearLeveling/src/cli.c
+++ b/Examples/MAX78000/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX78000/WearLeveling/src/cli.c
+++ b/Examples/MAX78000/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX78002/WearLeveling/src/cli.c
+++ b/Examples/MAX78002/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo 
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo 
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX78002/WearLeveling/src/cli.c
+++ b/Examples/MAX78002/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo 
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;

--- a/Examples/MAX78002/WearLeveling/src/cli.c
+++ b/Examples/MAX78002/WearLeveling/src/cli.c
@@ -259,7 +259,7 @@ int cmd_get(char *cmd, size_t size)
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-
+        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART),next_ch); //Echo 
         if (next_ch == 0x08) { // backspace
             if (num_recv != 0) {
                 num_recv--;


### PR DESCRIPTION
The command line interface of the Wear leveling examples for all Micros did not echo characters back to the terminal.
Described in the [MSDK-1184](https://jira.maxim-ic.com/browse/MSDK-1184).

The fix adds a UART write to the console passing in the character that is entered by the user.