### PR TITLE
fix(Examples): MSDK-1184 Fix CLI bugs in Wear Leveling example.

### DIFF
--- a/Examples/MAX78000/WearLeveling/src/cli.c
+++ b/Examples/MAX78000/WearLeveling/src/cli.c
@@ -44,6 +44,21 @@
 #include "mxc_errors.h"
 #include "uart.h"
 
+/* ASCII macros */
+#define END_OF_TEXT 0x03
+#define BACK_SPACE 0x08
+#define SPACE_BAR 0x20
+#define NULL_TERMINATION 0x00
+#define ARROW_KEY_CODE_1 0x1B
+#define ARROW_KEY_CODE_2 0x5B
+#define ARROW_KEY_CODE_LEFT 0x44
+#define ARROW_KEY_CODE_RIGHT 0x43
+#define ARROW_KEY_CODE_UP 0x41
+#define ARROW_KEY_CODE_DOWN 0x42
+#define TAB_SPACE 0x09
+#define POWER_OF 0x5E
+#define CAPITAL_C 0x43
+
 /********************************************************************************/
 /******************************* Private Functions ******************************/
 /********************************************************************************/
@@ -241,11 +256,63 @@ static int swl_CmdHandler(lfs_t *lfs, char *args)
     return E_NO_ERROR;
 }
 
+/* =| checkArrowKeys |======================================
+ *
+ * Function to check for the presence of arrow keys in the 
+ *  input command.
+ *
+ * NOTE: The cmd should have atleast 3 bytes of data to 
+ *  check for the arrow keys. Sanity check should be done 
+ *  before calling this function.
+ * 
+ * =============================================================
+ */
+bool checkArrowKeys(char *cmd)
+{
+    if (((cmd[0] == ARROW_KEY_CODE_1) && (cmd[1] == ARROW_KEY_CODE_2)) &&
+        ((cmd[2] == ARROW_KEY_CODE_UP) || (cmd[2] == ARROW_KEY_CODE_DOWN) ||
+         (cmd[2] == ARROW_KEY_CODE_RIGHT) || (cmd[2] == ARROW_KEY_CODE_LEFT)))
+        return true;
+    else
+        return false;
+}
+
+/* =| checkLeadingSpaces |======================================
+ *
+ * Function to check for the leading spaces in the 
+ *  input command.
+ *
+ * If any Leading spaces are present, the function would remove 
+ *  those spaces and returns a valid Null terminated command 
+ *  in the same input cmd.
+ * 
+ * =============================================================
+ */
+void checkLeadingSpaces(char *cmd, unsigned int *num_recv)
+{
+    unsigned int leadingZerosCount = 0;
+    for (leadingZerosCount = 0; leadingZerosCount < (*num_recv); leadingZerosCount++) {
+        if (cmd[leadingZerosCount] != SPACE_BAR)
+            break;
+    }
+    if (leadingZerosCount > 0) {
+        memmove(cmd, cmd + leadingZerosCount, (*num_recv) - leadingZerosCount);
+        *num_recv = *num_recv - leadingZerosCount;
+        cmd[*num_recv] = NULL_TERMINATION;
+        ++(*num_recv);
+    }
+}
+
+uint8_t backSpaceSequence[3] = { BACK_SPACE, SPACE_BAR, BACK_SPACE };
+uint8_t abortSequence[2] = { POWER_OF, CAPITAL_C };
 /********************************************************************************/
 /******************************* Public Functions *******************************/
 /********************************************************************************/
 int cmd_get(char *cmd, size_t size)
 {
+    /* Clear the buffer before storing the command */
+    memset(cmd, 0x00, CMD_MAX_SIZE);
+
     if (cmd == NULL) {
         return E_NULL_PTR;
     } else if (size < 0) {
@@ -253,19 +320,46 @@ int cmd_get(char *cmd, size_t size)
     }
 
     bool eoc = false;
-    int num_recv = 0;
+    unsigned int num_recv = 0;
     int next_ch;
+    int backSpaceLen = (int)(sizeof(backSpaceSequence) / sizeof(backSpaceSequence[0]));
+    int abortLen = (int)(sizeof(abortSequence) / sizeof(abortSequence[0]));
 
     while (!eoc) {
         // Read character from RX FIFO, wait here until 1 is available
         while ((next_ch = MXC_UART_ReadCharacter(MXC_UART_GET_UART(CONSOLE_UART))) < E_NO_ERROR) {}
-        MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch); //Echo
-        if (next_ch == 0x08) { // backspace
-            if (num_recv != 0) {
+
+        if (next_ch == BACK_SPACE) { // backspace
+            if (num_recv > 0) {
                 num_recv--;
+                MXC_UART_Write(MXC_UART_GET_UART(CONSOLE_UART), backSpaceSequence, &backSpaceLen);
+                cmd[num_recv] = NULL_TERMINATION;
             }
-        } else { // Store character
+        } else if (next_ch == TAB_SPACE) {
+            /* Ignore Tab Space input */
+            continue;
+        } else if (next_ch == END_OF_TEXT) {
+            /* ^C abort */
+            num_recv = 0;
+            MXC_UART_Write(MXC_UART_GET_UART(CONSOLE_UART), abortSequence, &abortLen);
+            break;
+        } else {
+            /* Store character */
             cmd[num_recv++] = (char)next_ch;
+            bool arrowKey = false;
+            if (num_recv >= 3) {
+                arrowKey = checkArrowKeys(cmd + num_recv - 3);
+                if (arrowKey) {
+                    /* Remove the arrow key from the cmd */
+                    cmd[num_recv - 3] = NULL_TERMINATION;
+                    num_recv -= 3;
+                }
+            }
+            if ((!arrowKey) && ((char)next_ch != ARROW_KEY_CODE_1) &&
+                ((char)next_ch != ARROW_KEY_CODE_2)) {
+                /* Echo out if not an arrow key */
+                MXC_UART_WriteCharacter(MXC_UART_GET_UART(CONSOLE_UART), next_ch);
+            }
         }
 
         // if buffer full or EOC received, exit loop
@@ -273,7 +367,8 @@ int cmd_get(char *cmd, size_t size)
             eoc = true;
         }
     }
-
+    cmd[num_recv] = NULL_TERMINATION;
+    checkLeadingSpaces(cmd, &num_recv);
     return num_recv;
 }
 


### PR DESCRIPTION
Below are the bugs fixed in the Wear Leveling CLI example: -

1. Handling Back Space input.
2. Handling Tab Space input.
3. Handling Arrow key input.
4. Handling abort input.
5. Handling Leading spaces input.
6. Included Macros for ASCII equivalent to increase readability. 

Included Sanity check for the input commands. 
NOTE:- This code uses memmove() function to copy data in the overlapping memory segment.