### PR TITLE
fix(Examples)!: Require DMA Channel as Input Argument for ADC DMA Conversions, Fix ADC DMA Transfer Bug for Channels > 0

### DIFF
--- a/Documentation/CONTRIBUTING.md
+++ b/Documentation/CONTRIBUTING.md
@@ -275,10 +275,11 @@ The `Documentation/build.py` script can be used to build the MSDK User Guide and
 To **build** the docs:
 
 1. Install [doxygen](https://www.doxygen.nl/download.html)
-2. Install Python 3
-3. `pip install -r Documentation/requirements.txt`
-4. `python Documentation/build.py`
-5. The site will be built in the `docs` folder of the repo.
+2. Add doxygen's binary diretory to the [Environmental Path](https://learn.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ee537574(v=office.14)) Variable
+3. Install Python 3
+4. `pip install -r Documentation/requirements.txt`
+5. `python Documentation/build.py`
+6. The site will be built in the `docs` folder of the repo.
 
 To **preview** the generated site:
 

--- a/Examples/MAX32662/ADC/main.c
+++ b/Examples/MAX32662/ADC/main.c
@@ -362,8 +362,8 @@ int main(void)
         int dma_channel = MXC_DMA_AcquireChannel();
         adc_conv.dma_channel = dma_channel;
 
-        MXC_NVIC_SetVector(MXC_DMA_GET_IRQ(dma_channel), DMA_IRQHandler);
-        NVIC_EnableIRQ(MXC_DMA_GET_IRQ(dma_channel));
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(dma_channel), DMA_IRQHandler);
+        NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(dma_channel));
         MXC_ADC_StartConversionDMA(&adc_conv, adc_val, adc_dma_callback);
 
         while (!dma_done) {}

--- a/Examples/MAX32662/ADC/main.c
+++ b/Examples/MAX32662/ADC/main.c
@@ -128,7 +128,7 @@ void adc_dma_callback(int ch, int err)
     dma_done = 1;
 }
 
-void DMA0_IRQHandler(void)
+void DMA_IRQHandler(void)
 {
     MXC_DMA_Handler();
 }
@@ -335,7 +335,6 @@ int main(void)
 
 #ifdef DMA
     MXC_DMA_Init();
-    NVIC_EnableIRQ(DMA0_IRQn);
 #endif
     while (1) {
         /* Flash LED when starting ADC cycle */
@@ -360,10 +359,16 @@ int main(void)
 #ifdef DMA
         dma_done = 0;
 
-        MXC_DMA_ReleaseChannel(0);
+        int dma_channel = MXC_DMA_AcquireChannel();
+        adc_conv.dma_channel = dma_channel;
+
+        MXC_NVIC_SetVector(MXC_DMA_GET_IRQ(dma_channel), DMA_IRQHandler);
+        NVIC_EnableIRQ(MXC_DMA_GET_IRQ(dma_channel));
         MXC_ADC_StartConversionDMA(&adc_conv, adc_val, adc_dma_callback);
 
         while (!dma_done) {}
+
+        MXC_DMA_ReleaseChannel(adc_conv.dma_channel);
 #endif
 
         ShowAdcResult();

--- a/Examples/MAX32672/ADC/main.c
+++ b/Examples/MAX32672/ADC/main.c
@@ -147,7 +147,7 @@ void adc_dma_callback(int ch, int err)
     dma_done = 1;
 }
 
-void DMA0_IRQHandler(void)
+void DMA_IRQHandler(void)
 {
     MXC_DMA_Handler();
 }
@@ -375,7 +375,6 @@ int main(void)
 
 #ifdef DMA
     MXC_DMA_Init();
-    NVIC_EnableIRQ(DMA0_IRQn);
 #endif
 
     while (1) {
@@ -383,7 +382,6 @@ int main(void)
         LED_On(0);
         MXC_TMR_Delay(MXC_TMR0, MSEC(10));
         LED_Off(0);
-
 #ifdef POLLING
         adc_temp_conversion();
         WaitforConversionComplete();
@@ -414,10 +412,16 @@ int main(void)
             MXC_TMR_Delay(MXC_TMR0, USEC(500));
         }
 
-        MXC_DMA_ReleaseChannel(0);
+        int dma_channel = MXC_DMA_AcquireChannel();
+        adc_conv.dma_channel = dma_channel;
+
+        MXC_NVIC_SetVector(MXC_DMA_GET_IRQ(dma_channel), DMA_IRQHandler);
+        NVIC_EnableIRQ(MXC_DMA_GET_IRQ(dma_channel));
         MXC_ADC_StartConversionDMA(&adc_conv, &adc_val[0], adc_dma_callback);
 
         while (!dma_done) {}
