### PR TITLE
fix(Examples): MSDK-1192: Fix Leading Spaces issue in the Flash CLI example

### DIFF
--- a/Examples/MAX78000/Flash_CLI/main.c
+++ b/Examples/MAX78000/Flash_CLI/main.c
@@ -154,7 +154,7 @@ void checkLeadingSpaces(char *buffer, unsigned int *index)
             break;
     }
     if (leadingZerosCount > 0) {
-        memcpy(buffer, buffer + leadingZerosCount, (*index) - leadingZerosCount);
+        memmove(buffer, buffer + leadingZerosCount, (*index) - leadingZerosCount);
         *index = *index - leadingZerosCount;
         buffer[*index] = NULL_TERMINATION;
         ++(*index);

--- a/Examples/MAX78000/Flash_CLI/main.c
+++ b/Examples/MAX78000/Flash_CLI/main.c
@@ -83,6 +83,7 @@ TaskHandle_t cmd_task_id;
 #define ARROW_KEY_CODE_RIGHT 0x43
 #define ARROW_KEY_CODE_UP 0x41
 #define ARROW_KEY_CODE_DOWN 0x42
+#define TAB_SPACE 0x09
 
 /* Console ISR selection */
 #if (CONSOLE_UART == 0)
@@ -251,6 +252,9 @@ void vCmdLineTask(void *pvParameters)
                         buffer[index] = NULL_TERMINATION;
                     }
                     fflush(stdout);
+                } else if (tmp == TAB_SPACE) {
+                    /* Ignore Tab Space input */
+                    continue;
                 } else if (tmp == END_OF_TEXT) {
                     /* ^C abort */
                     index = 0;
@@ -285,16 +289,16 @@ void vCmdLineTask(void *pvParameters)
                     bool arrowKey = false;
                     if (index >= 3) {
                         arrowKey = checkArrowKeys(buffer + index - 3);
+                        if (arrowKey) {
+                            /* Remove the arrow key from the buffer */
+                            buffer[index - 3] = NULL_TERMINATION;
+                            index -= 3;
+                        }
                     }
-                    if (!arrowKey) {
+                    if ((!arrowKey) && (tmp != ARROW_KEY_CODE_1) && (tmp != ARROW_KEY_CODE_2)) {
                         /* Echo out if not an arrow key */
-                        if ((tmp != ARROW_KEY_CODE_1) && (tmp != ARROW_KEY_CODE_2))
-                            putchar(tmp);
+                        putchar(tmp);
                         fflush(stdout);
-                    } else {
-                        /* Remove the arrow key from the buffer */
-                        buffer[index - 3] = NULL_TERMINATION;
-                        index -= 3;
                     }
                 } else {
                     /* Throw away data and beep terminal */

--- a/Examples/MAX78000/Flash_CLI/main.c
+++ b/Examples/MAX78000/Flash_CLI/main.c
@@ -140,11 +140,11 @@ void vCmdLineTask_cb(mxc_uart_req_t *req, int error)
  */
 void checkLeadingSpaces(char* buffer, unsigned int* index){
     unsigned int leadingZerosCount = 0;
-    for(leadingZerosCount=0; leadingZerosCount < (*index); leadingZerosCount++){
+    for (leadingZerosCount = 0; leadingZerosCount < (*index); leadingZerosCount++) {
         if (buffer[leadingZerosCount] != SPACE_BAR)
             break;
     }
-    if (leadingZerosCount > 0){
+    if (leadingZerosCount > 0) {
         memcpy(buffer, buffer+leadingZerosCount, (*index)-leadingZerosCount);
         *index = *index - leadingZerosCount;
         buffer[*index] = NULL_TERMINATION;

--- a/Examples/MAX78000/Flash_CLI/main.c
+++ b/Examples/MAX78000/Flash_CLI/main.c
@@ -73,8 +73,8 @@ TaskHandle_t cmd_task_id;
 #define STRING_(x) #x
 
 /* ASCII macros */
-#define BACK_SPACE       0x08
-#define SPACE_BAR        0x20
+#define BACK_SPACE 0x08
+#define SPACE_BAR 0x20
 #define NULL_TERMINATION 0x00
 
 /* Console ISR selection */
@@ -138,14 +138,14 @@ void vCmdLineTask_cb(mxc_uart_req_t *req, int error)
  * 
  * =============================================================
  */
-void checkLeadingSpaces(char* buffer, unsigned int* index){
+void checkLeadingSpaces(char *buffer, unsigned int *index){
     unsigned int leadingZerosCount = 0;
     for (leadingZerosCount = 0; leadingZerosCount < (*index); leadingZerosCount++) {
         if (buffer[leadingZerosCount] != SPACE_BAR)
             break;
     }
     if (leadingZerosCount > 0) {
-        memcpy(buffer, buffer+leadingZerosCount, (*index)-leadingZerosCount);
+        memcpy(buffer, buffer + leadingZerosCount, (*index) - leadingZerosCount);
         *index = *index - leadingZerosCount;
         buffer[*index] = NULL_TERMINATION;
         ++(*index);
@@ -233,14 +233,15 @@ void vCmdLineTask(void *pvParameters)
                     buffer[index] = NULL_TERMINATION;
                     checkLeadingSpaces(buffer, &index);
                     /* Evaluate */
-                    if (index != 0){
+                    if (index != 0) {
                         do {
                             xMore = FreeRTOS_CLIProcessCommand(buffer, output, OUTPUT_BUF_SIZE);
                             /* If xMore == pdTRUE, then output buffer contains no null
 						    * termination, so we know it is OUTPUT_BUF_SIZE. If pdFALSE, we can
 						    * use strlen.
 						    */
-                            for (x = 0; x < (xMore == pdTRUE ? OUTPUT_BUF_SIZE : strlen(output)); x++) {
+                            for (x = 0; x < (xMore == pdTRUE ? OUTPUT_BUF_SIZE : strlen(output));
+                                 x++) {
                                 putchar(*(output + x));
                             }
                         } while (xMore != pdFALSE);

--- a/Examples/MAX78000/Flash_CLI/main.c
+++ b/Examples/MAX78000/Flash_CLI/main.c
@@ -138,7 +138,8 @@ void vCmdLineTask_cb(mxc_uart_req_t *req, int error)
  * 
  * =============================================================
  */
-void checkLeadingSpaces(char *buffer, unsigned int *index){
+void checkLeadingSpaces(char *buffer, unsigned int *index)
+{
     unsigned int leadingZerosCount = 0;
     for (leadingZerosCount = 0; leadingZerosCount < (*index); leadingZerosCount++) {
         if (buffer[leadingZerosCount] != SPACE_BAR)


### PR DESCRIPTION
1. Fixed the leading spaces issue in the Flash CLI (1st issue in the ticket).  
2. Removed magic numbers and included relevant ASCII equivalent with Macros.  
3. Included few more check to avoid unwanted echo statements (2nd issue in the ticket).  

Corresponding Jira ticket is [here](https://jira.maxim-ic.com/browse/MSDK-1192)  

Note: - Line 236 (index != 0) in the updated code would resolve the second issue in the ticket.