### PR TITLE
chore(Examples): Remove obsolete directories from project include paths

### DIFF
--- a/Examples/MAX32520/AES/.cproject
+++ b/Examples/MAX32520/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/AES/.vscode/settings.json
+++ b/Examples/MAX32520/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32520/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32520/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/CRC/.cproject
+++ b/Examples/MAX32520/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/CRC/.vscode/settings.json
+++ b/Examples/MAX32520/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/Coremark/.cproject
+++ b/Examples/MAX32520/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/Coremark/.vscode/settings.json
+++ b/Examples/MAX32520/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/DMA/.cproject
+++ b/Examples/MAX32520/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/DMA/.vscode/settings.json
+++ b/Examples/MAX32520/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ECDSA/.cproject
+++ b/Examples/MAX32520/ECDSA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/ECDSA/.vscode/settings.json
+++ b/Examples/MAX32520/ECDSA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32520/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32520/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/Flash/.cproject
+++ b/Examples/MAX32520/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/Flash/.vscode/settings.json
+++ b/Examples/MAX32520/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/Flash_CLI/.cproject
+++ b/Examples/MAX32520/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32520/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32520/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32520/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32520/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32520/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/GPIO/.cproject
+++ b/Examples/MAX32520/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/GPIO/.vscode/settings.json
+++ b/Examples/MAX32520/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/Hello_World/.cproject
+++ b/Examples/MAX32520/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32520/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32520/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32520/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/I2C_MNGR/.cproject
+++ b/Examples/MAX32520/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32520/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32520/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/I2C_SCAN/.cproject
+++ b/Examples/MAX32520/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32520/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/I2C_Sensor/.cproject
+++ b/Examples/MAX32520/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32520/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/ICC/.cproject
+++ b/Examples/MAX32520/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/ICC/.vscode/settings.json
+++ b/Examples/MAX32520/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/LP/.cproject
+++ b/Examples/MAX32520/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/LP/.vscode/settings.json
+++ b/Examples/MAX32520/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/Library_Generate/.cproject
+++ b/Examples/MAX32520/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32520/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/Library_Use/.cproject
+++ b/Examples/MAX32520/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32520/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/LockDebug/.cproject
+++ b/Examples/MAX32520/LockDebug/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/LockDebug/.vscode/settings.json
+++ b/Examples/MAX32520/LockDebug/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/OTP_Dump/.cproject
+++ b/Examples/MAX32520/OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32520/OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/SCPA_OTP_Dump/.cproject
+++ b/Examples/MAX32520/SCPA_OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32520/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32520/SCPA_OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/SFE/.cproject
+++ b/Examples/MAX32520/SFE/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/SFE/.vscode/settings.json
+++ b/Examples/MAX32520/SFE/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/SFE_Host/.cproject
+++ b/Examples/MAX32520/SFE_Host/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/SFE_Host/.vscode/settings.json
+++ b/Examples/MAX32520/SFE_Host/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/SMON/.cproject
+++ b/Examples/MAX32520/SMON/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/SMON/.vscode/settings.json
+++ b/Examples/MAX32520/SMON/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/SPI/.cproject
+++ b/Examples/MAX32520/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/SPI/.vscode/settings.json
+++ b/Examples/MAX32520/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/SPI_MasterSlave/.cproject
+++ b/Examples/MAX32520/SPI_MasterSlave/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32520/SPI_MasterSlave/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/TMR/.cproject
+++ b/Examples/MAX32520/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/TMR/.vscode/settings.json
+++ b/Examples/MAX32520/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/TRNG/.cproject
+++ b/Examples/MAX32520/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/TRNG/.vscode/settings.json
+++ b/Examples/MAX32520/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/UCL/.cproject
+++ b/Examples/MAX32520/UCL/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/UCL/.vscode/settings.json
+++ b/Examples/MAX32520/UCL/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32520/Watchdog/.cproject
+++ b/Examples/MAX32520/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32520/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32520/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/ADC/.cproject
+++ b/Examples/MAX32572/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/ADC/.vscode/settings.json
+++ b/Examples/MAX32572/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/AES/.cproject
+++ b/Examples/MAX32572/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/AES/.vscode/settings.json
+++ b/Examples/MAX32572/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Barcode_Decoder/.cproject
+++ b/Examples/MAX32572/Barcode_Decoder/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Barcode_Decoder/.vscode/settings.json
+++ b/Examples/MAX32572/Barcode_Decoder/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/CRC/.cproject
+++ b/Examples/MAX32572/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/CRC/.vscode/settings.json
+++ b/Examples/MAX32572/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/CameraIF/.cproject
+++ b/Examples/MAX32572/CameraIF/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/CameraIF/.vscode/settings.json
+++ b/Examples/MAX32572/CameraIF/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Coremark/.cproject
+++ b/Examples/MAX32572/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Coremark/.vscode/settings.json
+++ b/Examples/MAX32572/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/DES/.cproject
+++ b/Examples/MAX32572/DES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/DES/.vscode/settings.json
+++ b/Examples/MAX32572/DES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/DMA/.cproject
+++ b/Examples/MAX32572/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/DMA/.vscode/settings.json
+++ b/Examples/MAX32572/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Flash/.cproject
+++ b/Examples/MAX32572/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Flash/.vscode/settings.json
+++ b/Examples/MAX32572/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32572/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32572/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32572/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/GPIO/.cproject
+++ b/Examples/MAX32572/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/GPIO/.vscode/settings.json
+++ b/Examples/MAX32572/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/HTMR/.cproject
+++ b/Examples/MAX32572/HTMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/HTMR/.vscode/settings.json
+++ b/Examples/MAX32572/HTMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Hash/.cproject
+++ b/Examples/MAX32572/Hash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Hash/.vscode/settings.json
+++ b/Examples/MAX32572/Hash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Hello_World/.cproject
+++ b/Examples/MAX32572/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32572/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32572/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32572/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/I2C/.cproject
+++ b/Examples/MAX32572/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/I2C/.vscode/settings.json
+++ b/Examples/MAX32572/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/I2C_Sensor/.cproject
+++ b/Examples/MAX32572/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32572/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/ICC/.cproject
+++ b/Examples/MAX32572/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/ICC/.vscode/settings.json
+++ b/Examples/MAX32572/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/LP/.cproject
+++ b/Examples/MAX32572/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/LP/.vscode/settings.json
+++ b/Examples/MAX32572/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Library_Generate/.cproject
+++ b/Examples/MAX32572/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32572/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Library_Use/.cproject
+++ b/Examples/MAX32572/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32572/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/MAX32572_Demo_BareMetal/.cproject
+++ b/Examples/MAX32572/MAX32572_Demo_BareMetal/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/EMV/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/EMV/include/afe&quot;"/>

--- a/Examples/MAX32572/MAX32572_Demo_BareMetal/.vscode/settings.json
+++ b/Examples/MAX32572/MAX32572_Demo_BareMetal/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/MAX32572_Demo_FreeRTOS/.cproject
+++ b/Examples/MAX32572/MAX32572_Demo_FreeRTOS/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/EMV/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/EMV/include/afe&quot;"/>

--- a/Examples/MAX32572/MAX32572_Demo_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32572/MAX32572_Demo_FreeRTOS/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/MSR/.cproject
+++ b/Examples/MAX32572/MSR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/MSR/.vscode/settings.json
+++ b/Examples/MAX32572/MSR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/OTP_Dump/.cproject
+++ b/Examples/MAX32572/OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32572/OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/OWM/.cproject
+++ b/Examples/MAX32572/OWM/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/OWM/.vscode/settings.json
+++ b/Examples/MAX32572/OWM/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Pulse_Train/.cproject
+++ b/Examples/MAX32572/Pulse_Train/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32572/Pulse_Train/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/RTC/.cproject
+++ b/Examples/MAX32572/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/RTC/.vscode/settings.json
+++ b/Examples/MAX32572/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SDHC_FAT/.cproject
+++ b/Examples/MAX32572/SDHC_FAT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/ff13/Source&quot;"/>

--- a/Examples/MAX32572/SDHC_FAT/.vscode/settings.json
+++ b/Examples/MAX32572/SDHC_FAT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SDHC_Raw/.cproject
+++ b/Examples/MAX32572/SDHC_Raw/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/Include&quot;"/>
 								</option>

--- a/Examples/MAX32572/SDHC_Raw/.vscode/settings.json
+++ b/Examples/MAX32572/SDHC_Raw/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SKB/.cproject
+++ b/Examples/MAX32572/SKB/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/SKB/.vscode/settings.json
+++ b/Examples/MAX32572/SKB/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SMON/.cproject
+++ b/Examples/MAX32572/SMON/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/SMON/.vscode/settings.json
+++ b/Examples/MAX32572/SMON/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SPI/.cproject
+++ b/Examples/MAX32572/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/SPI/.vscode/settings.json
+++ b/Examples/MAX32572/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SPIXF/.cproject
+++ b/Examples/MAX32572/SPIXF/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/SPIXF/.vscode/settings.json
+++ b/Examples/MAX32572/SPIXF/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SPIXR/.cproject
+++ b/Examples/MAX32572/SPIXR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/SPIXR/.vscode/settings.json
+++ b/Examples/MAX32572/SPIXR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SPI_MasterSlave/.cproject
+++ b/Examples/MAX32572/SPI_MasterSlave/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32572/SPI_MasterSlave/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SPI_Usecase/.cproject
+++ b/Examples/MAX32572/SPI_Usecase/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/SPI_Usecase/.vscode/settings.json
+++ b/Examples/MAX32572/SPI_Usecase/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/SRCC/.cproject
+++ b/Examples/MAX32572/SRCC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/SRCC/.vscode/settings.json
+++ b/Examples/MAX32572/SRCC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Security_Monitor/.cproject
+++ b/Examples/MAX32572/Security_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Security_Monitor/.vscode/settings.json
+++ b/Examples/MAX32572/Security_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Semaphore/.cproject
+++ b/Examples/MAX32572/Semaphore/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Semaphore/.vscode/settings.json
+++ b/Examples/MAX32572/Semaphore/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/TFT_Demo/.cproject
+++ b/Examples/MAX32572/TFT_Demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX32572/TFT_Demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/TMR/.cproject
+++ b/Examples/MAX32572/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/TMR/.vscode/settings.json
+++ b/Examples/MAX32572/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/TRNG/.cproject
+++ b/Examples/MAX32572/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/TRNG/.vscode/settings.json
+++ b/Examples/MAX32572/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Temp_Monitor/.cproject
+++ b/Examples/MAX32572/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32572/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/UART/.cproject
+++ b/Examples/MAX32572/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/UART/.vscode/settings.json
+++ b/Examples/MAX32572/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/USB_CDCACM/.cproject
+++ b/Examples/MAX32572/USB_CDCACM/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core/musbhsfc&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>

--- a/Examples/MAX32572/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX32572/USB_CDCACM/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/USB_CompositeDevice_MSC_CDC/.cproject
+++ b/Examples/MAX32572/USB_CompositeDevice_MSC_CDC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core/musbhsfc&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>

