### PR TITLE
fix(Examples): Fix double-type subseconds calculation for MAX32655, MAX78000, and MAX78002

### DIFF
--- a/Examples/MAX32572/Barcode_Decoder/src/utils.c
+++ b/Examples/MAX32572/Barcode_Decoder/src/utils.c
@@ -55,15 +55,16 @@ void utils_delay_ms(unsigned int ms)
 
 unsigned int utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX32572/Barcode_Decoder/src/utils.c
+++ b/Examples/MAX32572/Barcode_Decoder/src/utils.c
@@ -60,7 +60,7 @@ unsigned int utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX32572/CameraIF/src/utils.c
+++ b/Examples/MAX32572/CameraIF/src/utils.c
@@ -55,15 +55,16 @@ void utils_delay_ms(unsigned int ms)
 
 unsigned int utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX32572/CameraIF/src/utils.c
+++ b/Examples/MAX32572/CameraIF/src/utils.c
@@ -60,7 +60,7 @@ unsigned int utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX32572/MAX32572_Demo_BareMetal/src/utils.c
+++ b/Examples/MAX32572/MAX32572_Demo_BareMetal/src/utils.c
@@ -44,15 +44,16 @@
 /************************   PUBLIC FUNCTIONS  *******************************/
 unsigned int utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX32572/MAX32572_Demo_BareMetal/src/utils.c
+++ b/Examples/MAX32572/MAX32572_Demo_BareMetal/src/utils.c
@@ -49,7 +49,7 @@ unsigned int utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX32572/MAX32572_Demo_FreeRTOS/src/utils.c
+++ b/Examples/MAX32572/MAX32572_Demo_FreeRTOS/src/utils.c
@@ -45,15 +45,16 @@
 /************************   PUBLIC FUNCTIONS  *******************************/
 unsigned int utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX32572/MAX32572_Demo_FreeRTOS/src/utils.c
+++ b/Examples/MAX32572/MAX32572_Demo_FreeRTOS/src/utils.c
@@ -50,7 +50,7 @@ unsigned int utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX32572/TFT_Demo/src/utils.c
+++ b/Examples/MAX32572/TFT_Demo/src/utils.c
@@ -45,15 +45,16 @@
 /************************   PUBLIC FUNCTIONS  *******************************/
 unsigned int utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX32572/TFT_Demo/src/utils.c
+++ b/Examples/MAX32572/TFT_Demo/src/utils.c
@@ -50,7 +50,7 @@ unsigned int utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX32572/lwIP_Ping/main.c
+++ b/Examples/MAX32572/lwIP_Ping/main.c
@@ -125,7 +125,7 @@ static unsigned int sys_get_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX32572/lwIP_Ping/main.c
+++ b/Examples/MAX32572/lwIP_Ping/main.c
@@ -120,15 +120,16 @@ static void link_callback_func(struct netif *netif)
 
 static unsigned int sys_get_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX32572/lwIP_TCP/main.c
+++ b/Examples/MAX32572/lwIP_TCP/main.c
@@ -125,7 +125,7 @@ static unsigned int sys_get_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX32572/lwIP_TCP/main.c
+++ b/Examples/MAX32572/lwIP_TCP/main.c
@@ -120,15 +120,16 @@ static void link_callback_func(struct netif *netif)
 
 static unsigned int sys_get_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX32655/TFT_Demo/src/utils.c
+++ b/Examples/MAX32655/TFT_Demo/src/utils.c
@@ -43,15 +43,16 @@
 /************************   PUBLIC FUNCTIONS  *******************************/
 unsigned int utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX32655/TFT_Demo/src/utils.c
+++ b/Examples/MAX32655/TFT_Demo/src/utils.c
@@ -48,7 +48,7 @@ unsigned int utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78000/CNN/faceid_evkit-riscv/src/utils.c
+++ b/Examples/MAX78000/CNN/faceid_evkit-riscv/src/utils.c
@@ -46,7 +46,7 @@
 
 void utils_delay_ms(uint32_t ms)
 {
-   MXC_Delay(ms * 1000UL);
+    MXC_Delay(ms * 1000UL);
 }
 
 uint32_t utils_get_time_ms(void)

--- a/Examples/MAX78000/CNN/faceid_evkit-riscv/src/utils.c
+++ b/Examples/MAX78000/CNN/faceid_evkit-riscv/src/utils.c
@@ -44,17 +44,23 @@
 
 /************************    PUBLIC FUNCTIONS  *******************************/
 
