### PR TITLE
fix(Examples): MSDK-1203: Update READMEs to remove outdated BOARD info

### DIFF
--- a/Examples/MAX32655/ADC/README.md
+++ b/Examples/MAX32655/ADC/README.md
@@ -15,14 +15,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/AES/README.md
+++ b/Examples/MAX32655/AES/README.md
@@ -12,14 +12,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/BLE_fit_FreeRTOS/README.md
+++ b/Examples/MAX32655/BLE_fit_FreeRTOS/README.md
@@ -39,5 +39,5 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 

--- a/Examples/MAX32655/Bootloader/README.md
+++ b/Examples/MAX32655/Bootloader/README.md
@@ -39,5 +39,5 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 

--- a/Examples/MAX32655/CRC/README.md
+++ b/Examples/MAX32655/CRC/README.md
@@ -11,14 +11,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/DMA/README.md
+++ b/Examples/MAX32655/DMA/README.md
@@ -13,14 +13,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/README.md
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/README.md
@@ -17,14 +17,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
-##### Board Selection
 
-Before building firmware you must select the correct value for _BOARD_  in "Makefile", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/README.md
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/README.md
@@ -15,15 +15,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-
-Before building firmware you must select the correct value for _BOARD_  in "Makefile", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/EEPROM_Emulator/README.md
+++ b/Examples/MAX32655/EEPROM_Emulator/README.md
@@ -52,7 +52,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX32655/External_Flash/README.md
+++ b/Examples/MAX32655/External_Flash/README.md
@@ -11,7 +11,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/FTHR_I2C/README.md
+++ b/Examples/MAX32655/FTHR_I2C/README.md
@@ -13,7 +13,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 

--- a/Examples/MAX32655/Flash/README.md
+++ b/Examples/MAX32655/Flash/README.md
@@ -25,7 +25,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Hardware Connections
 

--- a/Examples/MAX32655/Flash_CLI/README.md
+++ b/Examples/MAX32655/Flash_CLI/README.md
@@ -13,15 +13,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/FreeRTOSDemo/README.md
+++ b/Examples/MAX32655/FreeRTOSDemo/README.md
@@ -11,15 +11,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0 header. Also connect JP6 and JP7 for CTS/RTS signals. 

--- a/Examples/MAX32655/GPIO/README.md
+++ b/Examples/MAX32655/GPIO/README.md
@@ -25,14 +25,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/Hello_World/README.md
+++ b/Examples/MAX32655/Hello_World/README.md
@@ -13,7 +13,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/I2C/README.md
+++ b/Examples/MAX32655/I2C/README.md
@@ -11,14 +11,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/I2C_MNGR/README.md
+++ b/Examples/MAX32655/I2C_MNGR/README.md
@@ -15,7 +15,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.

--- a/Examples/MAX32655/I2C_SCAN/README.md
+++ b/Examples/MAX32655/I2C_SCAN/README.md
@@ -13,7 +13,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.

--- a/Examples/MAX32655/I2C_Sensor/README.md
+++ b/Examples/MAX32655/I2C_Sensor/README.md
@@ -13,7 +13,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/I2S/README.md
+++ b/Examples/MAX32655/I2S/README.md
@@ -11,7 +11,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/I2S_Playback/README.md
+++ b/Examples/MAX32655/I2S_Playback/README.md
@@ -15,7 +15,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/ICC/README.md
+++ b/Examples/MAX32655/ICC/README.md
@@ -16,14 +16,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/LP/README.md
+++ b/Examples/MAX32655/LP/README.md
@@ -11,14 +11,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/LPCMP/README.md
+++ b/Examples/MAX32655/LPCMP/README.md
@@ -13,18 +13,8 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
-## Setup
-
-##### Building Firmware:
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_RevA", depending on the EV kit you are using to run the example.
-
-After doing so, navigate to the directory where the example is located using a terminal window. Enter the following comand to build all of the files needed to run the example.
-
-```
-$ make
-```
 
 ##### Required Connections
 If using the Standard EV Kit (EvKit_V1):

--- a/Examples/MAX32655/Pulse_Train/README.md
+++ b/Examples/MAX32655/Pulse_Train/README.md
@@ -23,14 +23,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/RF_Test/README.md
+++ b/Examples/MAX32655/RF_Test/README.md
@@ -11,7 +11,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 # Usage
 

