### PR TITLE
feat(PeriphDrivers): Provide user a way to manually drive SPI slave select pin

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/spi.h
@@ -643,6 +643,18 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32520/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/spi.h
@@ -645,11 +645,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32520/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/spi.h
@@ -652,7 +652,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 /**@} end of group spi */

--- a/Libraries/PeriphDrivers/Include/MAX32570/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/spi.h
@@ -651,6 +651,18 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32570/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/spi.h
@@ -653,11 +653,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32570/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/spi.h
@@ -660,7 +660,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 /**@} end of group spi */

--- a/Libraries/PeriphDrivers/Include/MAX32572/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/spi.h
@@ -645,6 +645,18 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32572/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/spi.h
@@ -647,11 +647,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32572/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/spi.h
@@ -654,7 +654,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 /**@} end of group spi */

--- a/Libraries/PeriphDrivers/Include/MAX32650/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/spi.h
@@ -650,11 +650,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32650/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/spi.h
@@ -649,6 +649,18 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 //-------------------------------------------------------------------------------------------
 /**@} end of group spi */
 

--- a/Libraries/PeriphDrivers/Include/MAX32650/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/spi.h
@@ -657,7 +657,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32655/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/spi.h
@@ -690,6 +690,19 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32655/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/spi.h
@@ -692,11 +692,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32655/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/spi.h
@@ -699,7 +699,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32660/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/spi.h
@@ -644,6 +644,19 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32660/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/spi.h
@@ -646,11 +646,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32660/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/spi.h
@@ -653,7 +653,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32662/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/spi.h
@@ -669,6 +669,19 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32662/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/spi.h
@@ -671,11 +671,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32662/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/spi.h
@@ -678,7 +678,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32665/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/spi.h
@@ -649,11 +649,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32665/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/spi.h
@@ -647,6 +647,19 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32665/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/spi.h
@@ -656,7 +656,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32670/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/spi.h
@@ -645,6 +645,18 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32670/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/spi.h
@@ -646,11 +646,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32670/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/spi.h
@@ -653,7 +653,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32672/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/spi.h
@@ -644,6 +644,18 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32672/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/spi.h
@@ -645,11 +645,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32672/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/spi.h
@@ -652,7 +652,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32675/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/spi.h
@@ -644,6 +644,18 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32675/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/spi.h
@@ -645,11 +645,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32675/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/spi.h
@@ -652,7 +652,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32680/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/spi.h
@@ -669,11 +669,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32680/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/spi.h
@@ -667,6 +667,19 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32680/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/spi.h
@@ -676,7 +676,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Include/MAX32690/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/spi.h
@@ -664,11 +664,11 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
 
 /**
- * @brief   Enable disable HW CS control feature.
+ * @brief   Enable/Disable HW CS control feature.
  *
- * Depend on the application user might would like to drive slave select pin
- * The SPI driver able to drive SS pin automatically this feature can be disable/enable
- * by this function
+ * Depending on the application, the user might need to manually drive the slave select pin.
+ * The SPI driver automatically drives the SS pin and this function enables/disables this
+ * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   state           true or false

--- a/Libraries/PeriphDrivers/Include/MAX32690/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/spi.h
@@ -662,6 +662,19 @@ void MXC_SPI_AbortAsync(mxc_spi_regs_t *spi);
  * @param   spi         Pointer to SPI registers (selects the SPI block used.)
  */
 void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
+
+/**
+ * @brief   Enable disable HW CS control feature.
+ *
+ * Depend on the application user might would like to drive slave select pin
+ * The SPI driver able to drive SS pin automatically this feature can be disable/enable
+ * by this function
+ *
+ * @param   spi             Pointer to SPI registers (selects the SPI block used.)
+ * @param   state           true or false
+ */
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
+
 /**@} end of group spi */
 
 #ifdef __cplusplus

--- a/Libraries/PeriphDrivers/Include/MAX32690/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/spi.h
@@ -671,7 +671,7 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi);
  * feature.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