--- a/Examples/MAX32572/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX32572/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/USB_CompositeDevice_MSC_HID/.cproject
+++ b/Examples/MAX32572/USB_CompositeDevice_MSC_HID/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core/musbhsfc&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>

--- a/Examples/MAX32572/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX32572/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/USB_HIDKeyboard/.cproject
+++ b/Examples/MAX32572/USB_HIDKeyboard/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core/musbhsfc&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>

--- a/Examples/MAX32572/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX32572/USB_HIDKeyboard/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/USB_MassStorage/.cproject
+++ b/Examples/MAX32572/USB_MassStorage/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core/musbhsfc&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>

--- a/Examples/MAX32572/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX32572/USB_MassStorage/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/Watchdog/.cproject
+++ b/Examples/MAX32572/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32572/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32572/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/WearLeveling/.cproject
+++ b/Examples/MAX32572/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32572/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32572/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/lwIP_Ping/.cproject
+++ b/Examples/MAX32572/lwIP_Ping/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/lwIP/include/Maxim&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/lwIP/include&quot;"/>

--- a/Examples/MAX32572/lwIP_Ping/.vscode/settings.json
+++ b/Examples/MAX32572/lwIP_Ping/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32572/lwIP_TCP/.cproject
+++ b/Examples/MAX32572/lwIP_TCP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/lwIP/include/Maxim&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/lwIP/include&quot;"/>

--- a/Examples/MAX32572/lwIP_TCP/.vscode/settings.json
+++ b/Examples/MAX32572/lwIP_TCP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ADC/.cproject
+++ b/Examples/MAX32650/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/ADC/.vscode/settings.json
+++ b/Examples/MAX32650/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ADC_MAX11261/.cproject
+++ b/Examples/MAX32650/ADC_MAX11261/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/ADC_MAX11261/.vscode/settings.json
+++ b/Examples/MAX32650/ADC_MAX11261/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/AES/.cproject
+++ b/Examples/MAX32650/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/AES/.vscode/settings.json
+++ b/Examples/MAX32650/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32650/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32650/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/CLCD/.cproject
+++ b/Examples/MAX32650/CLCD/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/CLCD/.vscode/settings.json
+++ b/Examples/MAX32650/CLCD/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/CRC/.cproject
+++ b/Examples/MAX32650/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/CRC/.vscode/settings.json
+++ b/Examples/MAX32650/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Coremark/.cproject
+++ b/Examples/MAX32650/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Coremark/.vscode/settings.json
+++ b/Examples/MAX32650/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/DES/.cproject
+++ b/Examples/MAX32650/DES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/DES/.vscode/settings.json
+++ b/Examples/MAX32650/DES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/DMA/.cproject
+++ b/Examples/MAX32650/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/DMA/.vscode/settings.json
+++ b/Examples/MAX32650/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32650/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32650/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/EMCC/.cproject
+++ b/Examples/MAX32650/EMCC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/EMCC/.vscode/settings.json
+++ b/Examples/MAX32650/EMCC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Flash/.cproject
+++ b/Examples/MAX32650/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Flash/.vscode/settings.json
+++ b/Examples/MAX32650/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Flash_CLI/.cproject
+++ b/Examples/MAX32650/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32650/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32650/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32650/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32650/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32650/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/GPIO/.cproject
+++ b/Examples/MAX32650/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/GPIO/.vscode/settings.json
+++ b/Examples/MAX32650/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/HBMC/.cproject
+++ b/Examples/MAX32650/HBMC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/HBMC/.vscode/settings.json
+++ b/Examples/MAX32650/HBMC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Hello_World/.cproject
+++ b/Examples/MAX32650/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32650/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32650/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32650/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/I2C/.cproject
+++ b/Examples/MAX32650/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/I2C/.vscode/settings.json
+++ b/Examples/MAX32650/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/I2C_MNGR/.cproject
+++ b/Examples/MAX32650/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32650/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32650/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/I2C_SCAN/.cproject
+++ b/Examples/MAX32650/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32650/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/I2C_Sensor/.cproject
+++ b/Examples/MAX32650/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32650/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/I2S/.cproject
+++ b/Examples/MAX32650/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/I2S/.vscode/settings.json
+++ b/Examples/MAX32650/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/ICC/.cproject
+++ b/Examples/MAX32650/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/ICC/.vscode/settings.json
+++ b/Examples/MAX32650/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/LP/.cproject
+++ b/Examples/MAX32650/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/LP/.vscode/settings.json
+++ b/Examples/MAX32650/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Library_Generate/.cproject
+++ b/Examples/MAX32650/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32650/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Library_Use/.cproject
+++ b/Examples/MAX32650/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32650/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/MAA/.cproject
+++ b/Examples/MAX32650/MAA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/MAA/.vscode/settings.json
+++ b/Examples/MAX32650/MAA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/OTP_Dump/.cproject
+++ b/Examples/MAX32650/OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32650/OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/OWM/.cproject
+++ b/Examples/MAX32650/OWM/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/OWM/.vscode/settings.json
+++ b/Examples/MAX32650/OWM/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Pulse_Train/.cproject
+++ b/Examples/MAX32650/Pulse_Train/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32650/Pulse_Train/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/RTC/.cproject
+++ b/Examples/MAX32650/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/RTC/.vscode/settings.json
+++ b/Examples/MAX32650/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/RTC_Backup/.cproject
+++ b/Examples/MAX32650/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32650/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SCPA_OTP_Dump/.cproject
+++ b/Examples/MAX32650/SCPA_OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32650/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32650/SCPA_OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SDHC_FAT/.cproject
+++ b/Examples/MAX32650/SDHC_FAT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/ff14/Source&quot;"/>

--- a/Examples/MAX32650/SDHC_FAT/.vscode/settings.json
+++ b/Examples/MAX32650/SDHC_FAT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SDHC_Raw/.cproject
+++ b/Examples/MAX32650/SDHC_Raw/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/ff14/Source&quot;"/>