--- a/Examples/MAX32655/RTC/README.md
+++ b/Examples/MAX32655/RTC/README.md
@@ -28,14 +28,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/RTC_Backup/README.md
+++ b/Examples/MAX32655/RTC_Backup/README.md
@@ -14,14 +14,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/SPI/README.md
+++ b/Examples/MAX32655/SPI/README.md
@@ -16,14 +16,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/TFT_Demo/README.md
+++ b/Examples/MAX32655/TFT_Demo/README.md
@@ -11,15 +11,13 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured only for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions.
 
 ## Setup
 
 ##### Board Selection
 
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/TFT_Demo/resources/tft_fthr/bmp/README.md
+++ b/Examples/MAX32655/TFT_Demo/resources/tft_fthr/bmp/README.md
@@ -14,5 +14,5 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 

--- a/Examples/MAX32655/TMR/README.md
+++ b/Examples/MAX32655/TMR/README.md
@@ -29,14 +29,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/TRNG/README.md
+++ b/Examples/MAX32655/TRNG/README.md
@@ -11,14 +11,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/Temp_Monitor/README.md
+++ b/Examples/MAX32655/Temp_Monitor/README.md
@@ -19,7 +19,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Required Connections
 

--- a/Examples/MAX32655/UART/README.md
+++ b/Examples/MAX32655/UART/README.md
@@ -11,14 +11,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/UCL/README.md
+++ b/Examples/MAX32655/UCL/README.md
@@ -13,13 +13,9 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
-##### Board Selection
-
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/WUT/README.md
+++ b/Examples/MAX32655/WUT/README.md
@@ -16,14 +16,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32655/Watchdog/README.md
+++ b/Examples/MAX32655/Watchdog/README.md
@@ -24,14 +24,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the board version you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32670/Flash_CLI/README.md
+++ b/Examples/MAX32670/Flash_CLI/README.md
@@ -17,11 +17,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ## Setup
 
-##### Board Selection
-
-Before building firmware you must select the correct value for _BOARD_  in "[project.mk](project.mk)", either `EvKit_V1` or `FTHR_Apps_P1`, depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX32680/GPIO/README.md
+++ b/Examples/MAX32680/GPIO/README.md
@@ -29,10 +29,7 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ## Setup
 