+
+        MXC_DMA_ReleaseChannel(adc_conv.dma_channel);
 #endif
         ShowAdcResult();
 

--- a/Examples/MAX32672/ADC/main.c
+++ b/Examples/MAX32672/ADC/main.c
@@ -415,8 +415,8 @@ int main(void)
         int dma_channel = MXC_DMA_AcquireChannel();
         adc_conv.dma_channel = dma_channel;
 
-        MXC_NVIC_SetVector(MXC_DMA_GET_IRQ(dma_channel), DMA_IRQHandler);
-        NVIC_EnableIRQ(MXC_DMA_GET_IRQ(dma_channel));
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(dma_channel), DMA_IRQHandler);
+        NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(dma_channel));
         MXC_ADC_StartConversionDMA(&adc_conv, &adc_val[0], adc_dma_callback);
 
         while (!dma_done) {}

--- a/Examples/MAX32690/ADC/main.c
+++ b/Examples/MAX32690/ADC/main.c
@@ -456,8 +456,8 @@ int main(void)
         int dma_channel = MXC_DMA_AcquireChannel();
         adc_conv.dma_channel = dma_channel;
 
-        MXC_NVIC_SetVector(MXC_DMA_GET_IRQ(dma_channel), DMA_IRQHandler);
-        NVIC_EnableIRQ(MXC_DMA_GET_IRQ(dma_channel));
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(dma_channel), DMA_IRQHandler);
+        NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(dma_channel));
         MXC_ADC_StartConversionDMA(&adc_conv, &adc_val[0], adc_dma_callback);
 
         while (!dma_done) {}

--- a/Examples/MAX32690/ADC/main.c
+++ b/Examples/MAX32690/ADC/main.c
@@ -138,7 +138,7 @@ void adc_dma_callback(int ch, int err)
     dma_done = 1;
 }
 
-void DMA0_IRQHandler(void)
+void DMA_IRQHandler(void)
 {
     MXC_DMA_Handler();
 }
@@ -416,7 +416,6 @@ int main(void)
 
 #ifdef DMA
     MXC_DMA_Init();
-    NVIC_EnableIRQ(DMA0_IRQn);
 #endif
     while (1) {
         /* Flash LED when starting ADC cycle */
@@ -454,10 +453,16 @@ int main(void)
             MXC_TMR_Delay(MXC_TMR0, USEC(500));
         }
 
-        MXC_DMA_ReleaseChannel(0);
+        int dma_channel = MXC_DMA_AcquireChannel();
+        adc_conv.dma_channel = dma_channel;
+
+        MXC_NVIC_SetVector(MXC_DMA_GET_IRQ(dma_channel), DMA_IRQHandler);
+        NVIC_EnableIRQ(MXC_DMA_GET_IRQ(dma_channel));
         MXC_ADC_StartConversionDMA(&adc_conv, &adc_val[0], adc_dma_callback);
 
         while (!dma_done) {}
+
+        MXC_DMA_ReleaseChannel(adc_conv.dma_channel);
 #endif
         ShowAdcResult();
 

--- a/Examples/MAX78002/ADC/main.c
+++ b/Examples/MAX78002/ADC/main.c
@@ -143,7 +143,7 @@ void adc_dma_callback(int ch, int err)
     dma_done = 1;
 }
 
-void DMA0_IRQHandler(void)
+void DMA_IRQHandler(void)
 {
     MXC_DMA_Handler();
 }
@@ -385,7 +385,6 @@ int main(void)
 
 #ifdef DMA
     MXC_DMA_Init();
-    NVIC_EnableIRQ(DMA0_IRQn);
 #endif
     while (1) {
         /* Flash LED when starting ADC cycle */
@@ -423,10 +422,16 @@ int main(void)
             MXC_TMR_Delay(MXC_TMR0, USEC(500));
         }
 
-        MXC_DMA_ReleaseChannel(0);
-        MXC_ADC_StartConversionDMA(&adc_conv, &adc_val[0], adc_dma_callback);
+        int dma_channel = MXC_DMA_AcquireChannel();
+        adc_conv.dma_channel = dma_channel;
+
+        MXC_NVIC_SetVector(MXC_DMA_GET_IRQ(dma_channel), DMA_IRQHandler);
+        NVIC_EnableIRQ(MXC_DMA_GET_IRQ(dma_channel));
+        MXC_ADC_StartConversionDMA(&adc_conv, adc_val, adc_dma_callback);
 
         while (!dma_done) {}
+
+        MXC_DMA_ReleaseChannel(adc_conv.dma_channel);
 #endif
         ShowAdcResult();
 

