### PR TITLE
fix(Build): Fix "empty.c file not found" Error on Make v3.81 or Older

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,9 +52,10 @@ The scopes are dependent on the changes based on their location in the MSDK. The
 9.  **ThirdParty** – Any third-party library changes (e.g. FreeRTOS, LVGL, lwIP)
 10. **MAXUSB** – Any MAXUSB changes
 11. **SDHC** – Any SDHC changes
-12. **ignore** – Small and quick miscellaneous fixes (should not be used often)
-13. **workflow** – Any GitHub workflow related changes
-14. **Other** – Any changes that may not fit in the other scopes
+12. **Tools** – Any changes involving the build system
+13. **ignore** – Small and quick miscellaneous fixes (should not be used often)
+14. **workflow** – Any GitHub workflow related changes
+15. **Other** – Any changes that may not fit in the other scopes
 
 NOTE: The scope is case sensitive and must match one of the listed scopes.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,7 +52,7 @@ The scopes are dependent on the changes based on their location in the MSDK. The
 9.  **ThirdParty** – Any third-party library changes (e.g. FreeRTOS, LVGL, lwIP)
 10. **MAXUSB** – Any MAXUSB changes
 11. **SDHC** – Any SDHC changes
-12. **Tools** – Any changes involving the build system
+12. **Build** – Any changes involving the build system
 13. **ignore** – Small and quick miscellaneous fixes (should not be used often)
 14. **workflow** – Any GitHub workflow related changes
 15. **Other** – Any changes that may not fit in the other scopes

--- a/.github/workflows/Build_Examples.yml
+++ b/.github/workflows/Build_Examples.yml
@@ -173,7 +173,7 @@ jobs:
         run: pip install -r .github/workflows/scripts/requirements.txt
 
       # Runs a set of commands using the runners shell
-      - name: Build_Examples
+      - name: Build All Examples
         if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}
         run: |
           # This environment variable is required for the SBTs.
@@ -184,3 +184,151 @@ jobs:
           export MAXIM_PATH=$(pwd)
 
           python .github/workflows/scripts/build.py