-##### Board Selection
-Before building firmware you must select the correct value for _BOARD_  in "Makefile", either "EvKit\_V1" or "FTHR\_Apps\_P1", depending on the EV kit you are using to run the example.
-
-##### Required Connections
+### Required Connections
 If using the Standard EV Kit (EvKit\_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins JP4(RX_SEL) and JP5(TX_SEL) to RX0 and TX0  header.

--- a/Examples/MAX78000/CNN/mnist/README.md
+++ b/Examples/MAX78000/CNN/mnist/README.md
@@ -15,21 +15,11 @@ Universal instructions on building, flashing, and debugging this project can be 
 
 ### Project-Specific Build Notes
 
-(None - this project builds as a standard example)
+* This project comes pre-configured for the MAX32655EVKIT.  See [Board Support Packages](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#board-support-packages) in the MSDK User Guide for instructions on changing the target board.
 
 ## Setup
 
-##### Building Firmware: 
-
-Before building firmware you must select the correct value for _BOARD_  in "project.mk", either "EvKit\_V1" or "FTHR\_RevA", depending on the EV kit you are using to run the example.
-
-After doing so, navigate to the directory where the example is located using a terminal window. Enter the following comand to build all of the files needed to run the example.
-
-```
-$ make
-```
-
-##### Required Connections:
+### Required Connections:
 
 If using the MAX78000EVKIT (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.

--- a/Examples/MAX78000/Coremark/README.md
+++ b/Examples/MAX78000/Coremark/README.md
@@ -24,12 +24,10 @@ If using the Standard EvKit (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--	Select "EvKit_V1" for _BOARD_ in "project.mk"
 
 If using the Featherboard (FTHR_RevA):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR_RevA" for _BOARD_ in "project.mk"
 
 ## Expected Output
 

--- a/Examples/MAX78000/EEPROM_Emulator/README.md
+++ b/Examples/MAX78000/EEPROM_Emulator/README.md
@@ -61,14 +61,12 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--	Select "EvKit_V1" for _BOARD_ in "project.mk"
 -   Connect pins SCL - P0.30 (J4.11) and SDA - P0.31 (J4.12) to the I2C Bus
 -   Connect Ready Signal (P2.4) to the pin used for ready signal on your micro.
 
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR_RevA" for _BOARD_ in "project.mk"
 -   Connect pins SCL - P0.16 (J4.8) and SDA - P0.17 (J4.6) to the I2C Bus
 -   Connect Ready Signal - P0.19 (J4.9) to the pin used for ready signal on your micro.
 

--- a/Examples/MAX78000/Flash_CLI/README.md
+++ b/Examples/MAX78000/Flash_CLI/README.md
@@ -22,12 +22,10 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--	Select "EvKit\_V1" for _BOARD_ in "project.mk"
 
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR\_RevA" for _BOARD_ in "project.mk"
 
 ## Expected Output
 

--- a/Examples/MAX78000/FreeRTOSDemo/README.md
+++ b/Examples/MAX78000/FreeRTOSDemo/README.md
@@ -20,12 +20,10 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--	Select "EvKit_V1" for _BOARD_ in "project.mk"
 
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR_RevA" for _BOARD_ in "project.mk"
 
 ## Expected Output
 

--- a/Examples/MAX78000/Hello_World/README.md
+++ b/Examples/MAX78000/Hello_World/README.md
@@ -22,12 +22,10 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--	Select "EvKit_V1" for _BOARD_ in "project.mk"
 
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR_RevA" for _BOARD_ in "project.mk"
 
 ## Expected Output
 

--- a/Examples/MAX78000/Hello_World_Cpp/README.md
+++ b/Examples/MAX78000/Hello_World_Cpp/README.md
@@ -22,12 +22,10 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--	Select "EvKit_V1" for _BOARD_ in "project.mk"
 
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR_RevA" for _BOARD_ in "project.mk"
 
 ## Expected Output
 

--- a/Examples/MAX78000/I2C_MNGR/README.md
+++ b/Examples/MAX78000/I2C_MNGR/README.md
@@ -24,7 +24,6 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--   Select "EvKit_V1" for _BOARD_ in "Makefile"
 -   Connect P0.30, pin 8 on camera header (J4) to the SCL line of the I2C Bus.
 -   Connect P0.31, pin 6 on camera header (J4) to the SDA line of the I2C Bus.
 -   Connect two EEPROM IC's to the I2C Bus.
@@ -32,7 +31,6 @@ If using the MAX78000EVKIT (EvKit_V1):
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--   Select "FTHR_RevA" for _BOARD_ in "Makefile"
 -   Connect P0.16, "SCL" pin on header J4 to the SCL line of the I2C Bus.
 -   Connect P0.17, "SDA" pin on header J4 to the SDA line of the I2C Bus.
 -   Connect two EEPROM IC's to the I2C Bus.

--- a/Examples/MAX78000/I2C_Sensor/README.md
+++ b/Examples/MAX78000/I2C_Sensor/README.md
@@ -22,13 +22,11 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--	Select "EvKit\_V1" for _BOARD_ in "project.mk"
 -   You must connect pin 8 on camera header J4 (SCL), pin 6 on camera header J4 (SDA), VDD and GND to corresponding pins of MAX31889 EVKIT_A board (via J3 terminal)
 
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR\_RevA" for _BOARD_ in "project.mk"
 -   You must connect pin 11 on header J4 (SCL), pin 12 on header J4 (SDA), VDD and GND to corresponding pins of MAX31889 EVKIT_A board (via J3 terminal)
 
 ## Expected Output

--- a/Examples/MAX78000/Temp_Monitor/README.md
+++ b/Examples/MAX78000/Temp_Monitor/README.md
@@ -28,13 +28,11 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
 -   Close jumper JP1 (LED1 EN).
 -   Close jumper JP2 (LED2 EN).
--	Select "EvKit_V1" for _BOARD_ in "project.mk"
 -   Make the following connections between the MAX78000 and MAX31889 EV Kits: P0.30-->SCL(J2.11), P0.31-->SDA(J2.12), VDDIO(JP9.3)-->VDD(J1.2), GND-->GND(J1.4)
 
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR_RevA" for _BOARD_ in "project.mk"
 -   Make the following connections between the MAX78000 and MAX31889 EV Kits: P0.16(J4.11)-->SCL(J2.11), P0.17(J4.12)-->SDA(J2.12), 3V3(J8.2)-->VDD(J1.2), GND(J8.4)-->GND(J1.4)
 
 ## Expected Output

--- a/Examples/MAX78000/UCL/README.md
+++ b/Examples/MAX78000/UCL/README.md
@@ -20,12 +20,10 @@ If using the MAX78000EVKIT (EvKit_V1):
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -   Connect pins 1 and 2 (P0_1) of the JH1 (UART 0 EN) header.
 -   Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "EvKit_V1" for _BOARD_ in "project.mk"
 
 If using the MAX78000FTHR (FTHR_RevA)
 -   Connect a USB cable between the PC and the CN1 (USB/PWR) connector.
 -	Open a terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
--	Select "FTHR_RevA" for _BOARD_ in "project.mk"
 
 ## Expected Output
 


### PR DESCRIPTION
Updated board info for MAX32655, MAX32670, MAX32680 and MAX78000.
Issue captured in [MSDK-1203](https://jira.maxim-ic.com/browse/MSDK-1203)