--- a/Examples/MAX78002/ADC/main.c
+++ b/Examples/MAX78002/ADC/main.c
@@ -425,8 +425,8 @@ int main(void)
         int dma_channel = MXC_DMA_AcquireChannel();
         adc_conv.dma_channel = dma_channel;
 
-        MXC_NVIC_SetVector(MXC_DMA_GET_IRQ(dma_channel), DMA_IRQHandler);
-        NVIC_EnableIRQ(MXC_DMA_GET_IRQ(dma_channel));
+        MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(dma_channel), DMA_IRQHandler);
+        NVIC_EnableIRQ(MXC_DMA_CH_GET_IRQ(dma_channel));
         MXC_ADC_StartConversionDMA(&adc_conv, adc_val, adc_dma_callback);
 
         while (!dma_done) {}

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.h
@@ -375,12 +375,12 @@ typedef enum {
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
-#define MXC_DMA_GET_IRQ(i)             \
-    (IRQn_Type)((i) == 0 ? DMA0_IRQn : \
-                (i) == 1 ? DMA1_IRQn : \
-                (i) == 2 ? DMA2_IRQn : \
-                (i) == 3 ? DMA3_IRQn : \
-                           0)
+#define MXC_DMA_CH_GET_IRQ(i)             \
+    ((IRQn_Type)(((i) == 0) ? DMA0_IRQn : \
+                 ((i) == 1) ? DMA1_IRQn : \
+                 ((i) == 2) ? DMA2_IRQn : \
+                 ((i) == 3) ? DMA3_IRQn : \
+                              0))
 
 /******************************************************************************/
 /*                                                                        FLC */

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/max32662.h
@@ -375,6 +375,13 @@ typedef enum {
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
+#define MXC_DMA_GET_IRQ(i)             \
+    (IRQn_Type)((i) == 0 ? DMA0_IRQn : \
+                (i) == 1 ? DMA1_IRQn : \
+                (i) == 2 ? DMA2_IRQn : \
+                (i) == 3 ? DMA3_IRQn : \
+                           0)
+
 /******************************************************************************/
 /*                                                                        FLC */
 #define MXC_FLC_INSTANCES (1)

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
@@ -444,20 +444,20 @@ mxc_aes_regs_t mxc_sys_aes_regs_t;
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
-#define MXC_DMA_GET_IRQ(i)               \
-    (IRQn_Type)((i) == 0  ? DMA0_IRQn :  \
-                (i) == 1  ? DMA1_IRQn :  \
-                (i) == 2  ? DMA2_IRQn :  \
-                (i) == 3  ? DMA3_IRQn :  \
-                (i) == 4  ? DMA4_IRQn :  \
-                (i) == 5  ? DMA5_IRQn :  \
-                (i) == 6  ? DMA6_IRQn :  \
-                (i) == 7  ? DMA7_IRQn :  \
-                (i) == 8  ? DMA8_IRQn :  \
-                (i) == 9  ? DMA9_IRQn :  \
-                (i) == 10 ? DMA10_IRQn : \
-                (i) == 11 ? DMA11_IRQn : \
-                            0)
+#define MXC_DMA_CH_GET_IRQ(i)               \
+    ((IRQn_Type)(((i) == 0)  ? DMA0_IRQn :  \
+                 ((i) == 1)  ? DMA1_IRQn :  \
+                 ((i) == 2)  ? DMA2_IRQn :  \
+                 ((i) == 3)  ? DMA3_IRQn :  \
+                 ((i) == 4)  ? DMA4_IRQn :  \
+                 ((i) == 5)  ? DMA5_IRQn :  \
+                 ((i) == 6)  ? DMA6_IRQn :  \
+                 ((i) == 7)  ? DMA7_IRQn :  \
+                 ((i) == 8)  ? DMA8_IRQn :  \
+                 ((i) == 9)  ? DMA9_IRQn :  \
+                 ((i) == 10) ? DMA10_IRQn : \
+                 ((i) == 11) ? DMA11_IRQn : \
+                               0))
 
 /******************************************************************************/
 /*                                                                        FLC */

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
@@ -444,20 +444,20 @@ mxc_aes_regs_t mxc_sys_aes_regs_t;
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
-#define MXC_DMA_GET_IRQ(i)             \
-    (IRQn_Type)((i) == 0 ? DMA0_IRQn : \
-                (i) == 1 ? DMA1_IRQn : \
-                (i) == 2 ? DMA2_IRQn : \
-                (i) == 3 ? DMA3_IRQn : \
-                (i) == 4 ? DMA4_IRQn : \
-                (i) == 5 ? DMA5_IRQn : \
-                (i) == 6 ? DMA6_IRQn : \
-                (i) == 7 ? DMA7_IRQn : \
-                (i) == 8 ? DMA8_IRQn : \
-                (i) == 9 ? DMA9_IRQn : \
+#define MXC_DMA_GET_IRQ(i)               \
+    (IRQn_Type)((i) == 0  ? DMA0_IRQn :  \
+                (i) == 1  ? DMA1_IRQn :  \
+                (i) == 2  ? DMA2_IRQn :  \
+                (i) == 3  ? DMA3_IRQn :  \
+                (i) == 4  ? DMA4_IRQn :  \
+                (i) == 5  ? DMA5_IRQn :  \
+                (i) == 6  ? DMA6_IRQn :  \
+                (i) == 7  ? DMA7_IRQn :  \
+                (i) == 8  ? DMA8_IRQn :  \
+                (i) == 9  ? DMA9_IRQn :  \
                 (i) == 10 ? DMA10_IRQn : \
                 (i) == 11 ? DMA11_IRQn : \
-                           0)
+                            0)
 
 /******************************************************************************/
 /*                                                                        FLC */

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
@@ -444,6 +444,21 @@ mxc_aes_regs_t mxc_sys_aes_regs_t;
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
+#define MXC_DMA_GET_IRQ(i)             \
+    (IRQn_Type)((i) == 0 ? DMA0_IRQn : \
+                (i) == 1 ? DMA1_IRQn : \
+                (i) == 2 ? DMA2_IRQn : \
+                (i) == 3 ? DMA3_IRQn : \
+                (i) == 4 ? DMA4_IRQn : \
+                (i) == 5 ? DMA5_IRQn : \
+                (i) == 6 ? DMA6_IRQn : \
+                (i) == 7 ? DMA7_IRQn : \
+                (i) == 8 ? DMA8_IRQn : \
+                (i) == 9 ? DMA9_IRQn : \
+                (i) == 10 ? DMA10_IRQn : \
+                (i) == 11 ? DMA11_IRQn : \
+                           0)
+
 /******************************************************************************/
 /*                                                                        FLC */
 #define MXC_FLC_INSTANCES (2)

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
@@ -541,6 +541,24 @@ typedef enum {
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
+#define MXC_DMA_GET_IRQ(i)               \
+    (IRQn_Type)((i) == 0  ? DMA0_IRQn :  \
+                (i) == 1  ? DMA1_IRQn :  \
+                (i) == 2  ? DMA2_IRQn :  \
+                (i) == 3  ? DMA3_IRQn :  \
+                (i) == 4  ? DMA4_IRQn :  \
+                (i) == 5  ? DMA5_IRQn :  \
+                (i) == 6  ? DMA6_IRQn :  \
+                (i) == 7  ? DMA7_IRQn :  \
+                (i) == 8  ? DMA8_IRQn :  \
+                (i) == 9  ? DMA9_IRQn :  \
+                (i) == 10 ? DMA10_IRQn : \
+                (i) == 11 ? DMA11_IRQn : \
+                (i) == 12 ? DMA12_IRQn : \
+                (i) == 13 ? DMA13_IRQn : \
+                (i) == 14 ? DMA14_IRQn : \
+                (i) == 15 ? DMA15_IRQn : \
+                            0)
 /******************************************************************************/
 /*                                                                        FLC */
 #define MXC_FLC_INSTANCES (2)

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.h
@@ -541,24 +541,25 @@ typedef enum {
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
-#define MXC_DMA_GET_IRQ(i)               \
-    (IRQn_Type)((i) == 0  ? DMA0_IRQn :  \
-                (i) == 1  ? DMA1_IRQn :  \
-                (i) == 2  ? DMA2_IRQn :  \
-                (i) == 3  ? DMA3_IRQn :  \
-                (i) == 4  ? DMA4_IRQn :  \
-                (i) == 5  ? DMA5_IRQn :  \
-                (i) == 6  ? DMA6_IRQn :  \
-                (i) == 7  ? DMA7_IRQn :  \
-                (i) == 8  ? DMA8_IRQn :  \
-                (i) == 9  ? DMA9_IRQn :  \
-                (i) == 10 ? DMA10_IRQn : \
-                (i) == 11 ? DMA11_IRQn : \
-                (i) == 12 ? DMA12_IRQn : \
-                (i) == 13 ? DMA13_IRQn : \
-                (i) == 14 ? DMA14_IRQn : \
-                (i) == 15 ? DMA15_IRQn : \
-                            0)
+#define MXC_DMA_CH_GET_IRQ(i)               \
+    ((IRQn_Type)(((i) == 0)  ? DMA0_IRQn :  \
+                 ((i) == 1)  ? DMA1_IRQn :  \
+                 ((i) == 2)  ? DMA2_IRQn :  \
+                 ((i) == 3)  ? DMA3_IRQn :  \
+                 ((i) == 4)  ? DMA4_IRQn :  \
+                 ((i) == 5)  ? DMA5_IRQn :  \
+                 ((i) == 6)  ? DMA6_IRQn :  \
+                 ((i) == 7)  ? DMA7_IRQn :  \
+                 ((i) == 8)  ? DMA8_IRQn :  \
+                 ((i) == 9)  ? DMA9_IRQn :  \
+                 ((i) == 10) ? DMA10_IRQn : \
+                 ((i) == 11) ? DMA11_IRQn : \
+                 ((i) == 12) ? DMA12_IRQn : \
+                 ((i) == 13) ? DMA13_IRQn : \
+                 ((i) == 14) ? DMA14_IRQn : \
+                 ((i) == 15) ? DMA15_IRQn : \
+                               0))
+
 /******************************************************************************/
 /*                                                                        FLC */
 #define MXC_FLC_INSTANCES (2)

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.h
@@ -502,7 +502,7 @@ typedef enum {
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
-#define MXC_DMA_GET_IRQ(i) ((IRQn_Type)(((i) == 0) ? DMA0_IRQn : ((i) == 1) ? DMA1_IRQn : \
+#define MXC_DMA_CH_GET_IRQ(i) ((IRQn_Type)(((i) == 0) ? DMA0_IRQn : ((i) == 1) ? DMA1_IRQn : \
                                 ((i) == 2) ? DMA2_IRQn : ((i) == 3) ? DMA3_IRQn : 0))
 
 /******************************************************************************/

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.h
@@ -502,7 +502,7 @@ typedef enum {
 
 #define MXC_DMA_GET_IDX(p) ((p) == MXC_DMA ? 0 : -1)
 
-#define MXC_DMA_CH_GET_IRQ(i) ((IRQn_Type)(((i) == 0) ? DMA0_IRQn : ((i) == 1) ? DMA1_IRQn : \
+#define MXC_DMA_GET_IRQ(i) ((IRQn_Type)(((i) == 0) ? DMA0_IRQn : ((i) == 1) ? DMA1_IRQn : \
                                 ((i) == 2) ? DMA2_IRQn : ((i) == 3) ? DMA3_IRQn : 0))
 
 /******************************************************************************/

--- a/Libraries/PeriphDrivers/Include/MAX32662/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/adc.h
@@ -202,7 +202,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number for this field
+    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number
 } mxc_adc_conversion_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32662/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/adc.h
@@ -202,7 +202,10 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number
+    int8_t dma_channel; /*!<The channel to use for DMA-enabled transactions.
+                            Users should call \ref MXC_DMA_AcquireChannel
+                            to assign the DMA channel number.
+                            For non-DMA transactions, this field is ignored.*/
 } mxc_adc_conversion_req_t;
 
 /**
@@ -269,6 +272,10 @@ int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
  * @brief   Perform a conversion on a specific channel using a DMA transfer
+ * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel
+ *          and should be passed via req input struct.
+ *          DMA Interrupt should be enabled using \ref NVIC_EnableIRQ and the
+ *          correct DMA IRQ must be enabled using \ref MXC_NVIC_SetVector by the user.
  *
  * @param   req \ref mxc_adc_conversion_req_t
  * @param   pointer to the variable to hold the conversion result

--- a/Libraries/PeriphDrivers/Include/MAX32662/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/adc.h
@@ -193,10 +193,16 @@ typedef struct {
     uint32_t idleCount; ///< Sample Clock Low time
 } mxc_adc_req_t;
 
+/**
+ * @brief  ADC Slot Settings
+ */
 typedef struct {
     mxc_adc_chsel_t channel; ///< channel select
 } mxc_adc_slot_req_t;
 