--- a/Examples/MAX32650/SDHC_Raw/.vscode/settings.json
+++ b/Examples/MAX32650/SDHC_Raw/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SPI/.cproject
+++ b/Examples/MAX32650/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/SPI/.vscode/settings.json
+++ b/Examples/MAX32650/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SPIMSS/.cproject
+++ b/Examples/MAX32650/SPIMSS/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/SPIMSS/.vscode/settings.json
+++ b/Examples/MAX32650/SPIMSS/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SPIXF/.cproject
+++ b/Examples/MAX32650/SPIXF/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/SPIXF/.vscode/settings.json
+++ b/Examples/MAX32650/SPIXF/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SPIXF_ICC/.cproject
+++ b/Examples/MAX32650/SPIXF_ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/SPIXF_ICC/.vscode/settings.json
+++ b/Examples/MAX32650/SPIXF_ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SPIXR/.cproject
+++ b/Examples/MAX32650/SPIXR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/SPIXR/.vscode/settings.json
+++ b/Examples/MAX32650/SPIXR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SPI_MasterSlave/.cproject
+++ b/Examples/MAX32650/SPI_MasterSlave/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32650/SPI_MasterSlave/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Semaphore/.cproject
+++ b/Examples/MAX32650/Semaphore/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Semaphore/.vscode/settings.json
+++ b/Examples/MAX32650/Semaphore/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/SysTick/.cproject
+++ b/Examples/MAX32650/SysTick/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/SysTick/.vscode/settings.json
+++ b/Examples/MAX32650/SysTick/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/TMR/.cproject
+++ b/Examples/MAX32650/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/TMR/.vscode/settings.json
+++ b/Examples/MAX32650/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/TRNG/.cproject
+++ b/Examples/MAX32650/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/TRNG/.vscode/settings.json
+++ b/Examples/MAX32650/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Temp_Monitor/.cproject
+++ b/Examples/MAX32650/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32650/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/UART/.cproject
+++ b/Examples/MAX32650/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/UART/.vscode/settings.json
+++ b/Examples/MAX32650/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/UCL/.cproject
+++ b/Examples/MAX32650/UCL/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/UCL/.vscode/settings.json
+++ b/Examples/MAX32650/UCL/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/USB_CDCACM/.cproject
+++ b/Examples/MAX32650/USB_CDCACM/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32650/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX32650/USB_CDCACM/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/USB_CompositeDevice_MSC_CDC/.cproject
+++ b/Examples/MAX32650/USB_CompositeDevice_MSC_CDC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32650/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX32650/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/USB_CompositeDevice_MSC_HID/.cproject
+++ b/Examples/MAX32650/USB_CompositeDevice_MSC_HID/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32650/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX32650/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/USB_HIDKeyboard/.cproject
+++ b/Examples/MAX32650/USB_HIDKeyboard/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32650/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX32650/USB_HIDKeyboard/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/USB_MassStorage/.cproject
+++ b/Examples/MAX32650/USB_MassStorage/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32650/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX32650/USB_MassStorage/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/Watchdog/.cproject
+++ b/Examples/MAX32650/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32650/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32650/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32650/WearLeveling/.cproject
+++ b/Examples/MAX32650/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32650/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32650/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ADC/.cproject
+++ b/Examples/MAX32655/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/ADC/.vscode/settings.json
+++ b/Examples/MAX32655/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/AES/.cproject
+++ b/Examples/MAX32655/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/AES/.vscode/settings.json
+++ b/Examples/MAX32655/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32655/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32655/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE4_ctr/.cproject
+++ b/Examples/MAX32655/BLE4_ctr/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE4_ctr/.vscode/settings.json
+++ b/Examples/MAX32655/BLE4_ctr/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE5_ctr/.cproject
+++ b/Examples/MAX32655/BLE5_ctr/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE5_ctr/.vscode/settings.json
+++ b/Examples/MAX32655/BLE5_ctr/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_FreeRTOS/.cproject
+++ b/Examples/MAX32655/BLE_FreeRTOS/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_FreeRTOS/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -71,7 +70,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_datc/.cproject
+++ b/Examples/MAX32655/BLE_datc/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_datc/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_datc/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_dats/.cproject
+++ b/Examples/MAX32655/BLE_dats/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_dats/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_dats/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_fcc/.cproject
+++ b/Examples/MAX32655/BLE_fcc/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_fcc/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_fcc/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_fit/.cproject
+++ b/Examples/MAX32655/BLE_fit/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_fit/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_fit/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_fit_FreeRTOS/.cproject
+++ b/Examples/MAX32655/BLE_fit_FreeRTOS/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_fit_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_fit_FreeRTOS/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -71,7 +70,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_mcs/.cproject
+++ b/Examples/MAX32655/BLE_mcs/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_mcs/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_mcs/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_otac/.cproject
+++ b/Examples/MAX32655/BLE_otac/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_otac/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_otac/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_otas/.cproject
+++ b/Examples/MAX32655/BLE_otas/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_otas/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_otas/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/BLE_periph/.cproject
+++ b/Examples/MAX32655/BLE_periph/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32655/BLE_periph/.vscode/settings.json
+++ b/Examples/MAX32655/BLE_periph/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Bootloader/.cproject
+++ b/Examples/MAX32655/Bootloader/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Bootloader/.vscode/settings.json
+++ b/Examples/MAX32655/Bootloader/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/CRC/.cproject
+++ b/Examples/MAX32655/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/CRC/.vscode/settings.json
+++ b/Examples/MAX32655/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Coremark/.cproject
+++ b/Examples/MAX32655/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Coremark/.vscode/settings.json
+++ b/Examples/MAX32655/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/DMA/.cproject
+++ b/Examples/MAX32655/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/DMA/.vscode/settings.json
+++ b/Examples/MAX32655/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.cproject
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.vscode/settings.json
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_arm/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.cproject
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.vscode/settings.json
+++ b/Examples/MAX32655/Dual_core_sync/Dual_core_sync_riscv/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32655/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32655/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/External_Flash/.cproject
+++ b/Examples/MAX32655/External_Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/External_Flash/.vscode/settings.json
+++ b/Examples/MAX32655/External_Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/FTHR_I2C/.cproject
+++ b/Examples/MAX32655/FTHR_I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/FTHR_I2C/.vscode/settings.json
+++ b/Examples/MAX32655/FTHR_I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Flash/.cproject
+++ b/Examples/MAX32655/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Flash/.vscode/settings.json
+++ b/Examples/MAX32655/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Flash_CLI/.cproject
+++ b/Examples/MAX32655/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32655/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32655/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32655/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32655/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32655/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/GPIO/.cproject
+++ b/Examples/MAX32655/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/GPIO/.vscode/settings.json
+++ b/Examples/MAX32655/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Hello_World-riscv/.cproject
+++ b/Examples/MAX32655/Hello_World-riscv/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Hello_World-riscv/.vscode/settings.json
+++ b/Examples/MAX32655/Hello_World-riscv/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Hello_World/.cproject
+++ b/Examples/MAX32655/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32655/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32655/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32655/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/I2C/.cproject
+++ b/Examples/MAX32655/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/I2C/.vscode/settings.json
+++ b/Examples/MAX32655/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/I2C_MNGR/.cproject
+++ b/Examples/MAX32655/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32655/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32655/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/I2C_SCAN/.cproject
+++ b/Examples/MAX32655/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32655/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/I2C_Sensor/.cproject
+++ b/Examples/MAX32655/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32655/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/I2S/.cproject
+++ b/Examples/MAX32655/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/I2S/.vscode/settings.json
+++ b/Examples/MAX32655/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/I2S_Playback/.cproject
+++ b/Examples/MAX32655/I2S_Playback/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/I2S_Playback/.vscode/settings.json
+++ b/Examples/MAX32655/I2S_Playback/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/ICC/.cproject
+++ b/Examples/MAX32655/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/ICC/.vscode/settings.json
+++ b/Examples/MAX32655/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/LP/.cproject
+++ b/Examples/MAX32655/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/LP/.vscode/settings.json
+++ b/Examples/MAX32655/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/LPCMP/.cproject
+++ b/Examples/MAX32655/LPCMP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/LPCMP/.vscode/settings.json
+++ b/Examples/MAX32655/LPCMP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Library_Generate/.cproject
+++ b/Examples/MAX32655/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32655/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Library_Use/.cproject
+++ b/Examples/MAX32655/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32655/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Pulse_Train/.cproject
+++ b/Examples/MAX32655/Pulse_Train/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32655/Pulse_Train/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/RF_Test/.cproject
+++ b/Examples/MAX32655/RF_Test/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32655/RF_Test/.vscode/settings.json
+++ b/Examples/MAX32655/RF_Test/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/RTC/.cproject
+++ b/Examples/MAX32655/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/RTC/.vscode/settings.json
+++ b/Examples/MAX32655/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/RTC_Backup/.cproject
+++ b/Examples/MAX32655/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32655/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/RV_ARM_Loader/.cproject
+++ b/Examples/MAX32655/RV_ARM_Loader/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/RV_ARM_Loader/.vscode/settings.json
+++ b/Examples/MAX32655/RV_ARM_Loader/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/SPI/.cproject
+++ b/Examples/MAX32655/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/SPI/.vscode/settings.json
+++ b/Examples/MAX32655/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/TFT_Demo/.cproject
+++ b/Examples/MAX32655/TFT_Demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32655/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX32655/TFT_Demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/TMR/.cproject
+++ b/Examples/MAX32655/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/TMR/.vscode/settings.json
+++ b/Examples/MAX32655/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/TRNG/.cproject
+++ b/Examples/MAX32655/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/TRNG/.vscode/settings.json
+++ b/Examples/MAX32655/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Temp_Monitor/.cproject
+++ b/Examples/MAX32655/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32655/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/UART/.cproject
+++ b/Examples/MAX32655/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/UART/.vscode/settings.json
+++ b/Examples/MAX32655/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/UCL/.cproject
+++ b/Examples/MAX32655/UCL/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/UCL/.vscode/settings.json
+++ b/Examples/MAX32655/UCL/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/WUT/.cproject
+++ b/Examples/MAX32655/WUT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/WUT/.vscode/settings.json
+++ b/Examples/MAX32655/WUT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/Watchdog/.cproject
+++ b/Examples/MAX32655/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32655/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32655/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32655/WearLeveling/.cproject
+++ b/Examples/MAX32655/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32655/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32655/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32660/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32660/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32660/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Bootloader_Host/.cproject
+++ b/Examples/MAX32660/Bootloader_Host/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Bootloader_Host/.vscode/settings.json
+++ b/Examples/MAX32660/Bootloader_Host/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Coremark/.cproject
+++ b/Examples/MAX32660/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Coremark/.vscode/settings.json
+++ b/Examples/MAX32660/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/DMA/.cproject
+++ b/Examples/MAX32660/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/DMA/.vscode/settings.json
+++ b/Examples/MAX32660/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32660/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32660/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Flash/.cproject
+++ b/Examples/MAX32660/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Flash/.vscode/settings.json
+++ b/Examples/MAX32660/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Flash_CLI/.cproject
+++ b/Examples/MAX32660/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32660/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32660/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32660/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32660/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32660/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/GPIO/.cproject
+++ b/Examples/MAX32660/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/GPIO/.vscode/settings.json
+++ b/Examples/MAX32660/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Hello_World/.cproject
+++ b/Examples/MAX32660/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32660/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32660/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32660/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/I2C/.cproject
+++ b/Examples/MAX32660/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/I2C/.vscode/settings.json
+++ b/Examples/MAX32660/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/I2C_MNGR/.cproject
+++ b/Examples/MAX32660/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32660/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32660/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/I2C_SCAN/.cproject
+++ b/Examples/MAX32660/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32660/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/I2C_Sensor/.cproject
+++ b/Examples/MAX32660/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32660/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/I2S/.cproject
+++ b/Examples/MAX32660/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/I2S/.vscode/settings.json
+++ b/Examples/MAX32660/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/ICC/.cproject
+++ b/Examples/MAX32660/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/ICC/.vscode/settings.json
+++ b/Examples/MAX32660/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Info_Block_Usecase/.cproject
+++ b/Examples/MAX32660/Info_Block_Usecase/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Info_Block_Usecase/.vscode/settings.json
+++ b/Examples/MAX32660/Info_Block_Usecase/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/LP/.cproject
+++ b/Examples/MAX32660/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/LP/.vscode/settings.json
+++ b/Examples/MAX32660/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Library_Generate/.cproject
+++ b/Examples/MAX32660/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32660/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Library_Use/.cproject
+++ b/Examples/MAX32660/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32660/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/RTC/.cproject
+++ b/Examples/MAX32660/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/RTC/.vscode/settings.json
+++ b/Examples/MAX32660/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/RTC_Backup/.cproject
+++ b/Examples/MAX32660/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32660/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/SPI/.cproject
+++ b/Examples/MAX32660/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/SPI/.vscode/settings.json
+++ b/Examples/MAX32660/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/SPIMSS/.cproject
+++ b/Examples/MAX32660/SPIMSS/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/SPIMSS/.vscode/settings.json
+++ b/Examples/MAX32660/SPIMSS/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/SPI_MasterSlave/.cproject
+++ b/Examples/MAX32660/SPI_MasterSlave/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32660/SPI_MasterSlave/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/SecureROM_BL_Host/.cproject
+++ b/Examples/MAX32660/SecureROM_BL_Host/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/SecureROM_BL_Host/.vscode/settings.json
+++ b/Examples/MAX32660/SecureROM_BL_Host/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/TMR/.cproject
+++ b/Examples/MAX32660/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/TMR/.vscode/settings.json
+++ b/Examples/MAX32660/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Temp_Monitor/.cproject
+++ b/Examples/MAX32660/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32660/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/UART/.cproject
+++ b/Examples/MAX32660/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/UART/.vscode/settings.json
+++ b/Examples/MAX32660/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/UART_Wakeup/.cproject
+++ b/Examples/MAX32660/UART_Wakeup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/UART_Wakeup/.vscode/settings.json
+++ b/Examples/MAX32660/UART_Wakeup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/Watchdog/.cproject
+++ b/Examples/MAX32660/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32660/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32660/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32660/WearLeveling/.cproject
+++ b/Examples/MAX32660/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32660/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32660/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ADC/.cproject
+++ b/Examples/MAX32662/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/ADC/.vscode/settings.json
+++ b/Examples/MAX32662/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32662/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32662/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Bootloader_Host/.cproject
+++ b/Examples/MAX32662/Bootloader_Host/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Bootloader_Host/.vscode/settings.json
+++ b/Examples/MAX32662/Bootloader_Host/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/CAN/.cproject
+++ b/Examples/MAX32662/CAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/CAN/.vscode/settings.json
+++ b/Examples/MAX32662/CAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Coremark/.cproject
+++ b/Examples/MAX32662/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Coremark/.vscode/settings.json
+++ b/Examples/MAX32662/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/DMA/.cproject
+++ b/Examples/MAX32662/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/DMA/.vscode/settings.json
+++ b/Examples/MAX32662/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Demo/.cproject
+++ b/Examples/MAX32662/Demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Demo/.vscode/settings.json
+++ b/Examples/MAX32662/Demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32662/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32662/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Flash/.cproject
+++ b/Examples/MAX32662/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Flash/.vscode/settings.json
+++ b/Examples/MAX32662/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Flash_CLI/.cproject
+++ b/Examples/MAX32662/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32662/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32662/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/GPIO/.cproject
+++ b/Examples/MAX32662/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/GPIO/.vscode/settings.json
+++ b/Examples/MAX32662/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Hello_World/.cproject
+++ b/Examples/MAX32662/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32662/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32662/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32662/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/I2C/.cproject
+++ b/Examples/MAX32662/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/I2C/.vscode/settings.json
+++ b/Examples/MAX32662/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/I2C_MNGR/.cproject
+++ b/Examples/MAX32662/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32662/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32662/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/I2C_SCAN/.cproject
+++ b/Examples/MAX32662/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32662/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/I2C_Sensor/.cproject
+++ b/Examples/MAX32662/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32662/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/I2S/.cproject
+++ b/Examples/MAX32662/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/I2S/.vscode/settings.json
+++ b/Examples/MAX32662/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/ICC/.cproject
+++ b/Examples/MAX32662/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/ICC/.vscode/settings.json
+++ b/Examples/MAX32662/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Info_Block_Usecase/.cproject
+++ b/Examples/MAX32662/Info_Block_Usecase/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Info_Block_Usecase/.vscode/settings.json
+++ b/Examples/MAX32662/Info_Block_Usecase/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/LP/.cproject
+++ b/Examples/MAX32662/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/LP/.vscode/settings.json
+++ b/Examples/MAX32662/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Library_Generate/.cproject
+++ b/Examples/MAX32662/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32662/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Library_Use/.cproject
+++ b/Examples/MAX32662/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32662/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/RTC/.cproject
+++ b/Examples/MAX32662/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/RTC/.vscode/settings.json
+++ b/Examples/MAX32662/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/RTC_Backup/.cproject
+++ b/Examples/MAX32662/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32662/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/SCPA_OTP_Dump/.cproject
+++ b/Examples/MAX32662/SCPA_OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32662/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32662/SCPA_OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/SPI/.cproject
+++ b/Examples/MAX32662/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/SPI/.vscode/settings.json
+++ b/Examples/MAX32662/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/SPI_MasterSlave/.cproject
+++ b/Examples/MAX32662/SPI_MasterSlave/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32662/SPI_MasterSlave/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/TMR/.cproject
+++ b/Examples/MAX32662/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/TMR/.vscode/settings.json
+++ b/Examples/MAX32662/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Temp_Monitor/.cproject
+++ b/Examples/MAX32662/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32662/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/UART/.cproject
+++ b/Examples/MAX32662/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/UART/.vscode/settings.json
+++ b/Examples/MAX32662/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/UART_Wakeup/.cproject
+++ b/Examples/MAX32662/UART_Wakeup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/UART_Wakeup/.vscode/settings.json
+++ b/Examples/MAX32662/UART_Wakeup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/UCL/.cproject
+++ b/Examples/MAX32662/UCL/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/UCL/.vscode/settings.json
+++ b/Examples/MAX32662/UCL/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/Watchdog/.cproject
+++ b/Examples/MAX32662/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32662/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32662/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32662/WearLeveling/.cproject
+++ b/Examples/MAX32662/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32662/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32662/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ADC/.cproject
+++ b/Examples/MAX32665/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/ADC/.vscode/settings.json
+++ b/Examples/MAX32665/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/AES/.cproject
+++ b/Examples/MAX32665/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/AES/.vscode/settings.json
+++ b/Examples/MAX32665/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32665/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32665/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE4_ctr/.cproject
+++ b/Examples/MAX32665/BLE4_ctr/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE4_ctr/.vscode/settings.json
+++ b/Examples/MAX32665/BLE4_ctr/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE5_ctr/.cproject
+++ b/Examples/MAX32665/BLE5_ctr/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE5_ctr/.vscode/settings.json
+++ b/Examples/MAX32665/BLE5_ctr/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_FreeRTOS/.cproject
+++ b/Examples/MAX32665/BLE_FreeRTOS/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_FreeRTOS/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -72,7 +71,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_datc/.cproject
+++ b/Examples/MAX32665/BLE_datc/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_datc/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_datc/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_dats/.cproject
+++ b/Examples/MAX32665/BLE_dats/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_dats/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_dats/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_fcc/.cproject
+++ b/Examples/MAX32665/BLE_fcc/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_fcc/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_fcc/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_fit/.cproject
+++ b/Examples/MAX32665/BLE_fit/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_fit/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_fit/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_mcs/.cproject
+++ b/Examples/MAX32665/BLE_mcs/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_mcs/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_mcs/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_otac/.cproject
+++ b/Examples/MAX32665/BLE_otac/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_otac/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_otac/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_otas/.cproject
+++ b/Examples/MAX32665/BLE_otas/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_otas/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_otas/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -69,7 +68,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/BLE_periph/.cproject
+++ b/Examples/MAX32665/BLE_periph/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/BLE_periph/.vscode/settings.json
+++ b/Examples/MAX32665/BLE_periph/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Bootloader/.cproject
+++ b/Examples/MAX32665/Bootloader/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/Bootloader/.vscode/settings.json
+++ b/Examples/MAX32665/Bootloader/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Bootloader_Host/.cproject
+++ b/Examples/MAX32665/Bootloader_Host/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/Bootloader_Host/.vscode/settings.json
+++ b/Examples/MAX32665/Bootloader_Host/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/CRC/.cproject
+++ b/Examples/MAX32665/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/CRC/.vscode/settings.json
+++ b/Examples/MAX32665/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Coremark/.cproject
+++ b/Examples/MAX32665/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/Coremark/.vscode/settings.json
+++ b/Examples/MAX32665/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/DES/.cproject
+++ b/Examples/MAX32665/DES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/DES/.vscode/settings.json
+++ b/Examples/MAX32665/DES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/DMA/.cproject
+++ b/Examples/MAX32665/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/DMA/.vscode/settings.json
+++ b/Examples/MAX32665/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Demo/.cproject
+++ b/Examples/MAX32665/Demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/LVGL/lvgl&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/LVGL/lvgl/src&quot;"/>

