### PR TITLE
fix(Build): Link with libphy_hard.a when MFLOAT_ABI = hard

### DIFF
--- a/Libraries/libs.mk
+++ b/Libraries/libs.mk
@@ -47,7 +47,11 @@ CORDIO_DIR ?= $(LIBS_DIR)/Cordio
 include $(CORDIO_DIR)/platform/targets/maxim/build/cordio_lib.mk
 
 ifeq ($(RISCV_CORE),)
+ifeq ($(MFLOAT_ABI),hard)
+LIBS      += $(LIBS_DIR)/BlePhy/$(CHIP_UC)/libphy_hard.a
+else
 LIBS      += $(LIBS_DIR)/BlePhy/$(CHIP_UC)/libphy.a
+endif
 else
 LIBS      += $(LIBS_DIR)/BlePhy/$(CHIP_UC)/libphy_riscv.a
 endif


### PR DESCRIPTION
## Pull Request Template

### Description

BLE builds fail when MFLOAT_ABI = hard, e.g. with macOS 12.6.7:

```
khp@Kevins-MacBook-Pro-M1 BLE_periph_20230718 % make all VERBOSE=1 BOARD=FTHR PROJECT=BLE_periph_20230718 TARGET=MAX32665 MFLOAT_ABI=hard
.
.
.
arm-none-eabi-gcc @/Users/khp/Dropbox/Projects/Documents/MXC/Examples/BLE_periph_20230718/build/ln_args.txt
/usr/local/gcc-arm-none-eabi-9-2020-q2-update/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: error: /Users/khp/Dropbox/Projects/Documents/MXC/Examples/BLE_periph_20230718/build/BLE_periph_20230718.elf uses VFP register arguments, /Users/khp/Dropbox/Projects/Documents/MXC/Examples/msdk/Libraries/BlePhy/MAX32665/libphy.a(pal_bb.o) does not
```
Changed libs.mk to select libphy_hard.a when appropriate.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related Github issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