+
+  Regression_Test_Make_3_81:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Update the submodules below, doing so here will convert ssh to https
+          submodules: false
+          fetch-depth: 0
+          ref: '${{ github.event.pull_request.head.ref }}'
+          repository: '${{ github.event.pull_request.head.repo.full_name }}'      
+
+      - name: Install Make 3.81
+        run: |
+          # Build and install Make version 3.81.
+          cd $GITHUB_WORKSPACE
+          ls -la
+          wget https://ftp.gnu.org/gnu/make/make-3.81.tar.gz
+          tar -xvf make-3.81.tar.gz
+          cd make-3.81
+
+          # Note: This patch is necessary to get make to build on Ubuntu-22.04.
+          patch glob/glob.c $GITHUB_WORKSPACE/.github/workflows/patch/glob_patch.patch
+
+          ./configure --prefix=$GITHUB_WORKSPACE/make-3.81
+          make
+          make install
+          
+          # Pre-prend 3.81 to path
+          echo "$GITHUB_WORKSPACE/make-3.81/bin:$GITHUB_PATH" > $GITHUB_PATH
+          make --version
+
+      - name: Check Make Version
+        run: |
+          # If this fails, there is a setup issue with the workflow.
+          VERSION_CHECK=$(make --version | grep 3.81)
+          if [ ! "$VERSION_CHECK" ];then
+            exit 2
+          fi
+
+      - name: Check watch files
+        id: check_watch 
+        run: |
+          # Determine if we need to run the test
+          RUN_TEST=0
+
+          # Always run test if a workflow_dispatch
+          if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
+            RUN_TEST=1
+          fi
+
+          # Check for changes made to these files
+          WATCH_FILES="\
+            Build_Examples.yml \
+            .c \
+            .cpp \
+            .S \
+            .s \
+            .h \
+            .a \
+            .mk \
+            makefile \
+            Makefile"
+
+          # Get the diff from main
+          CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/origin/main)
+
+          echo "Watching these locations and files"
+          echo $WATCH_FILES
+
+          echo "Checking the following changes"
+          echo $CHANGE_FILES
+
+          for watch_file in $WATCH_FILES; do 
+              for change_file in $CHANGE_FILES; do 
+                  if [[ "${change_file,,}" == *"${watch_file,,}" ]]; then
+                      echo "Match found. Watch type: $watch_file, File: $change_file"
+                      RUN_TEST=1
+                  fi
+              done
+          done
+
+          # End the test early if there wasn't a significant change
+          if [[ $RUN_TEST -eq 0 ]]; then
+            echo "Skipping Build"
+          else
+            echo "Running Build"
+          fi
+          
+          echo "RUN_TEST=$RUN_TEST" >> $GITHUB_OUTPUT
+
+      - name: Install ARM GCC Toolchain (arm-none-eabi-gcc)
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        id: arm-none-eabi-gcc-action
+        if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}
+        with:
+          release: '10.3-2021.10' # <-- The compiler release to use
+          
+      - name: Install RISCV GCC Toolchain (riscv-none-embed-gcc)
+        if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}
+        run: |
+          # Install RISCV tools
+          npm install --global xpm@latest
+          
+          TOOL_VER=10.2.0-1.2.1
+          xpm install --global @xpack-dev-tools/riscv-none-embed-gcc@$TOOL_VER
+          cp -r /home/runner/.local/xPacks/@xpack-dev-tools/riscv-none-embed-gcc /home/runner/riscv-none-embed-gcc
+          
+          # Add riscv tools to path
+          echo "/home/runner/riscv-none-embed-gcc/$TOOL_VER/.content/bin" >> $GITHUB_PATH
+
+      - name: Install RISCV GCC Toolchain (riscv-none-elf-gcc)
+        if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}
+        run: |
+          # Install RISCV tools (updated)
+          npm install --global xpm@latest
+          
+          # https://www.npmjs.com/package/@xpack-dev-tools/riscv-none-elf-gcc
+          TOOL_VER=12.2.0-3.1
+          xpm install --global @xpack-dev-tools/riscv-none-elf-gcc@$TOOL_VER
+          cp -r /home/runner/.local/xPacks/@xpack-dev-tools/riscv-none-elf-gcc /home/runner/riscv-none-elf-gcc
+          
+          # Add riscv tools to path
+          echo "/home/runner/riscv-none-elf-gcc/$TOOL_VER/.content/bin" >> $GITHUB_PATH
+
+      - name: Setup Python
+        if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}
+        uses: actions/setup-python@v4.5.0
+        with:
+          python-version: '3.10'
+
+      - name: Install packages
+        if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}
+        run: pip install -r .github/workflows/scripts/requirements.txt
+
+      - name: Build PeriphDrivers and Hello_World
+        if: ${{ steps.check_watch.outputs.RUN_TEST == '1' }}
+        run: |
+          # This environment variable is required for the SBTs.
+          # It must be set to the absolute path inside the Github repo.
+          export MAXIM_SBT_DIR=$(pwd)/Tools/SBT
+          
+          # Set MAXIM_PATH to limit warnings
+          export MAXIM_PATH=$(pwd)
+
+          python .github/workflows/scripts/build.py --projects Hello_World
+    

--- a/.github/workflows/PR_Title_Check.yml
+++ b/.github/workflows/PR_Title_Check.yml
@@ -45,6 +45,7 @@ jobs:
           scopes: |
             Documentation
             Examples
+            Build
             Tools
             BLE
             Boards

--- a/.github/workflows/patch/glob_patch.patch
+++ b/.github/workflows/patch/glob_patch.patch
@@ -1,0 +1,20 @@
+--- glob-old.c	2023-07-15 18:06:47.276205928 -0500
++++ glob.c	2023-07-15 18:08:24.256204829 -0500
+@@ -207,7 +207,7 @@
+ #endif /* __GNU_LIBRARY__ */
+ 
+ 
+-#if !defined __alloca && !defined __GNU_LIBRARY__
++#if !defined __alloca && defined __GNU_LIBRARY__
+ 
+ # ifdef	__GNUC__
+ #  undef alloca
+@@ -230,7 +230,7 @@
+ 
+ #endif
+ 
+-#ifndef __GNU_LIBRARY__
++#ifdef __GNU_LIBRARY__
+ # define __stat stat
+ # ifdef STAT_MACROS_BROKEN
+ #  undef S_ISDIR

