### PR TITLE
feat(workflow): Add new workflow for Releases

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,37 @@
+name: "Release"
+
+on:
+  release:
+    types:
+      - "published"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v3.5.3"
+
+      - name: "Archive Tools"
+        shell: "bash"
+        run: tar -cf Tools.tar.xz --use-compress-program='xz -9' ./Tools
+
+      - name: "Archive Examples"
+        shell: "bash"
+        run: tar -cf Examples.tar.xz --use-compress-program='xz -9' ./Examples
+
+      - name: "Archive Libraries"
+        shell: "bash"
+        run: tar -cf Libraries.tar.xz --use-compress-program='xz -9' ./Libraries
+
+      - name: "Upload the achives to the release"
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          files: |
+            ${{ github.workspace }}/Tools.tar.xz
+            ${{ github.workspace }}/Examples.tar.xz
+            ${{ github.workspace }}/Libraries.tar.xz

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,4 +1,4 @@
-name: "Release"
+name: "Package Release Components"
 
 on:
   release:


### PR DESCRIPTION
### Description

This PR creates a new workflow just for created GitHub releases.

It packages up the `Examples`, `Libraries` and `Tools` folders for use elsewhere without having to download the whole repository or download the complete installer (or just to update your examples etc. without having to go through a complete re-install).

This could later be expanded on to use the same workflow for bundling the installer automatically within Actions.

I created a dummy release on the fork to test the action: https://github.com/ALofthou/msdk/releases/tag/Test_Release

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related Github issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [X] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional. See [here](https://github.com/ALofthou/msdk/releases/tag/Test_Release)