+void utils_delay_ms(uint32_t ms)
+{
+   MXC_Delay(ms * 1000UL);
+}
+
 uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78000/CNN/faceid_evkit-riscv/src/utils.c
+++ b/Examples/MAX78000/CNN/faceid_evkit-riscv/src/utils.c
@@ -56,7 +56,7 @@ uint32_t utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78000/CNN/faceid_evkit/src/utils.c
+++ b/Examples/MAX78000/CNN/faceid_evkit/src/utils.c
@@ -46,15 +46,16 @@
 
 uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78000/CNN/faceid_evkit/src/utils.c
+++ b/Examples/MAX78000/CNN/faceid_evkit/src/utils.c
@@ -51,7 +51,7 @@ uint32_t utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78000/CNN/facial_recognition/src/utils.c
+++ b/Examples/MAX78000/CNN/facial_recognition/src/utils.c
@@ -46,7 +46,7 @@
 
 void utils_delay_ms(uint32_t ms)
 {
-   MXC_Delay(ms * 1000UL);
+    MXC_Delay(ms * 1000UL);
 }
 
 uint32_t utils_get_time_ms(void)

--- a/Examples/MAX78000/CNN/facial_recognition/src/utils.c
+++ b/Examples/MAX78000/CNN/facial_recognition/src/utils.c
@@ -44,17 +44,23 @@
 
 /************************    PUBLIC FUNCTIONS  *******************************/
 
+void utils_delay_ms(uint32_t ms)
+{
+   MXC_Delay(ms * 1000UL);
+}
+
 uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78000/CNN/facial_recognition/src/utils.c
+++ b/Examples/MAX78000/CNN/facial_recognition/src/utils.c
@@ -56,7 +56,7 @@ uint32_t utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78000/CameraIF/utils.c
+++ b/Examples/MAX78000/CameraIF/utils.c
@@ -50,7 +50,7 @@
 /************************    PUBLIC FUNCTIONS  *******************************/
 void utils_delay_ms(uint32_t ms)
 {
-   MXC_Delay(ms * 1000UL);
+    MXC_Delay(ms * 1000UL);
 }
 
 uint32_t utils_get_time_ms(void)

--- a/Examples/MAX78000/CameraIF/utils.c
+++ b/Examples/MAX78000/CameraIF/utils.c
@@ -48,22 +48,23 @@
 /***************************** VARIABLES *************************************/
 
 /************************    PUBLIC FUNCTIONS  *******************************/
-//void utils_delay_ms(uint32_t ms)
-//{
-//    MXC_Delay(ms * 1000UL);
-//}
+void utils_delay_ms(uint32_t ms)
+{
+   MXC_Delay(ms * 1000UL);
+}
 
 uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78000/CameraIF/utils.c
+++ b/Examples/MAX78000/CameraIF/utils.c
@@ -60,7 +60,7 @@ uint32_t utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78000/TFT_Demo/src/utils.c
+++ b/Examples/MAX78000/TFT_Demo/src/utils.c
@@ -41,14 +41,14 @@
 /************************   STATIC FUNCTIONS  *******************************/
 
 /************************   PUBLIC FUNCTIONS  *******************************/
-uint32_t utils_get_time_ms(void)
+unsigned int utils_get_time_ms(void)
 {
     uint32_t sec, ssec;
     double subsec;
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)4096.0;
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78000/TFT_Demo/src/utils.c
+++ b/Examples/MAX78000/TFT_Demo/src/utils.c
@@ -41,17 +41,18 @@
 /************************   STATIC FUNCTIONS  *******************************/
 
 /************************   PUBLIC FUNCTIONS  *******************************/
-unsigned int utils_get_time_ms(void)
+uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78002/CNN/faceid_evkit/src/utils.c
+++ b/Examples/MAX78002/CNN/faceid_evkit/src/utils.c
@@ -55,7 +55,7 @@ uint32_t utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78002/CNN/faceid_evkit/src/utils.c
+++ b/Examples/MAX78002/CNN/faceid_evkit/src/utils.c
@@ -43,18 +43,23 @@
 /***************************** VARIABLES *************************************/
 
 /************************    PUBLIC FUNCTIONS  *******************************/
+void utils_delay_ms(uint32_t ms)
+{
+   MXC_Delay(ms * 1000UL);
+}
 
 uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78002/CNN/faceid_evkit/src/utils.c