- * @param   state           true or false
+ * @param   state           Non-zero values: enable HW SS mode. Zero: disable HW SS mode.
  */
 void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state);
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_es17.c
@@ -368,3 +368,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me10.c
@@ -417,4 +417,9 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
 
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}
+
 /**@} end of group spi */

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -363,3 +363,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me12.c
@@ -472,3 +472,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me13.c
@@ -413,3 +413,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -423,3 +423,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
@@ -392,3 +392,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me16.c
@@ -391,3 +391,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler(spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -530,3 +530,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -524,3 +524,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me21.c
@@ -408,3 +408,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me55.c
@@ -409,3 +409,8 @@ void MXC_SPI_AsyncHandler(mxc_spi_regs_t *spi)
 {
     MXC_SPI_RevA1_AsyncHandler((mxc_spi_reva_regs_t *)spi);
 }
+
+void MXC_SPI_HWSSControl(mxc_spi_regs_t *spi, int state)
+{
+    MXC_SPI_RevA1_HWSSControl((mxc_spi_reva_regs_t *)spi, state);
+}

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -1339,7 +1339,6 @@ void MXC_SPI_RevA1_HWSSControl(mxc_spi_reva_regs_t *spi, int state)
     int spi_num;
 
     spi_num = MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi);
-    MXC_ASSERT(spi_num >= 0);
 
     states[spi_num].hw_ss_control = state ? true : false;
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -1341,7 +1341,7 @@ void MXC_SPI_RevA1_HWSSControl(mxc_spi_reva_regs_t *spi, int state)
     spi_num = MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi);
     MXC_ASSERT(spi_num >= 0);
 
-    states[spi_num].hw_ss_control = state? true: false;
+    states[spi_num].hw_ss_control = state ? true : false;
 
     return;
 }

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -58,6 +58,7 @@ typedef struct {
     bool txrx_req;
     uint8_t req_done;
     uint8_t async;
+    bool hw_ss_control;
 } spi_req_reva_state_t;
 
 static spi_req_reva_state_t states[MXC_SPI_INSTANCES];
@@ -88,6 +89,7 @@ int MXC_SPI_RevA1_Init(mxc_spi_reva_regs_t *spi, int masterMode, int quadModeUse
     states[spi_num].mtFirstTrans = 0;
     states[spi_num].channelTx = E_NO_DEVICE;
     states[spi_num].channelRx = E_NO_DEVICE;
+    states[spi_num].hw_ss_control = true;
 
     spi->ctrl0 = (MXC_F_SPI_REVA_CTRL0_EN);
     spi->sstime =
@@ -113,22 +115,24 @@ int MXC_SPI_RevA1_Init(mxc_spi_reva_regs_t *spi, int masterMode, int quadModeUse
     // Clear the interrupts
     spi->intfl = spi->intfl;
 
-    if (numSlaves == 1) {
-        spi->ctrl0 |= MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS0;
-    }
+    if (states[spi_num].hw_ss_control) {
+        if (numSlaves == 1) {
+            spi->ctrl0 |= MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS0;
+        }
 
-    if (numSlaves == 2) {
-        spi->ctrl0 |= (MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS0 | MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS1);
-    }
+        if (numSlaves == 2) {
+            spi->ctrl0 |= (MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS0 | MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS1);
+        }
 
-    if (numSlaves == 3) {
-        spi->ctrl0 |= (MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS0 | MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS1 |
-                       MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS2);
-    }
+        if (numSlaves == 3) {
+            spi->ctrl0 |= (MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS0 | MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS1 |
+                           MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS2);
+        }
 
-    if (numSlaves == 4) {
-        spi->ctrl0 |= (MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS0 | MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS1 |
-                       MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS2 | MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS3);
+        if (numSlaves == 4) {
+            spi->ctrl0 |= (MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS0 | MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS1 |
+                           MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS2 | MXC_S_SPI_REVA_CTRL0_SS_ACTIVE_SS3);
+        }
     }
 
     //set quad mode
@@ -341,12 +345,16 @@ int MXC_SPI_RevA1_SetSlave(mxc_spi_reva_regs_t *spi, int ssIdx)
         return E_BAD_STATE;
     }
 
-    // Setup the slave select
-    // Activate chosen SS pin
-    spi->ctrl0 |= (1 << ssIdx) << MXC_F_SPI_REVA_CTRL0_SS_ACTIVE_POS;
-    // Deactivate all unchosen pins
-    spi->ctrl0 &= ~MXC_F_SPI_REVA_CTRL0_SS_ACTIVE |
-                  ((1 << ssIdx) << MXC_F_SPI_REVA_CTRL0_SS_ACTIVE_POS);
+    int spi_num = MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi);
+
+    if (states[spi_num].hw_ss_control) {
+        // Setup the slave select
+        // Activate chosen SS pin
+        spi->ctrl0 |= (1 << ssIdx) << MXC_F_SPI_REVA_CTRL0_SS_ACTIVE_POS;
+        // Deactivate all unchosen pins
+        spi->ctrl0 &= ~MXC_F_SPI_REVA_CTRL0_SS_ACTIVE |
+                      ((1 << ssIdx) << MXC_F_SPI_REVA_CTRL0_SS_ACTIVE_POS);
+    }
     return E_NO_ERROR;
 }
 