--- a/Examples/MAX32665/Demo/.vscode/settings.json
+++ b/Examples/MAX32665/Demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Display/.cproject
+++ b/Examples/MAX32665/Display/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/LVGL/lvgl&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/LVGL/lvgl/src&quot;"/>

--- a/Examples/MAX32665/Display/.vscode/settings.json
+++ b/Examples/MAX32665/Display/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ECC/.cproject
+++ b/Examples/MAX32665/ECC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/ECC/.vscode/settings.json
+++ b/Examples/MAX32665/ECC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32665/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32665/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Flash/.cproject
+++ b/Examples/MAX32665/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/Flash/.vscode/settings.json
+++ b/Examples/MAX32665/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Flash_CLI/.cproject
+++ b/Examples/MAX32665/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32665/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32665/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32665/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32665/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32665/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -60,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/GPIO/.cproject
+++ b/Examples/MAX32665/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/GPIO/.vscode/settings.json
+++ b/Examples/MAX32665/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/HTMR/.cproject
+++ b/Examples/MAX32665/HTMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/HTMR/.vscode/settings.json
+++ b/Examples/MAX32665/HTMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Hash/.cproject
+++ b/Examples/MAX32665/Hash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/Hash/.vscode/settings.json
+++ b/Examples/MAX32665/Hash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Hello_World/.cproject
+++ b/Examples/MAX32665/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32665/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32665/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32665/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/I2C/.cproject
+++ b/Examples/MAX32665/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/I2C/.vscode/settings.json
+++ b/Examples/MAX32665/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/I2C_MNGR/.cproject
+++ b/Examples/MAX32665/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32665/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32665/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/I2C_SCAN/.cproject
+++ b/Examples/MAX32665/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32665/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/I2C_Sensor/.cproject
+++ b/Examples/MAX32665/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32665/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/ICC/.cproject
+++ b/Examples/MAX32665/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/ICC/.vscode/settings.json
+++ b/Examples/MAX32665/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/LP/.cproject
+++ b/Examples/MAX32665/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/LP/.vscode/settings.json
+++ b/Examples/MAX32665/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Library_Generate/.cproject
+++ b/Examples/MAX32665/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32665/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Library_Use/.cproject
+++ b/Examples/MAX32665/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32665/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/MAA/.cproject
+++ b/Examples/MAX32665/MAA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/MAA/.vscode/settings.json
+++ b/Examples/MAX32665/MAA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/OTP_Dump/.cproject
+++ b/Examples/MAX32665/OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32665/OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/OWM/.cproject
+++ b/Examples/MAX32665/OWM/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/OWM/.vscode/settings.json
+++ b/Examples/MAX32665/OWM/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Pulse_Train/.cproject
+++ b/Examples/MAX32665/Pulse_Train/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32665/Pulse_Train/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/RF_Test/.cproject
+++ b/Examples/MAX32665/RF_Test/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32665/RF_Test/.vscode/settings.json
+++ b/Examples/MAX32665/RF_Test/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -72,7 +71,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/RPU/.cproject
+++ b/Examples/MAX32665/RPU/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/RPU/.vscode/settings.json
+++ b/Examples/MAX32665/RPU/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/RTC/.cproject
+++ b/Examples/MAX32665/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/RTC/.vscode/settings.json
+++ b/Examples/MAX32665/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/RTC_Backup/.cproject
+++ b/Examples/MAX32665/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32665/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/SCPA_OTP_Dump/.cproject
+++ b/Examples/MAX32665/SCPA_OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32665/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32665/SCPA_OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/SDHC_FAT/.cproject
+++ b/Examples/MAX32665/SDHC_FAT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/ff14/Source&quot;"/>

--- a/Examples/MAX32665/SDHC_FAT/.vscode/settings.json
+++ b/Examples/MAX32665/SDHC_FAT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/SDHC_Raw/.cproject
+++ b/Examples/MAX32665/SDHC_Raw/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/ff14/Source&quot;"/>