+++ b/Examples/MAX78002/CNN/faceid_evkit/src/utils.c
@@ -45,7 +45,7 @@
 /************************    PUBLIC FUNCTIONS  *******************************/
 void utils_delay_ms(uint32_t ms)
 {
-   MXC_Delay(ms * 1000UL);
+    MXC_Delay(ms * 1000UL);
 }
 
 uint32_t utils_get_time_ms(void)

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/cnn/nms.c
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/cnn/nms.c
@@ -99,7 +99,7 @@ uint32_t utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/cnn/nms.c
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/cnn/nms.c
@@ -89,7 +89,7 @@ void reset_arrays(void)
 
 void utils_delay_ms(uint32_t ms)
 {
-   MXC_Delay(ms * 1000UL);
+    MXC_Delay(ms * 1000UL);
 }
 
 uint32_t utils_get_time_ms(void)

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/cnn/nms.c
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/src/cnn/nms.c
@@ -87,17 +87,23 @@ void reset_arrays(void)
     memset(nms_removed, 0, sizeof(nms_removed));
 }
 
+void utils_delay_ms(uint32_t ms)
+{
+   MXC_Delay(ms * 1000UL);
+}
+
 uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78002/CSI2/utils.c
+++ b/Examples/MAX78002/CSI2/utils.c
@@ -48,18 +48,23 @@
 /***************************** VARIABLES *************************************/
 
 /************************    PUBLIC FUNCTIONS  *******************************/
+void utils_delay_ms(uint32_t ms)
+{
+   MXC_Delay(ms * 1000UL);
+}
 
 uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78002/CSI2/utils.c
+++ b/Examples/MAX78002/CSI2/utils.c
@@ -50,7 +50,7 @@
 /************************    PUBLIC FUNCTIONS  *******************************/
 void utils_delay_ms(uint32_t ms)
 {
-   MXC_Delay(ms * 1000UL);
+    MXC_Delay(ms * 1000UL);
 }
 
 uint32_t utils_get_time_ms(void)

--- a/Examples/MAX78002/CSI2/utils.c
+++ b/Examples/MAX78002/CSI2/utils.c
@@ -60,7 +60,7 @@ uint32_t utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 

--- a/Examples/MAX78002/CameraIF/utils.c
+++ b/Examples/MAX78002/CameraIF/utils.c
@@ -50,7 +50,7 @@
 /************************    PUBLIC FUNCTIONS  *******************************/
 void utils_delay_ms(uint32_t ms)
 {
-   MXC_Delay(ms * 1000UL);
+    MXC_Delay(ms * 1000UL);
 }
 
 uint32_t utils_get_time_ms(void)

--- a/Examples/MAX78002/CameraIF/utils.c
+++ b/Examples/MAX78002/CameraIF/utils.c
@@ -48,22 +48,23 @@
 /***************************** VARIABLES *************************************/
 
 /************************    PUBLIC FUNCTIONS  *******************************/
-//void utils_delay_ms(uint32_t ms)
-//{
-//    MXC_Delay(ms * 1000UL);
-//}
+void utils_delay_ms(uint32_t ms)
+{
+   MXC_Delay(ms * 1000UL);
+}
 
 uint32_t utils_get_time_ms(void)
 {
-    uint32_t sec;
-    uint32_t subsec;
+    uint32_t sec, ssec;
+    double subsec;
     uint32_t ms;
 
-    MXC_RTC_GetSubSeconds(&subsec);
-    subsec /= 4096;
+    MXC_RTC_GetSubSeconds(&ssec);
+    subsec = (double)ssec / 4096.0;
+
     MXC_RTC_GetSeconds(&sec);
 
-    ms = (sec * 1000) + (subsec * 1000);
+    ms = (sec * 1000) + (int)(subsec * 1000);
 
     return ms;
 }

--- a/Examples/MAX78002/CameraIF/utils.c
+++ b/Examples/MAX78002/CameraIF/utils.c
@@ -60,7 +60,7 @@ uint32_t utils_get_time_ms(void)
     uint32_t ms;
 
     MXC_RTC_GetSubSeconds(&ssec);
-    subsec = (double)ssec / 4096.0;
+    subsec = (double)ssec / (double)(4096.0);
 
     MXC_RTC_GetSeconds(&sec);
 


### PR DESCRIPTION
I goofed when fixing the utils_get_time_ms functions to use MXC_RTC_GetSubSeconds(...) for the latest release by removing the double type (ssec value is a 12-bit register field value).