+/**
+ * @brief  ADC Conversion Settings
+ */
 typedef struct {
     mxc_adc_conversion_mode_t mode; ///< conversion mode
     mxc_adc_trig_mode_t trig; ///< trigger mode

--- a/Libraries/PeriphDrivers/Include/MAX32662/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/adc.h
@@ -52,6 +52,7 @@ extern "C" {
 /**
  * @defgroup adc ADC
  * @ingroup periphlibs
+ * @details API for Analog to Digital Converter (ADC).
  * @{
  */
 
@@ -180,6 +181,9 @@ typedef enum {
 ///< Callback used when a conversion event is complete
 typedef void (*mxc_adc_complete_cb_t)(void *req, int error);
 
+/**
+ * @brief  ADC Settings
+ */
 typedef struct {
     mxc_adc_clock_t clock; ///< clock to use
     mxc_adc_clkdiv_t clkdiv; ///< clock divider
@@ -272,10 +276,10 @@ int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
  * @brief   Perform a conversion on a specific channel using a DMA transfer
- * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel
- *          and should be passed via req input struct.
- *          DMA Interrupt should be enabled using \ref NVIC_EnableIRQ and the
- *          correct DMA IRQ must be enabled using \ref MXC_NVIC_SetVector by the user.
+ * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
+ *          be passed to this function via "dma_channel" member of "req" input struct.
+ *          DMA IRQ corresponding to that channel must be enabled using \ref MXC_NVIC_SetVector,
+ *          and the \ref MXC_DMA_Handler should be called from the respective ISR.
  *
  * @param   req \ref mxc_adc_conversion_req_t
  * @param   pointer to the variable to hold the conversion result

--- a/Libraries/PeriphDrivers/Include/MAX32662/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/adc.h
@@ -206,10 +206,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; /*!<The channel to use for DMA-enabled transactions.
-                            Users should call \ref MXC_DMA_AcquireChannel
-                            to assign the DMA channel number.
-                            For non-DMA transactions, this field is ignored.*/
+    int8_t dma_channel; ///<The channel to use for DMA-enabled transactions
 } mxc_adc_conversion_req_t;
 
 /**
@@ -275,8 +272,8 @@ int MXC_ADC_StartConversion(void);
 int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
- * @brief   Perform a conversion on a specific channel using a DMA transfer
- * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
+ * @brief   Perform a conversion on a specific channel using a DMA transfer.
+ *          DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
  *          be passed to this function via "dma_channel" member of "req" input struct.
  *          DMA IRQ corresponding to that channel must be enabled using \ref MXC_NVIC_SetVector,
  *          and the \ref MXC_DMA_Handler should be called from the respective ISR.

--- a/Libraries/PeriphDrivers/Include/MAX32662/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/adc.h
@@ -202,6 +202,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
+    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number for this field
 } mxc_adc_conversion_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32672/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/adc.h
@@ -246,6 +246,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
+    int8_t dma_channel; ///< DMA channel number for DMA transfer
 } mxc_adc_conversion_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32672/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/adc.h
@@ -235,12 +235,18 @@ typedef struct {
     uint32_t idleCount; ///< Sample Clock Low time
 } mxc_adc_req_t;
 
+/**
+ * @brief  ADC Slot Settings
+ */
 typedef struct {
     mxc_adc_chsel_t channel; ///< channel select
     mxc_adc_divsel_t div; ///< Analog input divider
     mxc_adc_dynamic_pullup_t pullup_dyn; ///< Dynamic Pullup
 } mxc_adc_slot_req_t;
 
+/**
+ * @brief  ADC Conversion Settings
+ */
 typedef struct {
     mxc_adc_conversion_mode_t mode; ///< conversion mode
     mxc_adc_trig_mode_t trig; ///< trigger mode

--- a/Libraries/PeriphDrivers/Include/MAX32672/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/adc.h
@@ -246,7 +246,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; ///< DMA channel number for DMA transfer
+    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number
 } mxc_adc_conversion_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32672/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/adc.h
@@ -250,10 +250,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; /*!<The channel to use for DMA-enabled transactions.
-                            Users should call \ref MXC_DMA_AcquireChannel
-                            to assign the DMA channel number.
-                            For non-DMA transactions, this field is ignored.*/
+    int8_t dma_channel; ///<The channel to use for DMA-enabled transactions
 } mxc_adc_conversion_req_t;
 
 /**
@@ -319,8 +316,8 @@ int MXC_ADC_StartConversion(void);
 int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
- * @brief   Perform a conversion on a specific channel using a DMA transfer
- * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
+ * @brief   Perform a conversion on a specific channel using a DMA transfer.
+ *          DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
  *          be passed to this function via "dma_channel" member of "req" input struct.
  *          DMA IRQ corresponding to that channel must be enabled using \ref MXC_NVIC_SetVector,
  *          and the \ref MXC_DMA_Handler should be called from the respective ISR.

--- a/Libraries/PeriphDrivers/Include/MAX32672/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/adc.h
@@ -52,6 +52,7 @@ extern "C" {
 /**
  * @defgroup adc ADC
  * @ingroup periphlibs
+ * @details API for Analog to Digital Converter (ADC).
  * @{
  */
 
@@ -222,6 +223,9 @@ typedef enum {
 ///< Callback used when a conversion event is complete
 typedef void (*mxc_adc_complete_cb_t)(void *req, int error);
 
+/**
+ * @brief  ADC Settings
+ */
 typedef struct {
     mxc_adc_clock_t clock; ///< clock to use
     mxc_adc_clkdiv_t clkdiv; ///< clock divider
@@ -246,7 +250,10 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number
+    int8_t dma_channel; /*!<The channel to use for DMA-enabled transactions.
+                            Users should call \ref MXC_DMA_AcquireChannel
+                            to assign the DMA channel number.
+                            For non-DMA transactions, this field is ignored.*/
 } mxc_adc_conversion_req_t;
 
 /**
@@ -313,7 +320,11 @@ int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
  * @brief   Perform a conversion on a specific channel using a DMA transfer
- *
+ * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
+ *          be passed to this function via "dma_channel" member of "req" input struct.
+ *          DMA IRQ corresponding to that channel must be enabled using \ref MXC_NVIC_SetVector,
+ *          and the \ref MXC_DMA_Handler should be called from the respective ISR.
+ * 
  * @param   req \ref mxc_adc_conversion_req_t
  * @param   pointer to the variable to hold the conversion result
  * @param   callback the function to call when the conversion is complete

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -217,12 +217,18 @@ typedef struct {
     uint32_t idleCount; ///< Sample Clock Low time
 } mxc_adc_req_t;
 
+/**
+ * @brief  ADC Slot Settings
+ */
 typedef struct {
     mxc_adc_chsel_t channel; ///< channel select
     //    mxc_adc_divsel_t div;                    ///< Analog input divider
     //    mxc_adc_dynamic_pullup_t pullup_dyn;     ///< Dynamic Pullup
 } mxc_adc_slot_req_t;
 
+/**
+ * @brief  ADC Conversion Settings
+ */
 typedef struct {
     mxc_adc_conversion_mode_t mode; ///< conversion mode
     mxc_adc_trig_mode_t trig; ///< trigger mode

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -232,10 +232,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; /*!<The channel to use for DMA-enabled transactions.
-                            Users should call \ref MXC_DMA_AcquireChannel
-                            to assign the DMA channel number.
-                            For non-DMA transactions, this field is ignored.*/
+    int8_t dma_channel; ///<The channel to use for DMA-enabled transactions
 } mxc_adc_conversion_req_t;
 
 /**
@@ -310,8 +307,8 @@ int MXC_ADC_StartConversion(void);
 int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
- * @brief   Perform a conversion on a specific channel using a DMA transfer
- * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
+ * @brief   Perform a conversion on a specific channel using a DMA transfer.
+ *          DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
  *          be passed to this function via "dma_channel" member of "req" input struct.
  *          DMA IRQ corresponding to that channel must be enabled using \ref MXC_NVIC_SetVector,
  *          and the \ref MXC_DMA_Handler should be called from the respective ISR.

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -228,7 +228,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number for this field
+    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number
 } mxc_adc_conversion_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -52,6 +52,7 @@ extern "C" {
 /**
  * @defgroup adc ADC
  * @ingroup periphlibs
+ * @details API for Analog to Digital Converter (ADC).
  * @{
  */
 
@@ -204,6 +205,9 @@ typedef enum {
 ///< Callback used when a conversion event is complete
 typedef void (*mxc_adc_complete_cb_t)(void *req, int error);
 
+/**
+ * @brief  ADC Settings
+ */
 typedef struct {
     mxc_adc_clock_t clock; ///< clock to use
     mxc_adc_clkdiv_t clkdiv; ///< clock divider
@@ -228,7 +232,10 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number
+    int8_t dma_channel; /*!<The channel to use for DMA-enabled transactions.
+                            Users should call \ref MXC_DMA_AcquireChannel
+                            to assign the DMA channel number.
+                            For non-DMA transactions, this field is ignored.*/
 } mxc_adc_conversion_req_t;
 
 /**
@@ -304,7 +311,11 @@ int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
  * @brief   Perform a conversion on a specific channel using a DMA transfer
- *
+ * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
+ *          be passed to this function via "dma_channel" member of "req" input struct.
+ *          DMA IRQ corresponding to that channel must be enabled using \ref MXC_NVIC_SetVector,
+ *          and the \ref MXC_DMA_Handler should be called from the respective ISR.
+ * 
  * @param   req \ref mxc_adc_conversion_req_t
  * @param   pointer to the variable to hold the conversion result
  * @param   callback the function to call when the conversion is complete

--- a/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -228,6 +228,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
+    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number for this field
 } mxc_adc_conversion_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78002/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/adc.h
@@ -248,6 +248,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
+    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number for this field
 } mxc_adc_conversion_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78002/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/adc.h
@@ -237,12 +237,18 @@ typedef struct {
     uint32_t idleCount; ///< Sample Clock Low time
 } mxc_adc_req_t;
 
+/**
+ * @brief  ADC Slot Settings
+ */
 typedef struct {
     mxc_adc_chsel_t channel; ///< channel select
     mxc_adc_divsel_t div; ///< Analog input divider
     mxc_adc_dynamic_pullup_t pullup_dyn; ///< Dynamic Pullup
 } mxc_adc_slot_req_t;
 
+/**
+ * @brief  ADC Conversion Settings
+ */
 typedef struct {
     mxc_adc_conversion_mode_t mode; ///< conversion mode
     mxc_adc_trig_mode_t trig; ///< trigger mode

--- a/Libraries/PeriphDrivers/Include/MAX78002/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/adc.h
@@ -52,6 +52,7 @@ extern "C" {
 /**
  * @defgroup adc ADC
  * @ingroup periphlibs
+ * @details API for Analog to Digital Converter (ADC).
  * @{
  */
 
@@ -224,6 +225,9 @@ typedef enum {
 ///< Callback used when a conversion event is complete
 typedef void (*mxc_adc_complete_cb_t)(void *req, int error);
 
+/**
+ * @brief  ADC Settings
+ */
 typedef struct {
     mxc_adc_clock_t clock; ///< clock to use
     mxc_adc_clkdiv_t clkdiv; ///< clock divider
@@ -248,7 +252,10 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number
+    int8_t dma_channel; /*!<The channel to use for DMA-enabled transactions.
+                            Users should call \ref MXC_DMA_AcquireChannel
+                            to assign the DMA channel number.
+                            For non-DMA transactions, this field is ignored.*/
 } mxc_adc_conversion_req_t;
 
 /**
@@ -315,6 +322,10 @@ int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
  * @brief   Perform a conversion on a specific channel using a DMA transfer
+ * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
+ *          be passed to this function via "dma_channel" member of "req" input struct.
+ *          DMA IRQ corresponding to that channel must be enabled using \ref MXC_NVIC_SetVector,
+ *          and the \ref MXC_DMA_Handler should be called from the respective ISR.
  *
  * @param   req \ref mxc_adc_conversion_req_t
  * @param   pointer to the variable to hold the conversion result

--- a/Libraries/PeriphDrivers/Include/MAX78002/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/adc.h
@@ -248,7 +248,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number for this field
+    int8_t dma_channel; ///< User should call MXC_DMA_AcquireChannel() to assign DMA Channel number
 } mxc_adc_conversion_req_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78002/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/adc.h
@@ -252,10 +252,7 @@ typedef struct {
     mxc_adc_avg_t avg_number; ///< no of samples to average
     mxc_adc_div_lpmode_t lpmode_divder; ///< Divide by 2 control in lpmode
     uint8_t num_slots; ///< num of slots in the sequence
-    int8_t dma_channel; /*!<The channel to use for DMA-enabled transactions.
-                            Users should call \ref MXC_DMA_AcquireChannel
-                            to assign the DMA channel number.
-                            For non-DMA transactions, this field is ignored.*/
+    int8_t dma_channel; ///<The channel to use for DMA-enabled transactions
 } mxc_adc_conversion_req_t;
 
 /**
@@ -321,8 +318,8 @@ int MXC_ADC_StartConversion(void);
 int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
- * @brief   Perform a conversion on a specific channel using a DMA transfer
- * @note    DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
+ * @brief   Perform a conversion on a specific channel using a DMA transfer.
+ *          DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
  *          be passed to this function via "dma_channel" member of "req" input struct.
  *          DMA IRQ corresponding to that channel must be enabled using \ref MXC_NVIC_SetVector,
  *          and the \ref MXC_DMA_Handler should be called from the respective ISR.

--- a/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
@@ -214,7 +214,7 @@ int MXC_ADC_RevB_StartConversionDMA(mxc_adc_revb_regs_t *adc, mxc_adc_conversion
 
     num_bytes = (req->num_slots + 1) * 4; //Support 8 slots (32 bytes) only. (TODO)
 
-    channel = MXC_DMA_AcquireChannel();
+    channel = req->dma_channel;
 
     config.reqsel = MXC_S_DMA_CTRL_REQUEST_ADC;
     config.ch = channel;


### PR DESCRIPTION
Fixed the DMA transfer over multiple channels for ADC example in the MAX32672 board, and the corresponding JIRA ticket is [here](https://jira.maxim-ic.com/projects/MSDK/issues/MSDK-1218?filter=allopenissues)

This PR contains the fix for all example codes that uses ADC Rev B, which includes MAX32662, MAX32672, MAX32690, MAX78002.