--- a/Examples/MAX32665/SDHC_Raw/.vscode/settings.json
+++ b/Examples/MAX32665/SDHC_Raw/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/SPI/.cproject
+++ b/Examples/MAX32665/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/SPI/.vscode/settings.json
+++ b/Examples/MAX32665/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/SPIXF/.cproject
+++ b/Examples/MAX32665/SPIXF/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/SPIXF/.vscode/settings.json
+++ b/Examples/MAX32665/SPIXF/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/SPIXF_SFCC/.cproject
+++ b/Examples/MAX32665/SPIXF_SFCC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/SPIXF_SFCC/.vscode/settings.json
+++ b/Examples/MAX32665/SPIXF_SFCC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/SPIXR/.cproject
+++ b/Examples/MAX32665/SPIXR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/SPIXR/.vscode/settings.json
+++ b/Examples/MAX32665/SPIXR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/SRCC/.cproject
+++ b/Examples/MAX32665/SRCC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/SRCC/.vscode/settings.json
+++ b/Examples/MAX32665/SRCC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Semaphore/.cproject
+++ b/Examples/MAX32665/Semaphore/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/Semaphore/.vscode/settings.json
+++ b/Examples/MAX32665/Semaphore/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/TMR/.cproject
+++ b/Examples/MAX32665/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/TMR/.vscode/settings.json
+++ b/Examples/MAX32665/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/TRNG/.cproject
+++ b/Examples/MAX32665/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/TRNG/.vscode/settings.json
+++ b/Examples/MAX32665/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Temp_Monitor/.cproject
+++ b/Examples/MAX32665/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32665/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/UART/.cproject
+++ b/Examples/MAX32665/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/UART/.vscode/settings.json
+++ b/Examples/MAX32665/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/UCL/.cproject
+++ b/Examples/MAX32665/UCL/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32665/UCL/.vscode/settings.json
+++ b/Examples/MAX32665/UCL/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/USB_CDCACM/.cproject
+++ b/Examples/MAX32665/USB_CDCACM/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32665/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX32665/USB_CDCACM/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/USB_CompositeDevice_MSC_CDC/.cproject
+++ b/Examples/MAX32665/USB_CompositeDevice_MSC_CDC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32665/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX32665/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/USB_CompositeDevice_MSC_HID/.cproject
+++ b/Examples/MAX32665/USB_CompositeDevice_MSC_HID/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32665/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX32665/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/USB_HIDKeyboard/.cproject
+++ b/Examples/MAX32665/USB_HIDKeyboard/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32665/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX32665/USB_HIDKeyboard/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/USB_MassStorage/.cproject
+++ b/Examples/MAX32665/USB_MassStorage/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32665/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX32665/USB_MassStorage/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/WUT/.cproject
+++ b/Examples/MAX32665/WUT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/WUT/.vscode/settings.json
+++ b/Examples/MAX32665/WUT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/Watchdog/.cproject
+++ b/Examples/MAX32665/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32665/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32665/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32665/WearLeveling/.cproject
+++ b/Examples/MAX32665/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32665/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32665/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/AES/.cproject
+++ b/Examples/MAX32670/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/AES/.vscode/settings.json
+++ b/Examples/MAX32670/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32670/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32670/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32670/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/CRC/.cproject
+++ b/Examples/MAX32670/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/CRC/.vscode/settings.json
+++ b/Examples/MAX32670/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Coremark/.cproject
+++ b/Examples/MAX32670/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/Coremark/.vscode/settings.json
+++ b/Examples/MAX32670/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/DMA/.cproject
+++ b/Examples/MAX32670/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/DMA/.vscode/settings.json
+++ b/Examples/MAX32670/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32670/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32670/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/EXT_CLK/.cproject
+++ b/Examples/MAX32670/EXT_CLK/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/EXT_CLK/.vscode/settings.json
+++ b/Examples/MAX32670/EXT_CLK/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Flash/.cproject
+++ b/Examples/MAX32670/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/Flash/.vscode/settings.json
+++ b/Examples/MAX32670/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Flash_CLI/.cproject
+++ b/Examples/MAX32670/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32670/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32670/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32670/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32670/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32670/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/GPIO/.cproject
+++ b/Examples/MAX32670/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/GPIO/.vscode/settings.json
+++ b/Examples/MAX32670/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Hello_World/.cproject
+++ b/Examples/MAX32670/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32670/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32670/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32670/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/I2C/.cproject
+++ b/Examples/MAX32670/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/I2C/.vscode/settings.json
+++ b/Examples/MAX32670/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/I2C_MNGR/.cproject
+++ b/Examples/MAX32670/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32670/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32670/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/I2C_SCAN/.cproject
+++ b/Examples/MAX32670/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32670/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/I2C_Sensor/.cproject
+++ b/Examples/MAX32670/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32670/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/I2S/.cproject
+++ b/Examples/MAX32670/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/I2S/.vscode/settings.json
+++ b/Examples/MAX32670/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/ICC/.cproject
+++ b/Examples/MAX32670/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/ICC/.vscode/settings.json
+++ b/Examples/MAX32670/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/LP/.cproject
+++ b/Examples/MAX32670/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/LP/.vscode/settings.json
+++ b/Examples/MAX32670/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Library_Generate/.cproject
+++ b/Examples/MAX32670/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32670/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Library_Use/.cproject
+++ b/Examples/MAX32670/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32670/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/RTC/.cproject
+++ b/Examples/MAX32670/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/RTC/.vscode/settings.json
+++ b/Examples/MAX32670/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/RTC_Backup/.cproject
+++ b/Examples/MAX32670/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32670/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/SPI/.cproject
+++ b/Examples/MAX32670/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/SPI/.vscode/settings.json
+++ b/Examples/MAX32670/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/SPI_MasterSlave/.cproject
+++ b/Examples/MAX32670/SPI_MasterSlave/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32670/SPI_MasterSlave/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/SPI_Usecase/.cproject
+++ b/Examples/MAX32670/SPI_Usecase/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/SPI_Usecase/.vscode/settings.json
+++ b/Examples/MAX32670/SPI_Usecase/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/SecureROM_BL_Host/.cproject
+++ b/Examples/MAX32670/SecureROM_BL_Host/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/SecureROM_BL_Host/.vscode/settings.json
+++ b/Examples/MAX32670/SecureROM_BL_Host/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/TMR/.cproject
+++ b/Examples/MAX32670/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/TMR/.vscode/settings.json
+++ b/Examples/MAX32670/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/TRNG/.cproject
+++ b/Examples/MAX32670/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/TRNG/.vscode/settings.json
+++ b/Examples/MAX32670/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Temp_Monitor/.cproject
+++ b/Examples/MAX32670/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32670/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/UART/.cproject
+++ b/Examples/MAX32670/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/UART/.vscode/settings.json
+++ b/Examples/MAX32670/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/UCL/.cproject
+++ b/Examples/MAX32670/UCL/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/UCL/.vscode/settings.json
+++ b/Examples/MAX32670/UCL/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/Watchdog/.cproject
+++ b/Examples/MAX32670/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32670/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32670/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32670/WearLeveling/.cproject
+++ b/Examples/MAX32670/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32670/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32670/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ADC/.cproject
+++ b/Examples/MAX32672/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/ADC/.vscode/settings.json
+++ b/Examples/MAX32672/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/AES/.cproject
+++ b/Examples/MAX32672/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/AES/.vscode/settings.json
+++ b/Examples/MAX32672/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32672/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32672/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/CRC/.cproject
+++ b/Examples/MAX32672/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/CRC/.vscode/settings.json
+++ b/Examples/MAX32672/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/CTB_AES/.cproject
+++ b/Examples/MAX32672/CTB_AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/CTB_AES/.vscode/settings.json
+++ b/Examples/MAX32672/CTB_AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Comparator/.cproject
+++ b/Examples/MAX32672/Comparator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/Comparator/.vscode/settings.json
+++ b/Examples/MAX32672/Comparator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Coremark/.cproject
+++ b/Examples/MAX32672/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/Coremark/.vscode/settings.json
+++ b/Examples/MAX32672/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/DMA/.cproject
+++ b/Examples/MAX32672/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/DMA/.vscode/settings.json
+++ b/Examples/MAX32672/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Demo/.cproject
+++ b/Examples/MAX32672/Demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/Demo/.vscode/settings.json
+++ b/Examples/MAX32672/Demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Display/.cproject
+++ b/Examples/MAX32672/Display/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/LVGL/lvgl&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/LVGL/lvgl/src&quot;"/>

--- a/Examples/MAX32672/Display/.vscode/settings.json
+++ b/Examples/MAX32672/Display/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32672/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32672/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Flash/.cproject
+++ b/Examples/MAX32672/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/Flash/.vscode/settings.json
+++ b/Examples/MAX32672/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Flash_CLI/.cproject
+++ b/Examples/MAX32672/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32672/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32672/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32672/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32672/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32672/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -60,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/GPIO/.cproject
+++ b/Examples/MAX32672/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/GPIO/.vscode/settings.json
+++ b/Examples/MAX32672/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Hello_World/.cproject
+++ b/Examples/MAX32672/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32672/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32672/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32672/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/I2C/.cproject
+++ b/Examples/MAX32672/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/I2C/.vscode/settings.json
+++ b/Examples/MAX32672/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/I2C_MNGR/.cproject
+++ b/Examples/MAX32672/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32672/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32672/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/I2C_SCAN/.cproject
+++ b/Examples/MAX32672/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32672/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/I2C_Sensor/.cproject
+++ b/Examples/MAX32672/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32672/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/I2S/.cproject
+++ b/Examples/MAX32672/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/I2S/.vscode/settings.json
+++ b/Examples/MAX32672/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/ICC/.cproject
+++ b/Examples/MAX32672/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/ICC/.vscode/settings.json
+++ b/Examples/MAX32672/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/LP/.cproject
+++ b/Examples/MAX32672/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/LP/.vscode/settings.json
+++ b/Examples/MAX32672/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Library_Generate/.cproject
+++ b/Examples/MAX32672/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32672/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Library_Use/.cproject
+++ b/Examples/MAX32672/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32672/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/OLED_Demo/.cproject
+++ b/Examples/MAX32672/OLED_Demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/LVGL/lvgl&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/LVGL/lvgl/src&quot;"/>

