### PR TITLE
fix(Examples): Fix return value logic for verifyData function in I2C examples

### DIFF
--- a/Examples/MAX32650/I2C/main.c
+++ b/Examples/MAX32650/I2C/main.c
@@ -176,7 +176,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
     for (i = 0; i < I2C_BYTES; ++i) {
@@ -276,7 +276,8 @@ int main()
     printf("\n-->Result: \n");
     printData();
     printf("\n");
-    if (verifyData()) {
+
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");

--- a/Examples/MAX32655/I2C/main.c
+++ b/Examples/MAX32655/I2C/main.c
@@ -174,7 +174,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
 
@@ -271,7 +271,7 @@ int main()
 
     printf("\n");
 
-    if (verifyData()) {
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");

--- a/Examples/MAX32660/I2C/main.c
+++ b/Examples/MAX32660/I2C/main.c
@@ -180,7 +180,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
     for (i = 0; i < I2C_BYTES; ++i) {
@@ -280,7 +280,8 @@ int main()
     printf("\n-->Result: \n");
     printData();
     printf("\n");
-    if (verifyData()) {
+
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");

--- a/Examples/MAX32662/I2C/main.c
+++ b/Examples/MAX32662/I2C/main.c
@@ -177,7 +177,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
     for (i = 0; i < I2C_BYTES; ++i) {
@@ -286,7 +286,8 @@ int main()
     printf("\n-->Result: \n");
     printData();
     printf("\n");
-    if (!verifyData()) {
+
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");

--- a/Examples/MAX32665/I2C/main.c
+++ b/Examples/MAX32665/I2C/main.c
@@ -178,7 +178,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
     for (i = 0; i < I2C_BYTES; ++i) {
@@ -282,7 +282,8 @@ int main()
     printf("\n-->Result: \n");
     printData();
     printf("\n");
-    if (verifyData()) {
+
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");

--- a/Examples/MAX32670/I2C/main.c
+++ b/Examples/MAX32670/I2C/main.c
@@ -178,7 +178,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
 
@@ -274,7 +274,7 @@ int main()
 
     printf("\n");
 
-    if (verifyData()) {
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");

--- a/Examples/MAX32672/I2C/main.c
+++ b/Examples/MAX32672/I2C/main.c
@@ -174,7 +174,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
 

--- a/Examples/MAX32675/I2C/main.c
+++ b/Examples/MAX32675/I2C/main.c
@@ -178,7 +178,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
 
@@ -190,9 +190,9 @@ int verifyData()
 
     if (fails > 0) {
         return E_FAIL;
-    } else {
-        return E_NO_ERROR;
     }
+
+    return E_NO_ERROR;
 }
 
 // *****************************************************************************
@@ -274,7 +274,7 @@ int main()
 
     printf("\n");
 
-    if (verifyData()) {
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");

--- a/Examples/MAX32680/I2C/main.c
+++ b/Examples/MAX32680/I2C/main.c
@@ -174,7 +174,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
 
@@ -271,7 +271,7 @@ int main()
 
     printf("\n");
 
-    if (verifyData()) {
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");

--- a/Examples/MAX32690/I2C/main.c
+++ b/Examples/MAX32690/I2C/main.c
@@ -181,7 +181,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
     for (i = 0; i < I2C_BYTES; ++i) {
@@ -281,7 +281,8 @@ int main()
     printf("\n-->Result: \n");
     printData();
     printf("\n");
-    if (!verifyData()) {
+
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
         LED_On(LED_GREEN);
     } else {

--- a/Examples/MAX78002/I2C/main.c
+++ b/Examples/MAX78002/I2C/main.c
@@ -178,7 +178,7 @@ void printData(void)
 }
 
 //Compare data to see if they are the same
-int verifyData()
+int verifyData(void)
 {
     int i, fails = 0;
 
@@ -275,7 +275,7 @@ int main()
 
     printf("\n");
 
-    if (verifyData()) {
+    if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
     } else {
         printf("\n-->I2C Transaction Failed\n");


### PR DESCRIPTION
Many of the I2C examples had the logic flipped for checking the return value of the verifyData function. verifyData returns E_NO_ERROR if the transaction was successful, but that would cause the program flow to print out a transaction failed message.