### PR TITLE
fix(BLE,Examples): Log packet count on BLE dats speed test

### DIFF
--- a/Examples/MAX32655/BLE_dats/dats_main.c
+++ b/Examples/MAX32655/BLE_dats/dats_main.c
@@ -422,12 +422,19 @@ static void trimStart(void)
 uint8_t datsWpWriteCback(dmConnId_t connId, uint16_t handle, uint8_t operation, uint16_t offset,
                          uint16_t len, uint8_t *pValue, attsAttr_t *pAttr)
 {
+    static uint32_t packetCount = 0;
+
     if (len < 64) {
         /* print received data if not a speed test message */
         APP_TRACE_INFO0((const char *)pValue);
 
         /* send back some data */
         datsSendData(connId);
+    } else {
+        APP_TRACE_INFO1("Speed test packet Count [%d]", packetCount++);
+        if (packetCount >= 5000) {
+            packetCount = 0;
+        }
     }
     return ATT_SUCCESS;
 }

--- a/Examples/MAX32665/BLE_dats/dats_main.c
+++ b/Examples/MAX32665/BLE_dats/dats_main.c
@@ -423,12 +423,18 @@ static void trimStart(void)
 uint8_t datsWpWriteCback(dmConnId_t connId, uint16_t handle, uint8_t operation, uint16_t offset,
                          uint16_t len, uint8_t *pValue, attsAttr_t *pAttr)
 {
+    static uint32_t packetCount = 0;
     if (len < 64) {
         /* print received data if not a speed test message */
         APP_TRACE_INFO0((const char *)pValue);
 
         /* send back some data */
         datsSendData(connId);
+    } else {
+        APP_TRACE_INFO1("Speed test packet Count [%d]", packetCount++);
+        if (packetCount >= 5000) {
+            packetCount = 0;
+        }
     }
     return ATT_SUCCESS;
 }

--- a/Examples/MAX32690/BLE_dats/dats_main.c
+++ b/Examples/MAX32690/BLE_dats/dats_main.c
@@ -422,12 +422,19 @@ static void trimStart(void)
 uint8_t datsWpWriteCback(dmConnId_t connId, uint16_t handle, uint8_t operation, uint16_t offset,
                          uint16_t len, uint8_t *pValue, attsAttr_t *pAttr)
 {
+    static uint32_t packetCount = 0;
+
     if (len < 64) {
         /* print received data if not a speed test message */
         APP_TRACE_INFO0((const char *)pValue);
 
         /* send back some data */
         datsSendData(connId);
+    } else {
+        APP_TRACE_INFO1("Speed test packet Count [%d]", packetCount++);
+        if (packetCount >= 5000) {
+            packetCount = 0;
+        }
     }
     return ATT_SUCCESS;
 }


### PR DESCRIPTION
Adds some visual feedback that packets are indeed being received on the sever side. Someone emailed me about throughput and was wondering if packets are indeed being received on the other side in this speed test.