--- a/Examples/MAX32672/OLED_Demo/.vscode/settings.json
+++ b/Examples/MAX32672/OLED_Demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/QDEC/.cproject
+++ b/Examples/MAX32672/QDEC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/QDEC/.vscode/settings.json
+++ b/Examples/MAX32672/QDEC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/RTC/.cproject
+++ b/Examples/MAX32672/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/RTC/.vscode/settings.json
+++ b/Examples/MAX32672/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/RTC_Backup/.cproject
+++ b/Examples/MAX32672/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32672/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/SCPA_OTP_Dump/.cproject
+++ b/Examples/MAX32672/SCPA_OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32672/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32672/SCPA_OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/SPI/.cproject
+++ b/Examples/MAX32672/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/SPI/.vscode/settings.json
+++ b/Examples/MAX32672/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/SPI_MasterSlave/.cproject
+++ b/Examples/MAX32672/SPI_MasterSlave/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX32672/SPI_MasterSlave/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/TMR/.cproject
+++ b/Examples/MAX32672/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/TMR/.vscode/settings.json
+++ b/Examples/MAX32672/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/TRNG/.cproject
+++ b/Examples/MAX32672/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/TRNG/.vscode/settings.json
+++ b/Examples/MAX32672/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Temp_Monitor/.cproject
+++ b/Examples/MAX32672/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32672/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/UART/.cproject
+++ b/Examples/MAX32672/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/UART/.vscode/settings.json
+++ b/Examples/MAX32672/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/UCL/.cproject
+++ b/Examples/MAX32672/UCL/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32672/UCL/.vscode/settings.json
+++ b/Examples/MAX32672/UCL/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/Watchdog/.cproject
+++ b/Examples/MAX32672/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX32672/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32672/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32672/WearLeveling/.cproject
+++ b/Examples/MAX32672/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32672/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32672/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ADC/.cproject
+++ b/Examples/MAX32675/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/ADC/.vscode/settings.json
+++ b/Examples/MAX32675/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/AES/.cproject
+++ b/Examples/MAX32675/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/AES/.vscode/settings.json
+++ b/Examples/MAX32675/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/AFE_DAC/.cproject
+++ b/Examples/MAX32675/AFE_DAC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/AFE_DAC/.vscode/settings.json
+++ b/Examples/MAX32675/AFE_DAC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32675/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32675/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32675/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/CRC/.cproject
+++ b/Examples/MAX32675/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/CRC/.vscode/settings.json
+++ b/Examples/MAX32675/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/Coremark/.cproject
+++ b/Examples/MAX32675/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/Coremark/.vscode/settings.json
+++ b/Examples/MAX32675/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/DMA/.cproject
+++ b/Examples/MAX32675/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/DMA/.vscode/settings.json
+++ b/Examples/MAX32675/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32675/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32675/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/Flash/.cproject
+++ b/Examples/MAX32675/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/Flash/.vscode/settings.json
+++ b/Examples/MAX32675/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/Flash_CLI/.cproject
+++ b/Examples/MAX32675/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32675/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32675/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32675/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32675/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32675/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/GPIO/.cproject
+++ b/Examples/MAX32675/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/GPIO/.vscode/settings.json
+++ b/Examples/MAX32675/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/HART_UART/.cproject
+++ b/Examples/MAX32675/HART_UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/HART_UART/.vscode/settings.json
+++ b/Examples/MAX32675/HART_UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/Hello_World/.cproject
+++ b/Examples/MAX32675/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32675/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32675/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32675/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/I2C/.cproject
+++ b/Examples/MAX32675/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/I2C/.vscode/settings.json
+++ b/Examples/MAX32675/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/I2C_MNGR/.cproject
+++ b/Examples/MAX32675/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32675/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32675/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/I2C_SCAN/.cproject
+++ b/Examples/MAX32675/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32675/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/I2C_Sensor/.cproject
+++ b/Examples/MAX32675/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32675/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/I2S/.cproject
+++ b/Examples/MAX32675/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/I2S/.vscode/settings.json
+++ b/Examples/MAX32675/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/ICC/.cproject
+++ b/Examples/MAX32675/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/ICC/.vscode/settings.json
+++ b/Examples/MAX32675/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/LP/.cproject
+++ b/Examples/MAX32675/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/LP/.vscode/settings.json
+++ b/Examples/MAX32675/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/Library_Generate/.cproject
+++ b/Examples/MAX32675/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32675/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/Library_Use/.cproject
+++ b/Examples/MAX32675/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32675/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/SPI/.cproject
+++ b/Examples/MAX32675/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/SPI/.vscode/settings.json
+++ b/Examples/MAX32675/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/TMR/.cproject
+++ b/Examples/MAX32675/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/TMR/.vscode/settings.json
+++ b/Examples/MAX32675/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/TRNG/.cproject
+++ b/Examples/MAX32675/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/TRNG/.vscode/settings.json
+++ b/Examples/MAX32675/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/UART/.cproject
+++ b/Examples/MAX32675/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/UART/.vscode/settings.json
+++ b/Examples/MAX32675/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/Watchdog/.cproject
+++ b/Examples/MAX32675/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32675/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32675/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32675/WearLeveling/.cproject
+++ b/Examples/MAX32675/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32675/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32675/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ADC/.cproject
+++ b/Examples/MAX32680/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/ADC/.vscode/settings.json
+++ b/Examples/MAX32680/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/AES/.cproject
+++ b/Examples/MAX32680/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/AES/.vscode/settings.json
+++ b/Examples/MAX32680/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/AFE_ADC/.cproject
+++ b/Examples/MAX32680/AFE_ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/AFE_ADC/.vscode/settings.json
+++ b/Examples/MAX32680/AFE_ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32680/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32680/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32680/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/BLE4_ctr/.cproject
+++ b/Examples/MAX32680/BLE4_ctr/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/BLE4_ctr/.vscode/settings.json
+++ b/Examples/MAX32680/BLE4_ctr/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/BLE_dats/.cproject
+++ b/Examples/MAX32680/BLE_dats/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/BLE_dats/.vscode/settings.json
+++ b/Examples/MAX32680/BLE_dats/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/CRC/.cproject
+++ b/Examples/MAX32680/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/CRC/.vscode/settings.json
+++ b/Examples/MAX32680/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Coremark/.cproject
+++ b/Examples/MAX32680/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Coremark/.vscode/settings.json
+++ b/Examples/MAX32680/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/DMA/.cproject
+++ b/Examples/MAX32680/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/DMA/.vscode/settings.json
+++ b/Examples/MAX32680/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32680/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32680/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Flash/.cproject
+++ b/Examples/MAX32680/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Flash/.vscode/settings.json
+++ b/Examples/MAX32680/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Flash_CLI/.cproject
+++ b/Examples/MAX32680/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32680/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32680/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32680/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32680/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32680/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/GPIO/.cproject
+++ b/Examples/MAX32680/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/GPIO/.vscode/settings.json
+++ b/Examples/MAX32680/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/HART_UART/.cproject
+++ b/Examples/MAX32680/HART_UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/HART_UART/.vscode/settings.json
+++ b/Examples/MAX32680/HART_UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Hello_World-riscv/.cproject
+++ b/Examples/MAX32680/Hello_World-riscv/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Hello_World-riscv/.vscode/settings.json
+++ b/Examples/MAX32680/Hello_World-riscv/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Hello_World/.cproject
+++ b/Examples/MAX32680/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32680/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32680/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32680/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/I2C/.cproject
+++ b/Examples/MAX32680/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/I2C/.vscode/settings.json
+++ b/Examples/MAX32680/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/I2C_MNGR/.cproject
+++ b/Examples/MAX32680/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32680/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32680/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/I2C_SCAN/.cproject
+++ b/Examples/MAX32680/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32680/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/I2C_Sensor/.cproject
+++ b/Examples/MAX32680/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32680/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/I2S/.cproject
+++ b/Examples/MAX32680/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/I2S/.vscode/settings.json
+++ b/Examples/MAX32680/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/ICC/.cproject
+++ b/Examples/MAX32680/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/ICC/.vscode/settings.json
+++ b/Examples/MAX32680/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/LP/.cproject
+++ b/Examples/MAX32680/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/LP/.vscode/settings.json
+++ b/Examples/MAX32680/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Library_Generate/.cproject
+++ b/Examples/MAX32680/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32680/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Library_Use/.cproject
+++ b/Examples/MAX32680/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32680/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Pulse_Train/.cproject
+++ b/Examples/MAX32680/Pulse_Train/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32680/Pulse_Train/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/RV_ARM_Loader/.cproject
+++ b/Examples/MAX32680/RV_ARM_Loader/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/RV_ARM_Loader/.vscode/settings.json
+++ b/Examples/MAX32680/RV_ARM_Loader/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/SPI/.cproject
+++ b/Examples/MAX32680/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/SPI/.vscode/settings.json
+++ b/Examples/MAX32680/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/TMR/.cproject
+++ b/Examples/MAX32680/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/TMR/.vscode/settings.json
+++ b/Examples/MAX32680/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/TRNG/.cproject
+++ b/Examples/MAX32680/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/TRNG/.vscode/settings.json
+++ b/Examples/MAX32680/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Temp_Monitor/.cproject
+++ b/Examples/MAX32680/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32680/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/UART/.cproject
+++ b/Examples/MAX32680/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/UART/.vscode/settings.json
+++ b/Examples/MAX32680/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/WUT/.cproject
+++ b/Examples/MAX32680/WUT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/WUT/.vscode/settings.json
+++ b/Examples/MAX32680/WUT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/Watchdog/.cproject
+++ b/Examples/MAX32680/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32680/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32680/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32680/WearLeveling/.cproject
+++ b/Examples/MAX32680/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32680/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32680/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ADC/.cproject
+++ b/Examples/MAX32690/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/ADC/.settings/language.settings.xml
+++ b/Examples/MAX32690/ADC/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-548276482683806336" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Examples/MAX32690/ADC/.vscode/settings.json
+++ b/Examples/MAX32690/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX32690/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX32690/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE4_ctr/.cproject
+++ b/Examples/MAX32690/BLE4_ctr/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE4_ctr/.vscode/settings.json
+++ b/Examples/MAX32690/BLE4_ctr/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE5_ctr/.cproject
+++ b/Examples/MAX32690/BLE5_ctr/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE5_ctr/.vscode/settings.json
+++ b/Examples/MAX32690/BLE5_ctr/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_FreeRTOS/.cproject
+++ b/Examples/MAX32690/BLE_FreeRTOS/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_FreeRTOS/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_FreeRTOS/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -71,7 +70,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_datc/.cproject
+++ b/Examples/MAX32690/BLE_datc/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_datc/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_datc/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_dats/.cproject
+++ b/Examples/MAX32690/BLE_dats/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_dats/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_dats/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_fcc/.cproject
+++ b/Examples/MAX32690/BLE_fcc/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_fcc/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_fcc/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_fit/.cproject
+++ b/Examples/MAX32690/BLE_fit/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_fit/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_fit/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_mcs/.cproject
+++ b/Examples/MAX32690/BLE_mcs/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_mcs/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_mcs/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_otac/.cproject
+++ b/Examples/MAX32690/BLE_otac/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_otac/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_otac/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_otas/.cproject
+++ b/Examples/MAX32690/BLE_otas/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_otas/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_otas/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/BLE_periph/.cproject
+++ b/Examples/MAX32690/BLE_periph/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/BLE_periph/.vscode/settings.json
+++ b/Examples/MAX32690/BLE_periph/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -68,7 +67,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Bootloader/.cproject
+++ b/Examples/MAX32690/Bootloader/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Bootloader/.vscode/settings.json
+++ b/Examples/MAX32690/Bootloader/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/CAN/.cproject
+++ b/Examples/MAX32690/CAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/CAN/.vscode/settings.json
+++ b/Examples/MAX32690/CAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/CRC/.cproject
+++ b/Examples/MAX32690/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/CRC/.vscode/settings.json
+++ b/Examples/MAX32690/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/CTB_AES/.cproject
+++ b/Examples/MAX32690/CTB_AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/CTB_AES/.vscode/settings.json
+++ b/Examples/MAX32690/CTB_AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Coremark/.cproject
+++ b/Examples/MAX32690/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Coremark/.vscode/settings.json
+++ b/Examples/MAX32690/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/DMA/.cproject
+++ b/Examples/MAX32690/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/DMA/.settings/language.settings.xml
+++ b/Examples/MAX32690/DMA/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-548276482683806336" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Examples/MAX32690/DMA/.vscode/settings.json
+++ b/Examples/MAX32690/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/EEPROM_Emulator/.cproject
+++ b/Examples/MAX32690/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX32690/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Flash/.cproject
+++ b/Examples/MAX32690/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Flash/.vscode/settings.json
+++ b/Examples/MAX32690/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Flash_CLI/.cproject
+++ b/Examples/MAX32690/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32690/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX32690/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/FreeRTOSDemo/.cproject
+++ b/Examples/MAX32690/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX32690/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX32690/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/GPIO/.cproject
+++ b/Examples/MAX32690/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/GPIO/.vscode/settings.json
+++ b/Examples/MAX32690/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/HBMC/.cproject
+++ b/Examples/MAX32690/HBMC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/HBMC/.vscode/settings.json
+++ b/Examples/MAX32690/HBMC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Hash/.cproject
+++ b/Examples/MAX32690/Hash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Hash/.vscode/settings.json
+++ b/Examples/MAX32690/Hash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Hello_World/.cproject
+++ b/Examples/MAX32690/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Hello_World/.vscode/settings.json
+++ b/Examples/MAX32690/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Hello_World_Cpp/.cproject
+++ b/Examples/MAX32690/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX32690/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/I2C/.cproject
+++ b/Examples/MAX32690/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/I2C/.vscode/settings.json
+++ b/Examples/MAX32690/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/I2C_MNGR/.cproject
+++ b/Examples/MAX32690/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX32690/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX32690/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/I2C_SCAN/.cproject
+++ b/Examples/MAX32690/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX32690/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/I2C_Sensor/.cproject
+++ b/Examples/MAX32690/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX32690/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/I2S/.cproject
+++ b/Examples/MAX32690/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/I2S/.vscode/settings.json
+++ b/Examples/MAX32690/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/ICC/.cproject
+++ b/Examples/MAX32690/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/ICC/.vscode/settings.json
+++ b/Examples/MAX32690/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/LP/.cproject
+++ b/Examples/MAX32690/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/LP/.vscode/settings.json
+++ b/Examples/MAX32690/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/LPCMP/.cproject
+++ b/Examples/MAX32690/LPCMP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/LPCMP/.vscode/settings.json
+++ b/Examples/MAX32690/LPCMP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Library_Generate/.cproject
+++ b/Examples/MAX32690/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX32690/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Library_Use/.cproject
+++ b/Examples/MAX32690/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Library_Use/.vscode/settings.json
+++ b/Examples/MAX32690/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Pulse_Train/.cproject
+++ b/Examples/MAX32690/Pulse_Train/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX32690/Pulse_Train/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/RF_Test/.cproject
+++ b/Examples/MAX32690/RF_Test/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Cordio/ble-host/sources/stack/cfg&quot;"/>