@@ -761,7 +769,7 @@ uint32_t MXC_SPI_RevA1_MasterTransHandler(mxc_spi_reva_regs_t *spi, mxc_spi_reva
     int spi_num = MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi);
 
     // Leave slave select asserted at the end of the transaction
-    if (!req->ssDeassert) {
+    if (states[spi_num].hw_ss_control && !req->ssDeassert) {
         spi->ctrl0 |= MXC_F_SPI_REVA_CTRL0_SS_CTRL;
     }
 
@@ -773,7 +781,7 @@ uint32_t MXC_SPI_RevA1_MasterTransHandler(mxc_spi_reva_regs_t *spi, mxc_spi_reva
     }
 
     // Deassert slave select at the end of the transaction
-    if (req->ssDeassert) {
+    if (states[spi_num].hw_ss_control && req->ssDeassert) {
         spi->ctrl0 &= ~MXC_F_SPI_REVA_CTRL0_SS_CTRL;
     }
 
@@ -1324,4 +1332,16 @@ void MXC_SPI_RevA1_SwapByte(uint8_t *arr, size_t length)
         arr[i] = arr[i + 1];
         arr[i + 1] = tmp;
     }
+}
+
+void MXC_SPI_RevA1_HWSSControl(mxc_spi_reva_regs_t *spi, int state)
+{
+    int spi_num;
+
+    spi_num = MXC_SPI_GET_IDX((mxc_spi_regs_t *)spi);
+    MXC_ASSERT(spi_num >= 0);
+
+    states[spi_num].hw_ss_control = state? true: false;
+
+    return;
 }

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.h
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.h
@@ -127,6 +127,7 @@ void MXC_SPI_RevA1_DMACallback(int ch, int error);
 int MXC_SPI_RevA1_SetDefaultTXData(mxc_spi_reva_regs_t *spi, unsigned int defaultTXData);
 void MXC_SPI_RevA1_AbortAsync(mxc_spi_reva_regs_t *spi);
 void MXC_SPI_RevA1_AsyncHandler(mxc_spi_reva_regs_t *spi);
+void MXC_SPI_RevA1_HWSSControl(mxc_spi_reva_regs_t *spi, int state);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description

While using SPI manual chip drive requires, existing SPI driver drive SS pin by HW, there is no any option to disable this behaviour, This feature exactly require while porting Zephyr/MBED... On these platform i add an patch at the top of SDK layer.
It will be nice if SDK support it on default.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related Github issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.