--- a/.github/workflows/scripts/build.py
+++ b/.github/workflows/scripts/build.py
@@ -6,6 +6,7 @@ from typing import Tuple
 from rich.progress import Progress
 from rich.console import Console
 from rich.text import Text
+from rich import inspect
 import time
 import shutil
 
@@ -38,7 +39,7 @@ def build_project(project:Path, target, board, maxim_path:Path, distclean=False)
     res = run(clean_cmd, cwd=project, shell=True, capture_output=True, encoding="utf-8")
 
     # Test build
-    build_cmd = f"make -r -j 8 --output-sync=target --no-print-directory TARGET={target} MAXIM_PATH={maxim_path.as_posix()} BOARD={board} FORCE_COLOR=1"
+    build_cmd = f"make -r -j 8 TARGET={target} MAXIM_PATH={maxim_path.as_posix()} BOARD={board} FORCE_COLOR=1"
     res = run(build_cmd, cwd=project, shell=True, capture_output=True, encoding="utf-8")
 
     project_info = {
@@ -83,23 +84,27 @@ def build_project(project:Path, target, board, maxim_path:Path, distclean=False)
     return (return_code, project_info)
 
 
-def test(maxim_path : Path = None, targets=None, boards=None, projects=None):
-    env = os.environ.copy()
-    if maxim_path is None and "MAXIM_PATH" in env.keys():
-        maxim_path = Path(env['MAXIM_PATH']).absolute()
-    else:
-        print("MAXIM_PATH not set.")
-        return
-
-    env["FORCE_COLOR"] = 1
+def test(maxim_path : Path = None, targets=None, boards=None, projects=None): 
 
     console = Console(emoji=False, color_system="standard")
 
+    env = os.environ.copy()
+    if maxim_path is None and "MAXIM_PATH" in env.keys():
+        maxim_path = Path(env['MAXIM_PATH']).absolute()
+        console.print(f"[green]Detected MAXIM_PATH[/green] = {maxim_path}")
+    else:
+        console.print("MAXIM_PATH not set.")
+        return
+    
+    env["FORCE_COLOR"] = 1
+
     # Remove the periphdrivers build directory
+    console.print("Cleaning PeriphDrivers build directories...")
     shutil.rmtree(Path(maxim_path) / "Libraries" / "PeriphDrivers" / "bin", ignore_errors=True)
 
     # Get list of target micros if none is specified
     if targets is None:
+        console.print("[yellow]Auto-searching for targets...[/yellow]")
         targets = []
 
         for dir in os.scandir(f"{maxim_path}/Examples"):
@@ -122,11 +127,15 @@ def test(maxim_path : Path = None, targets=None, boards=None, projects=None):
 
     for target in sorted(targets):
 
+        console.print("====================")
+        console.print(f"Testing {target}...")
+
         target_fails = 0
         target_warnings = 0
 
         # Get list of supported boards for this target.
         if boards is None:
+            console.print(f"[yellow]Auto-searching for {target} BSPs...[/yellow]")
             boards = []
             for dirpath, subdirs, items in os.walk(maxim_path / "Libraries" / "Boards" / target):
                 if "board.mk" in items and Path(dirpath).name not in blacklist:
@@ -139,36 +148,34 @@ def test(maxim_path : Path = None, targets=None, boards=None, projects=None):
         boards = sorted(boards) # Enforce alphabetical ordering
                 
         # Get list of examples for this target.
+        _projects = []
         if projects is None:
-            projects = []
+            console.print(f"[yellow]Auto-searching for {target} examples...[/yellow]")
             for dirpath, subdirs, items in os.walk(maxim_path / "Examples" / target):
                 if 'Makefile' in items and ("main.c" in items or "project.mk" in items):
-                    projects.append(Path(dirpath))
+                    _projects.append(Path(dirpath))
 
         else:
             assert(type(projects) is list)
             for dirpath, subdirs, items in os.walk(maxim_path / "Examples" / target):
                 dirpath = Path(dirpath)
                 if dirpath.name in projects:
-                    projects.remove(dirpath.name)
-                    projects.append(dirpath)
-
-
-        console.print("====================")
-        console.print(f"Found {len(projects)} projects for [bold cyan]{target}[/bold cyan]")
+                    _projects.append(dirpath)
+        
+        console.print(f"Found {len(_projects)} projects for [bold cyan]{target}[/bold cyan]")
         console.print(f"Detected boards: {boards}")
 
-        projects = sorted(projects) # Enforce alphabetical ordering
+        _projects = sorted(_projects) # Enforce alphabetical ordering
                 
 
         with Progress(console=console) as progress:
-            task_build = progress.add_task(description=f"{target}: PeriphDrivers", total=(len(projects) * len(boards)) + len(boards))
+            task_build = progress.add_task(description=f"{target}: PeriphDrivers", total=(len(_projects) * len(boards)) + len(boards))
 
             periph_success = True
 
             # Find Hello_World and do a PeriphDriver build test first.
             hello_world = None
-            for p in projects:
+            for p in _projects:
                 if p.name == "Hello_World":
                     hello_world = p
             
@@ -211,7 +218,7 @@ def test(maxim_path : Path = None, targets=None, boards=None, projects=None):
 
             if periph_success:
                 # Iteratively across and test example projects
-                for project in projects:
+                for project in _projects:
                     project_name = project.name
 
                     for board in boards:
@@ -254,10 +261,10 @@ def test(maxim_path : Path = None, targets=None, boards=None, projects=None):
             elif not periph_success:
                 progress.update(task_build, description=f"[bold cyan]{target}[/bold cyan]: [red]PeriphDriver build failed.[/red]", refresh=True)
             else:
-                progress.update(task_build, description=f"[bold cyan]{target}[/bold cyan]: [red]Failed for {target_fails}/{len(projects)} projects[/red]", refresh=True)            
+                progress.update(task_build, description=f"[bold cyan]{target}[/bold cyan]: [red]Failed for {target_fails}/{len(_projects)} projects[/red]", refresh=True)            
 
         boards = None # Reset boards list
-        projects = None # Reset projects list
+        _projects = None # Reset projects list
 
     console.print(f"Tested {count} cases.  {count - len(failed)}/{count} succeeded.")
     if (len(warnings) > 0):
@@ -283,6 +290,7 @@ parser.add_argument("--projects", type=str, nargs="+", required=False, help="Exa
 
 if __name__ == "__main__":
     args = parser.parse_args()
+    inspect(args, title="Script arguments:", )
     exit(
         test(
             maxim_path=args.maxim_path,

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -505,6 +505,6 @@ project_defines: $(BUILD_DIR)/project_defines.h
 $(BUILD_DIR)/project_defines.h: mkbuildir
 	@echo "" > $(BUILD_DIR)/_empty_tmp_file.c
 	@echo "// This is a generated file that's used to detect definitions that have been set by the compiler and build system." > $@
-	@$(CC) -E -P -dD $(BUILD_DIR)/_empty_tmp_file.c $(CFLAGS) >> $(BUILD_DIR)/project_defines.h
+	@$(CC) -E -P -dD $(BUILD_DIR)/_empty_tmp_file.c $(CFLAGS) >> $@
 	@rm $(BUILD_DIR)/_empty_tmp_file.c
 	@rm _empty_tmp_file.d

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -503,8 +503,8 @@ debug:
 .PHONY: project_defines
 project_defines: $(BUILD_DIR)/project_defines.h
 $(BUILD_DIR)/project_defines.h: mkbuildir
-	$(file > $(BUILD_DIR)/empty.c,)
-	$(file > $(BUILD_DIR)/project_defines.h,// This is a generated file that's used to detect definitions that have been set by the compiler and build system.)
-	@$(CC) -E -P -dD $(BUILD_DIR)/empty.c $(CFLAGS) >> $(BUILD_DIR)/project_defines.h
-	@rm $(BUILD_DIR)/empty.c
-	@rm empty.d
+	@echo "" > $(BUILD_DIR)/_empty_tmp_file.c
+	@echo "// This is a generated file that's used to detect definitions that have been set by the compiler and build system." > $@
+	@$(CC) -E -P -dD $(BUILD_DIR)/_empty_tmp_file.c $(CFLAGS) >> $(BUILD_DIR)/project_defines.h
+	@rm $(BUILD_DIR)/_empty_tmp_file.c
+	@rm _empty_tmp_file.d

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -460,8 +460,8 @@ debug:
 .PHONY: project_defines
 project_defines: $(BUILD_DIR)/project_defines.h
 $(BUILD_DIR)/project_defines.h: mkbuildir
-	$(file > $(BUILD_DIR)/empty.c,)
-	$(file > $(BUILD_DIR)/project_defines.h,// This is a generated file that's used to detect definitions that have been set by the compiler and build system.)
-	@$(CC) -E -P -dD $(BUILD_DIR)/empty.c $(CFLAGS) >> $(BUILD_DIR)/project_defines.h
-	@rm $(BUILD_DIR)/empty.c
-	@rm empty.d
+	@echo "" > $(BUILD_DIR)/_empty_tmp_file.c
+	@echo "// This is a generated file that's used to detect definitions that have been set by the compiler and build system." > $@
+	@$(CC) -E -P -dD $(BUILD_DIR)/_empty_tmp_file.c $(CFLAGS) >> $@
+	@rm $(BUILD_DIR)/_empty_tmp_file.c
+	@rm _empty_tmp_file.d

--- a/Libraries/MiscDrivers/Camera/mipi_camera.c
+++ b/Libraries/MiscDrivers/Camera/mipi_camera.c
@@ -70,9 +70,11 @@ extern int mipi_sensor_register(mipi_camera_t *camera);
 
 static mipi_camera_t camera;
 
+#ifndef OV5640_DVP
 static mxc_csi2_req_t g_req;
 static mxc_csi2_ctrl_cfg_t g_ctrl_cfg;
 static mxc_csi2_vfifo_cfg_t g_vfifo_cfg;
+#endif
 
 static mipi_camera_settings_t g_camera_settings;
 static char g_image_header[256];
@@ -215,6 +217,7 @@ int mipi_camera_init(mipi_camera_settings_t camera_settings)
     // Link function pointers from camera drivers
     mipi_sensor_register(&camera);
 
+#ifndef OV5640_DVP
     error = camera.init();
     if (error)
         return error;
@@ -280,6 +283,7 @@ int mipi_camera_init(mipi_camera_settings_t camera_settings)
     if (error != E_NO_ERROR) {
         return error;
     }
+#endif
 
     return error;
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -11,7 +11,7 @@ module.exports = {
      * Any rules defined here will override rules from @commitlint/config-conventional
      */
     rules: {
-        "scope-enum": [2, "always", ["Documentation", "Examples", "Tools", "BLE", "Boards", "CMSIS", "MiscDrivers", "PeriphDrivers", "ThirdParty", "SDHC", "MAXUSB", "ignore", "workflow", "Other"]],
+        "scope-enum": [2, "always", ["Documentation", "Build", "Examples", "Tools", "BLE", "Boards", "CMSIS", "MiscDrivers", "PeriphDrivers", "ThirdParty", "SDHC", "MAXUSB", "ignore", "workflow", "Other"]],
         "scope-empty": [2, "never"],        
         "type-enum": [2, "always", ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"]],
         "subject-case": [2, "always", ["sentence-case", "start-case", "pascal-case", "upper-case"]],


### PR DESCRIPTION
## Pull Request Template

### Description

The [`$(file)` operation](https://www.gnu.org/software/make/manual/make.html#File-Function) that was being used to generate our `project_defines.h` header file (as of #628) was only supported on Make v3.82 or newer.  As a result, v3.81 or older would throw the following error:

```bash
arm-none-eabi-gcc.exe: error: C:/Users/JCarter3/repos/fork/msdk/Examples/MAX78000/CNN/mnist-riscv/build/_empty_tmp_file.c: No such file or directory
arm-none-eabi-gcc.exe: fatal error: no input files
compilation terminated.
make[1]: *** [/C/Users/JCarter3/repos/fork/msdk/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk:508: /c/Users/JCarter3/repos/fork/msdk/Examples/MAX78000/CNN/mnist-riscv/build/project_defines.h] Error 1
make: *** [Makefile:56: arm] Error 2
```

This PR replaces the operation with an `echo` command that works cross-platform.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related Github issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