--- a/Examples/MAX32690/RF_Test/.vscode/settings.json
+++ b/Examples/MAX32690/RF_Test/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -71,7 +70,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/RTC/.cproject
+++ b/Examples/MAX32690/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/RTC/.vscode/settings.json
+++ b/Examples/MAX32690/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/RTC_Backup/.cproject
+++ b/Examples/MAX32690/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX32690/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/RV_ARM_Loader/.cproject
+++ b/Examples/MAX32690/RV_ARM_Loader/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/RV_ARM_Loader/.vscode/settings.json
+++ b/Examples/MAX32690/RV_ARM_Loader/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/SCPA_OTP_Dump/.cproject
+++ b/Examples/MAX32690/SCPA_OTP_Dump/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX32690/SCPA_OTP_Dump/.vscode/settings.json
+++ b/Examples/MAX32690/SCPA_OTP_Dump/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/SPI/.cproject
+++ b/Examples/MAX32690/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/SPI/.vscode/settings.json
+++ b/Examples/MAX32690/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/TFT_Demo/.cproject
+++ b/Examples/MAX32690/TFT_Demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX32690/TFT_Demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/TMR/.cproject
+++ b/Examples/MAX32690/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/TMR/.vscode/settings.json
+++ b/Examples/MAX32690/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/TRNG/.cproject
+++ b/Examples/MAX32690/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/TRNG/.vscode/settings.json
+++ b/Examples/MAX32690/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Temp_Monitor/.cproject
+++ b/Examples/MAX32690/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX32690/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/UART/.cproject
+++ b/Examples/MAX32690/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/UART/.vscode/settings.json
+++ b/Examples/MAX32690/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/UCL/.cproject
+++ b/Examples/MAX32690/UCL/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/UCL/.vscode/settings.json
+++ b/Examples/MAX32690/UCL/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/USB_CDCACM/.cproject
+++ b/Examples/MAX32690/USB_CDCACM/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32690/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX32690/USB_CDCACM/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/USB_CompositeDevice_MSC_CDC/.cproject
+++ b/Examples/MAX32690/USB_CompositeDevice_MSC_CDC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32690/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX32690/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/USB_CompositeDevice_MSC_HID/.cproject
+++ b/Examples/MAX32690/USB_CompositeDevice_MSC_HID/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32690/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX32690/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/USB_HIDKeyboard/.cproject
+++ b/Examples/MAX32690/USB_HIDKeyboard/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32690/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX32690/USB_HIDKeyboard/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/USB_MassStorage/.cproject
+++ b/Examples/MAX32690/USB_MassStorage/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX32690/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX32690/USB_MassStorage/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -61,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/WUT/.cproject
+++ b/Examples/MAX32690/WUT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/WUT/.vscode/settings.json
+++ b/Examples/MAX32690/WUT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/Watchdog/.cproject
+++ b/Examples/MAX32690/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX32690/Watchdog/.vscode/settings.json
+++ b/Examples/MAX32690/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX32690/WearLeveling/.cproject
+++ b/Examples/MAX32690/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX32690/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX32690/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -57,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ADC/.vscode/settings.json
+++ b/Examples/MAX78000/ADC/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/AES/.vscode/settings.json
+++ b/Examples/MAX78000/AES/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX78000/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/UNet-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/UNet-demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/UNet-highres-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/UNet-highres-demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/aisegment_unet-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/aisegment_unet-demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/aisegment_unet/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/aisegment_unet/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/asl/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/asl/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/asl_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/asl_demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cam01_facedetect_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cam01_facedetect_demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/camvid_unet/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/camvid_unet/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cats-dogs/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cats-dogs/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cats-dogs_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cats-dogs_demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cifar-10-auto-test/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-10-auto-test/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cifar-10/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-10/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cifar-100-mixed/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-100-mixed/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cifar-100-residual/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-100-residual/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-100-simplewide2x-mixed/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/cifar-100/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/cifar-100/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/digit-detection-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/digit-detection-demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/faceid/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/faceid/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/faceid_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/faceid_demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/faceid_evkit-riscv/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/faceid_evkit-riscv/.vscode/settings.json
@@ -59,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/faceid_evkit/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/faceid_evkit/.vscode/settings.json
@@ -59,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/facial_recognition/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/facial_recognition/.vscode/settings.json
@@ -61,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/facial_recognition/SDHC_weights/.vscode/settings.json
@@ -57,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/kws20_demo-riscv/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/kws20_demo-riscv/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/kws20_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/kws20_demo/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/kws20_v3/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/kws20_v3/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/mnist-riscv/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/mnist-riscv/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/mnist/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/mnist/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/rps-demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/rps-demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/rps/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/rps/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/snake_game_demo/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/snake_game_demo/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CNN/svhn_tinierssd/.vscode/settings.json
+++ b/Examples/MAX78000/CNN/svhn_tinierssd/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CRC/.vscode/settings.json
+++ b/Examples/MAX78000/CRC/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CameraIF/.vscode/settings.json
+++ b/Examples/MAX78000/CameraIF/.vscode/settings.json
@@ -59,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/CameraIF_Debayer/.vscode/settings.json
+++ b/Examples/MAX78000/CameraIF_Debayer/.vscode/settings.json
@@ -59,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Coremark/.vscode/settings.json
+++ b/Examples/MAX78000/Coremark/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/DMA/.vscode/settings.json
+++ b/Examples/MAX78000/DMA/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ECC/.vscode/settings.json
+++ b/Examples/MAX78000/ECC/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX78000/EEPROM_Emulator/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/FTHR_I2C/.vscode/settings.json
+++ b/Examples/MAX78000/FTHR_I2C/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Flash/.vscode/settings.json
+++ b/Examples/MAX78000/Flash/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX78000/Flash_CLI/.vscode/settings.json
@@ -59,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX78000/FreeRTOSDemo/.vscode/settings.json
@@ -60,7 +60,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/GPIO/.vscode/settings.json
+++ b/Examples/MAX78000/GPIO/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Hello_World/.vscode/settings.json
+++ b/Examples/MAX78000/Hello_World/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX78000/Hello_World_Cpp/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/I2C_ADXL343/.vscode/settings.json
+++ b/Examples/MAX78000/I2C_ADXL343/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX78000/I2C_MNGR/.vscode/settings.json
@@ -59,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX78000/I2C_SCAN/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX78000/I2C_Sensor/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/I2S/.vscode/settings.json
+++ b/Examples/MAX78000/I2S/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/I2S_DMA/.vscode/settings.json
+++ b/Examples/MAX78000/I2S_DMA/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/I2S_DMA_Target/.vscode/settings.json
+++ b/Examples/MAX78000/I2S_DMA_Target/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ICC/.vscode/settings.json
+++ b/Examples/MAX78000/ICC/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/ImgCapture/.vscode/settings.json
+++ b/Examples/MAX78000/ImgCapture/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/LP/.vscode/settings.json
+++ b/Examples/MAX78000/LP/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/LPCMP/.vscode/settings.json
+++ b/Examples/MAX78000/LPCMP/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX78000/Library_Generate/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Library_Use/.vscode/settings.json
+++ b/Examples/MAX78000/Library_Use/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX78000/Pulse_Train/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/RTC/.vscode/settings.json
+++ b/Examples/MAX78000/RTC/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX78000/RTC_Backup/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/SDHC_FTHR/.vscode/settings.json
+++ b/Examples/MAX78000/SDHC_FTHR/.vscode/settings.json
@@ -57,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/SPI/.vscode/settings.json
+++ b/Examples/MAX78000/SPI/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX78000/TFT_Demo/.vscode/settings.json
@@ -59,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/TMR/.vscode/settings.json
+++ b/Examples/MAX78000/TMR/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/TRNG/.vscode/settings.json
+++ b/Examples/MAX78000/TRNG/.vscode/settings.json
@@ -55,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX78000/Temp_Monitor/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/UART/.vscode/settings.json
+++ b/Examples/MAX78000/UART/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/UCL/.vscode/settings.json
+++ b/Examples/MAX78000/UCL/.vscode/settings.json
@@ -62,7 +62,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/WUT/.vscode/settings.json
+++ b/Examples/MAX78000/WUT/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/Watchdog/.vscode/settings.json
+++ b/Examples/MAX78000/Watchdog/.vscode/settings.json
@@ -56,7 +56,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78000/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX78000/WearLeveling/.vscode/settings.json
@@ -58,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ADC/.cproject
+++ b/Examples/MAX78002/ADC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/ADC/.vscode/settings.json
+++ b/Examples/MAX78002/ADC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/AES/.cproject
+++ b/Examples/MAX78002/AES/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/AES/.vscode/settings.json
+++ b/Examples/MAX78002/AES/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_bayes_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_bayes_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_class_marks_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_convolution_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_convolution_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_dotproduct_example_f32/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_fft_bin_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_fir_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_fir_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_graphic_equalizer_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_linear_interp_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_matrix_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_matrix_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_signal_converge_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_sin_cos_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_svm_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_svm_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/.cproject
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/ARM-DSP/arm_variance_example/.vscode/settings.json
+++ b/Examples/MAX78002/ARM-DSP/arm_variance_example/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/.cproject
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/CNN/cifar-100-effnet2/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/cifar-100-effnet2/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/.cproject
+++ b/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/cifar-100-mobilenet-v2-0.75/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CNN/faceid/.cproject
+++ b/Examples/MAX78002/CNN/faceid/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/CNN/faceid/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/faceid/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CNN/faceid_evkit/.cproject
+++ b/Examples/MAX78002/CNN/faceid_evkit/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/CNN/faceid_evkit/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/faceid_evkit/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CNN/imagenet-riscv/.cproject
+++ b/Examples/MAX78002/CNN/imagenet-riscv/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/CNN/imagenet-riscv/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/imagenet-riscv/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CNN/imagenet/.cproject
+++ b/Examples/MAX78002/CNN/imagenet/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/CNN/imagenet/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/imagenet/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CNN/kws20_demo/.cproject
+++ b/Examples/MAX78002/CNN/kws20_demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/CNN/kws20_demo/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/kws20_demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.cproject
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.vscode/settings.json
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CRC/.cproject
+++ b/Examples/MAX78002/CRC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/CRC/.vscode/settings.json
+++ b/Examples/MAX78002/CRC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CSI2/.cproject
+++ b/Examples/MAX78002/CSI2/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/CSI2/.vscode/settings.json
+++ b/Examples/MAX78002/CSI2/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CameraIF/.cproject
+++ b/Examples/MAX78002/CameraIF/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/CameraIF/.vscode/settings.json
+++ b/Examples/MAX78002/CameraIF/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/CameraIF_Debayer/.cproject
+++ b/Examples/MAX78002/CameraIF_Debayer/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/Core/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/5.9.0/DSP/Include&quot;"/>

--- a/Examples/MAX78002/CameraIF_Debayer/.vscode/settings.json
+++ b/Examples/MAX78002/CameraIF_Debayer/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Coremark/.cproject
+++ b/Examples/MAX78002/Coremark/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/Coremark/.vscode/settings.json
+++ b/Examples/MAX78002/Coremark/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/DMA/.cproject
+++ b/Examples/MAX78002/DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/DMA/.vscode/settings.json
+++ b/Examples/MAX78002/DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ECC/.cproject
+++ b/Examples/MAX78002/ECC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/ECC/.vscode/settings.json
+++ b/Examples/MAX78002/ECC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/EEPROM_Emulator/.cproject
+++ b/Examples/MAX78002/EEPROM_Emulator/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/EEPROM_Emulator/.vscode/settings.json
+++ b/Examples/MAX78002/EEPROM_Emulator/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Flash/.cproject
+++ b/Examples/MAX78002/Flash/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/Flash/.vscode/settings.json
+++ b/Examples/MAX78002/Flash/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Flash_CLI/.cproject
+++ b/Examples/MAX78002/Flash_CLI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX78002/Flash_CLI/.vscode/settings.json
+++ b/Examples/MAX78002/Flash_CLI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/FreeRTOSDemo/.cproject
+++ b/Examples/MAX78002/FreeRTOSDemo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS-Plus/Source/FreeRTOS-Plus-CLI&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>

--- a/Examples/MAX78002/FreeRTOSDemo/.vscode/settings.json
+++ b/Examples/MAX78002/FreeRTOSDemo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -60,7 +59,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/GPIO/.cproject
+++ b/Examples/MAX78002/GPIO/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/GPIO/.vscode/settings.json
+++ b/Examples/MAX78002/GPIO/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Hello_World/.cproject
+++ b/Examples/MAX78002/Hello_World/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/Hello_World/.vscode/settings.json
+++ b/Examples/MAX78002/Hello_World/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Hello_World_Cpp/.cproject
+++ b/Examples/MAX78002/Hello_World_Cpp/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/Hello_World_Cpp/.vscode/settings.json
+++ b/Examples/MAX78002/Hello_World_Cpp/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/I2C/.cproject
+++ b/Examples/MAX78002/I2C/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/I2C/.vscode/settings.json
+++ b/Examples/MAX78002/I2C/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/I2C_MNGR/.cproject
+++ b/Examples/MAX78002/I2C_MNGR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/FreeRTOS/Source/portable/GCC/ARM_CM4F&quot;"/>

--- a/Examples/MAX78002/I2C_MNGR/.vscode/settings.json
+++ b/Examples/MAX78002/I2C_MNGR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -59,7 +58,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/I2C_SCAN/.cproject
+++ b/Examples/MAX78002/I2C_SCAN/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/I2C_SCAN/.vscode/settings.json
+++ b/Examples/MAX78002/I2C_SCAN/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/I2C_Sensor/.cproject
+++ b/Examples/MAX78002/I2C_Sensor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/I2C_Sensor/.vscode/settings.json
+++ b/Examples/MAX78002/I2C_Sensor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/I2S/.cproject
+++ b/Examples/MAX78002/I2S/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/I2S/.vscode/settings.json
+++ b/Examples/MAX78002/I2S/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/I2S_DMA/.cproject
+++ b/Examples/MAX78002/I2S_DMA/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/I2S_DMA/.vscode/settings.json
+++ b/Examples/MAX78002/I2S_DMA/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ICC/.cproject
+++ b/Examples/MAX78002/ICC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/ICC/.vscode/settings.json
+++ b/Examples/MAX78002/ICC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/ImgCapture/.cproject
+++ b/Examples/MAX78002/ImgCapture/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/ImgCapture/.vscode/settings.json
+++ b/Examples/MAX78002/ImgCapture/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/LP/.cproject
+++ b/Examples/MAX78002/LP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/LP/.vscode/settings.json
+++ b/Examples/MAX78002/LP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/LPCMP/.cproject
+++ b/Examples/MAX78002/LPCMP/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/LPCMP/.vscode/settings.json
+++ b/Examples/MAX78002/LPCMP/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Library_Generate/.cproject
+++ b/Examples/MAX78002/Library_Generate/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/Library_Generate/.vscode/settings.json
+++ b/Examples/MAX78002/Library_Generate/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Library_Use/.cproject
+++ b/Examples/MAX78002/Library_Use/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/Library_Use/.vscode/settings.json
+++ b/Examples/MAX78002/Library_Use/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Pulse_Train/.cproject
+++ b/Examples/MAX78002/Pulse_Train/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/Pulse_Train/.vscode/settings.json
+++ b/Examples/MAX78002/Pulse_Train/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/QSPI/.cproject
+++ b/Examples/MAX78002/QSPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/QSPI/.vscode/settings.json
+++ b/Examples/MAX78002/QSPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/RTC/.cproject
+++ b/Examples/MAX78002/RTC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/RTC/.vscode/settings.json
+++ b/Examples/MAX78002/RTC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/RTC_Backup/.cproject
+++ b/Examples/MAX78002/RTC_Backup/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/RTC_Backup/.vscode/settings.json
+++ b/Examples/MAX78002/RTC_Backup/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/SDHC_FAT/.cproject
+++ b/Examples/MAX78002/SDHC_FAT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/ff14/Source&quot;"/>

--- a/Examples/MAX78002/SDHC_FAT/.vscode/settings.json
+++ b/Examples/MAX78002/SDHC_FAT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/SDHC_Raw/.cproject
+++ b/Examples/MAX78002/SDHC_Raw/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/Include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/SDHC/ff14/Source&quot;"/>

--- a/Examples/MAX78002/SDHC_Raw/.vscode/settings.json
+++ b/Examples/MAX78002/SDHC_Raw/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/SPI/.cproject
+++ b/Examples/MAX78002/SPI/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/SPI/.vscode/settings.json
+++ b/Examples/MAX78002/SPI/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/SPI_MasterSlave/.cproject
+++ b/Examples/MAX78002/SPI_MasterSlave/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/SPI_MasterSlave/.vscode/settings.json
+++ b/Examples/MAX78002/SPI_MasterSlave/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/TFT_Demo/.cproject
+++ b/Examples/MAX78002/TFT_Demo/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/TFT_Demo/.vscode/settings.json
+++ b/Examples/MAX78002/TFT_Demo/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/TMR/.cproject
+++ b/Examples/MAX78002/TMR/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/TMR/.vscode/settings.json
+++ b/Examples/MAX78002/TMR/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/TRNG/.cproject
+++ b/Examples/MAX78002/TRNG/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/TRNG/.vscode/settings.json
+++ b/Examples/MAX78002/TRNG/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Temp_Monitor/.cproject
+++ b/Examples/MAX78002/Temp_Monitor/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/Temp_Monitor/.vscode/settings.json
+++ b/Examples/MAX78002/Temp_Monitor/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/UART/.cproject
+++ b/Examples/MAX78002/UART/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/UART/.vscode/settings.json
+++ b/Examples/MAX78002/UART/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/USB_CDCACM/.cproject
+++ b/Examples/MAX78002/USB_CDCACM/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX78002/USB_CDCACM/.vscode/settings.json
+++ b/Examples/MAX78002/USB_CDCACM/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/.cproject
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_CDC/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_HID/.cproject
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_HID/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX78002/USB_CompositeDevice_MSC_HID/.vscode/settings.json
+++ b/Examples/MAX78002/USB_CompositeDevice_MSC_HID/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/USB_HIDKeyboard/.cproject
+++ b/Examples/MAX78002/USB_HIDKeyboard/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX78002/USB_HIDKeyboard/.vscode/settings.json
+++ b/Examples/MAX78002/USB_HIDKeyboard/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/USB_MassStorage/.cproject
+++ b/Examples/MAX78002/USB_MassStorage/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX78002/USB_MassStorage/.vscode/settings.json
+++ b/Examples/MAX78002/USB_MassStorage/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/USB_MassStorage_ThroughPut/.cproject
+++ b/Examples/MAX78002/USB_MassStorage_ThroughPut/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MAXUSB/include/core&quot;"/>

--- a/Examples/MAX78002/USB_MassStorage_ThroughPut/.vscode/settings.json
+++ b/Examples/MAX78002/USB_MassStorage_ThroughPut/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -62,7 +61,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/WUT/.cproject
+++ b/Examples/MAX78002/WUT/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									
 								</option>

--- a/Examples/MAX78002/WUT/.vscode/settings.json
+++ b/Examples/MAX78002/WUT/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -55,7 +54,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/Watchdog/.cproject
+++ b/Examples/MAX78002/Watchdog/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Camera&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/MiscDrivers/Display&quot;"/>

--- a/Examples/MAX78002/Watchdog/.vscode/settings.json
+++ b/Examples/MAX78002/Watchdog/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -56,7 +55,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",

--- a/Examples/MAX78002/WearLeveling/.cproject
+++ b/Examples/MAX78002/WearLeveling/.cproject
@@ -30,7 +30,6 @@
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs&quot;"/>
 <listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/littlefs/bd&quot;"/>

--- a/Examples/MAX78002/WearLeveling/.vscode/settings.json
+++ b/Examples/MAX78002/WearLeveling/.vscode/settings.json
@@ -38,7 +38,6 @@
     "C_Cpp.default.includePath": [
         "${workspaceFolder}",
         "${workspaceFolder}/**",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
         "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
@@ -58,7 +57,6 @@
     ],
     "C_Cpp.default.browse.path": [
         "${workspaceFolder}",
-        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
         "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
         "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
         "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",


### PR DESCRIPTION
Since PR #587 removed `Libraries/Boards/${TARGET}/Include` and `Libraries/Boards/${TARGET}/Source` directories, we may remove them from project configuration files. MAX78000 still keeps a separate `Include` directory so I have not removed that from MAX78000 example projects' settings.