### PR TITLE
refactor(PeriphDrivers): Fix -Warray-bounds warnings for can and dma

### DIFF
--- a/Libraries/PeriphDrivers/Source/CAN/can_reva.c
+++ b/Libraries/PeriphDrivers/Source/CAN/can_reva.c
@@ -141,12 +141,17 @@ mxc_can_capabilities_t MXC_CAN_RevA_GetCapabilities(void)
 int MXC_CAN_RevA_Init(mxc_can_reva_regs_t *can, mxc_can_unit_event_cb_t unit_cb,
                       mxc_can_object_event_cb_t obj_cb)
 {
-    obj_evt_cb[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] = obj_cb; // Set callback function pointers
-    unit_evt_cb[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] = unit_cb;
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+        
+    obj_evt_cb[can_idx] = obj_cb; // Set callback function pointers
+    unit_evt_cb[can_idx] = unit_cb;
 
-    MXC_FreeLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]); // Free CAN resources
-    MXC_FreeLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
-    MXC_FreeLock(&rx_dma_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+    MXC_FreeLock(&tx_lock[can_idx]); // Free CAN resources
+    MXC_FreeLock(&rx_lock[can_idx]);
+    MXC_FreeLock(&rx_dma_lock[can_idx]);
 
     return E_NO_ERROR;
 }
@@ -154,12 +159,17 @@ int MXC_CAN_RevA_Init(mxc_can_reva_regs_t *can, mxc_can_unit_event_cb_t unit_cb,
 /**********************************************************************************************************************************************************************/
 int MXC_CAN_RevA_UnInit(mxc_can_reva_regs_t *can)
 {
-    obj_evt_cb[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] = NULL; // Clear callback function pointers
-    unit_evt_cb[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] = NULL;
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
+    obj_evt_cb[can_idx] = NULL; // Clear callback function pointers
+    unit_evt_cb[can_idx] = NULL;
 
-    MXC_FreeLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]); // Free CAN resources
-    MXC_FreeLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
-    MXC_FreeLock(&rx_dma_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+    MXC_FreeLock(&tx_lock[can_idx]); // Free CAN resources
+    MXC_FreeLock(&rx_lock[can_idx]);
+    MXC_FreeLock(&rx_dma_lock[can_idx]);
 
     return E_NO_ERROR;
 }
@@ -167,21 +177,26 @@ int MXC_CAN_RevA_UnInit(mxc_can_reva_regs_t *can)
 /**********************************************************************************************************************************************************************/
 int MXC_CAN_RevA_PowerControl(mxc_can_reva_regs_t *can, mxc_can_pwr_ctrl_t pwr)
 {
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     if (pwr == MXC_CAN_PWR_CTRL_SLEEP) {
         // CAN periph able to go into sleep mode?
         if (can->stat & MXC_F_CAN_REVA_STAT_TX || can->intfl || can->eintfl || !can->wupclkdiv) {
             return E_BAD_STATE;
         }
 
-        MXC_CAN_SetMode(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), MXC_CAN_MODE_NORMAL);
+        MXC_CAN_SetMode(can_idx, MXC_CAN_MODE_NORMAL);
         can->mode |= MXC_F_CAN_REVA_MODE_SLP; // Enable CAN sleep mode
         while (!(can->mode & MXC_F_CAN_REVA_MODE_SLP)) {}
 
         // wait for any pending transactions to finish
-        MXC_CAN_SignalUnitEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), MXC_CAN_UNIT_EVT_INACTIVE);
+        MXC_CAN_SignalUnitEvent(can_idx, MXC_CAN_UNIT_EVT_INACTIVE);
     } else if (pwr == MXC_CAN_PWR_CTRL_FULL) {
         can->mode &= ~MXC_F_CAN_REVA_MODE_SLP; // Disable CAN sleep mode
-        MXC_CAN_SignalUnitEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), MXC_CAN_UNIT_EVT_ACTIVE);
+        MXC_CAN_SignalUnitEvent(can_idx, MXC_CAN_UNIT_EVT_ACTIVE);
     }
 
     return E_NO_ERROR;
@@ -394,14 +409,18 @@ int MXC_CAN_RevA_ObjectSetFilter(mxc_can_reva_regs_t *can, mxc_can_filt_cfg_t cf
     uint32_t op_type = (cfg & MXC_CAN_FILT_OP_TYPE_MASK);
     uint32_t filt_sel = (cfg & MXC_CAN_FILT_SEL_MASK);
     uint32_t dual_filt_sel;
-
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     if (filt_sel ==
         MXC_CAN_FILT_CFG_DUAL_GEN) { // If using middleware dual filter select, figure out which filter to set
         if (op_type == MXC_CAN_FILT_CFG_EXACT_ADD || op_type == MXC_CAN_FILT_CFG_MASK_ADD) {
-            filt_sel = ((filt_in_use[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] + 1) * 2)
+            filt_sel = ((filt_in_use[can_idx] + 1) * 2)
                        << MXC_CAN_FILT_SEL_SHIFT;
         } else if (op_type == MXC_CAN_FILT_CFG_EXACT_DEL || op_type == MXC_CAN_FILT_CFG_MASK_DEL) {
-            filt_sel = (filt_in_use[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] * 2)
+            filt_sel = (filt_in_use[can_idx] * 2)
                        << MXC_CAN_FILT_SEL_SHIFT;
         }
     }
@@ -410,7 +429,7 @@ int MXC_CAN_RevA_ObjectSetFilter(mxc_can_reva_regs_t *can, mxc_can_filt_cfg_t cf
 
     if (op_type == MXC_CAN_FILT_CFG_EXACT_ADD || op_type == MXC_CAN_FILT_CFG_MASK_ADD) {
         // Create filter selected
-        if (filt_in_use[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] >= MXC_CAN_FILT_PER_OBJ) {
+        if (filt_in_use[can_idx] >= MXC_CAN_FILT_PER_OBJ) {
             // Filter not available --> return error
             can->mode &= ~MXC_F_CAN_REVA_MODE_RST;
             return E_NONE_AVAIL;
@@ -467,10 +486,10 @@ int MXC_CAN_RevA_ObjectSetFilter(mxc_can_reva_regs_t *can, mxc_can_filt_cfg_t cf
             return E_BAD_PARAM;
         }
 
-        filt_in_use[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]++;
+        filt_in_use[can_idx]++;
     } else if (op_type == MXC_CAN_FILT_CFG_EXACT_DEL || op_type == MXC_CAN_FILT_CFG_MASK_DEL) {
         // Deleting filter
-        if (filt_in_use[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] == 0) {
+        if (filt_in_use[can_idx] == 0) {
             can->mode &= ~MXC_F_CAN_REVA_MODE_RST;
             return E_NONE_AVAIL;
         }
@@ -499,7 +518,7 @@ int MXC_CAN_RevA_ObjectSetFilter(mxc_can_reva_regs_t *can, mxc_can_filt_cfg_t cf
             return E_BAD_PARAM;
         }
 
-        filt_in_use[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]--;
+        filt_in_use[can_idx]--;
     } else {
         can->mode &= ~MXC_F_CAN_REVA_MODE_RST;
         return E_BAD_PARAM;
@@ -512,14 +531,19 @@ int MXC_CAN_RevA_ObjectSetFilter(mxc_can_reva_regs_t *can, mxc_can_filt_cfg_t cf
 /**********************************************************************************************************************************************************************/
 int MXC_CAN_RevA_ObjectConfigure(mxc_can_reva_regs_t *can, mxc_can_obj_cfg_t cfg)
 {
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     switch (cfg) {
     case MXC_CAN_OBJ_CFG_INACTIVE: // Configure object as inactive
-        MXC_CAN_PowerControl(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), MXC_CAN_PWR_CTRL_SLEEP);
+        MXC_CAN_PowerControl(can_idx, MXC_CAN_PWR_CTRL_SLEEP);
         break;
     case MXC_CAN_OBJ_CFG_TXRX: // Configure object to transmit and/or receive data
     case MXC_CAN_OBJ_CFG_RSV:
     case MXC_CAN_OBJ_CFG_TX_RTR_RX_DATA: // Configure object to receive message after sending RTR frames (RX always enabled when CAN is on, as long as MSG ID is accepted)
-        MXC_CAN_PowerControl(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), MXC_CAN_PWR_CTRL_FULL);
+        MXC_CAN_PowerControl(can_idx, MXC_CAN_PWR_CTRL_FULL);
         can->mode |= MXC_F_CAN_REVA_MODE_RST;
         can->mode |= MXC_F_CAN_REVA_MODE_DMA;
         can->fdctrl |= MXC_F_CAN_REVA_FDCTRL_EXTBT;
@@ -529,7 +553,7 @@ int MXC_CAN_RevA_ObjectConfigure(mxc_can_reva_regs_t *can, mxc_can_obj_cfg_t cfg
     default:
         return E_BAD_PARAM;
     }
-    obj_state[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] = cfg;
+    obj_state[can_idx] = cfg;
     return E_NO_ERROR;
 }
 
@@ -602,7 +626,11 @@ int MXC_CAN_RevA_ReadRXFIFO(mxc_can_reva_regs_t *can, mxc_can_msg_info_t *info, 
     uint8_t rxfifo_idx = 0, rxbuf_parse = 0, dma_buf_idx = 0;
     uint32_t rx_data = 0;
     uint32_t *dma_buf = dma_rx0;
-
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     if (info == NULL || data == NULL) {
         return E_NULL_PTR;
     } else if (!dma && can->rxdcnt == 0) {
@@ -611,9 +639,9 @@ int MXC_CAN_RevA_ReadRXFIFO(mxc_can_reva_regs_t *can, mxc_can_msg_info_t *info, 
     }
 
     // Select appropriate DMA buffer to read from if DMA read
-    if (dma && MXC_CAN_GET_IDX((mxc_can_regs_t *)can) == 0) {
+    if (dma && can_idx == 0) {
         dma_buf = dma_rx0;
-    } else if (dma && MXC_CAN_GET_IDX((mxc_can_regs_t *)can) == 1) {
+    } else if (dma && can_idx == 1) {
         dma_buf = dma_rx1;
     }
 
@@ -699,22 +727,26 @@ int MXC_CAN_RevA_MessageSend(mxc_can_reva_regs_t *can, mxc_can_req_t *req)
 {
     int err;
     uint8_t flags, ext_flags;
-
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     if (req == NULL) {
         return E_NULL_PTR;
-    } else if (MXC_GetLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)], 1)) {
+    } else if (MXC_GetLock(&tx_lock[can_idx], 1)) {
         // TX lock already taken
         return E_BAD_STATE;
     }
 
     // Format and write message to FIFO
-    if ((err = MXC_CAN_WriteTXFIFO(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), req->msg_info, req->data,
+    if ((err = MXC_CAN_WriteTXFIFO(can_idx, req->msg_info, req->data,
                                    req->data_sz)) < E_NO_ERROR) {
         return err;
     }
 
     MXC_CAN_ClearFlags(
-        MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+        can_idx,
         (MXC_F_CAN_REVA_INTFL_ERWARN | MXC_F_CAN_REVA_INTFL_ERPSV | MXC_F_CAN_REVA_INTFL_TX), 0);
     can->cmd = MXC_F_CAN_REVA_CMD_TXREQ; // Send TX request
 
@@ -722,17 +754,17 @@ int MXC_CAN_RevA_MessageSend(mxc_can_reva_regs_t *can, mxc_can_req_t *req)
     do {
         // Check for errors
         if ((err = MXC_CAN_RevA_Handler(can, &flags, &ext_flags)) != E_NO_ERROR) {
-            MXC_FreeLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+            MXC_FreeLock(&tx_lock[can_idx]);
             return err;
         }
     } while (!(flags & MXC_F_CAN_REVA_INTFL_TX));
 
     if (flags & MXC_F_CAN_REVA_INTFL_TX) { // If TX complete call callback function
-        MXC_CAN_SignalObjectEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+        MXC_CAN_SignalObjectEvent(can_idx,
                                   MXC_CAN_OBJ_EVT_TX_COMPLETE);
     }
 
-    MXC_FreeLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]); // Free TX lock
+    MXC_FreeLock(&tx_lock[can_idx]); // Free TX lock
 
     return E_NO_ERROR;
 }
@@ -741,26 +773,30 @@ int MXC_CAN_RevA_MessageSend(mxc_can_reva_regs_t *can, mxc_can_req_t *req)
 int MXC_CAN_RevA_MessageSendAsync(mxc_can_reva_regs_t *can, mxc_can_req_t *req)
 {
     int err;
-
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     if (req == NULL) {
         return E_NULL_PTR;
-    } else if (MXC_GetLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)], 1)) {
+    } else if (MXC_GetLock(&tx_lock[can_idx], 1)) {
         // TX lock already acquired
         return E_BAD_STATE;
     }
 
     // Format and write message to TX FIFO
-    if ((err = MXC_CAN_WriteTXFIFO(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), req->msg_info, req->data,
+    if ((err = MXC_CAN_WriteTXFIFO(can_idx, req->msg_info, req->data,
                                    req->data_sz)) < E_NO_ERROR) {
-        MXC_FreeLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+        MXC_FreeLock(&tx_lock[can_idx]);
         return err;
     }
 
     MXC_CAN_ClearFlags(
-        MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+        can_idx,
         (MXC_F_CAN_REVA_INTFL_ERWARN | MXC_F_CAN_REVA_INTFL_ERPSV | MXC_F_CAN_REVA_INTFL_TX), 0);
     MXC_CAN_EnableInt(
-        MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+        can_idx,
         (MXC_F_CAN_REVA_INTEN_ERWARN | MXC_F_CAN_REVA_INTEN_ERPSV | MXC_F_CAN_REVA_INTEN_TX), 0);
 
     can->cmd = MXC_F_CAN_REVA_CMD_TXREQ; // Assert TX request
@@ -780,11 +816,15 @@ int MXC_CAN_RevA_MessageRead(mxc_can_reva_regs_t *can, mxc_can_req_t *req)
 {
     int err = 0;
     uint8_t flags = 0, ext_flags = 0;
-
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     // Check for bad parameters
     if (req == NULL) {
         return E_NULL_PTR;
-    } else if (MXC_GetLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)], 1)) {
+    } else if (MXC_GetLock(&rx_lock[can_idx], 1)) {
         // RX lock already taken
         return E_BUSY;
     }
@@ -798,21 +838,21 @@ int MXC_CAN_RevA_MessageRead(mxc_can_reva_regs_t *can, mxc_can_req_t *req)
     } while (!(flags & (MXC_F_CAN_REVA_INTFL_RX | MXC_F_CAN_REVA_INTFL_DOR)));
 
     if (flags & MXC_F_CAN_REVA_INTFL_DOR) {
-        MXC_CAN_SignalObjectEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+        MXC_CAN_SignalObjectEvent(can_idx,
                                   MXC_CAN_OBJ_EVT_RX_OVERRUN);
     }
 
     if (flags & MXC_F_CAN_REVA_INTFL_RX) {
         // Read data from FIFO
-        if ((err = MXC_CAN_ReadRXFIFO(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), req->msg_info,
+        if ((err = MXC_CAN_ReadRXFIFO(can_idx, req->msg_info,
                                       req->data, req->data_sz)) < E_NO_ERROR) {
-            MXC_FreeLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+            MXC_FreeLock(&rx_lock[can_idx]);
             return err;
         }
-        MXC_CAN_SignalObjectEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), MXC_CAN_OBJ_EVT_RX);
+        MXC_CAN_SignalObjectEvent(can_idx, MXC_CAN_OBJ_EVT_RX);
     }
 
-    MXC_FreeLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]); // Free RX lock
+    MXC_FreeLock(&rx_lock[can_idx]); // Free RX lock
 
     return err;
 }
@@ -820,20 +860,25 @@ int MXC_CAN_RevA_MessageRead(mxc_can_reva_regs_t *can, mxc_can_req_t *req)
 /**********************************************************************************************************************************************************************/
 int MXC_CAN_RevA_MessageReadAsync(mxc_can_reva_regs_t *can, mxc_can_req_t *req)
 {
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     if (req == NULL) {
         return E_NULL_PTR;
-    } else if (MXC_GetLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)], 1)) {
+    } else if (MXC_GetLock(&rx_lock[can_idx], 1)) {
         // RX lock already taken
         return E_BUSY;
     }
 
-    rx_req[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] = req; // Store message read request
+    rx_req[can_idx] = req; // Store message read request
 
-    MXC_CAN_ClearFlags(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+    MXC_CAN_ClearFlags(can_idx,
                        (MXC_F_CAN_REVA_INTFL_ERWARN | MXC_F_CAN_REVA_INTFL_ERPSV |
                         MXC_F_CAN_REVA_INTFL_RX | MXC_F_CAN_REVA_INTFL_DOR),
                        0);
-    MXC_CAN_EnableInt(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+    MXC_CAN_EnableInt(can_idx,
                       (MXC_F_CAN_REVA_INTEN_ERWARN | MXC_F_CAN_REVA_INTEN_ERPSV |
                        MXC_F_CAN_REVA_INTEN_RX | MXC_F_CAN_REVA_INTEN_DOR),
                       0);
@@ -848,19 +893,23 @@ int MXC_CAN_RevA_MessageReadDMA(mxc_can_reva_regs_t *can, mxc_can_req_t *req,
     int ch;
     mxc_dma_config_t config;
     mxc_dma_srcdst_t srcdst;
-
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     if (req == NULL) {
         return E_NULL_PTR;
-    } else if (MXC_GetLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)], 1)) {
+    } else if (MXC_GetLock(&rx_lock[can_idx], 1)) {
         // RX lock already taken
         return E_BUSY;
-    } else if (MXC_GetLock(&rx_dma_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)], 1)) {
+    } else if (MXC_GetLock(&rx_dma_lock[can_idx], 1)) {
         // DMA lock already taken
-        MXC_FreeLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+        MXC_FreeLock(&rx_lock[can_idx]);
         return E_BUSY;
     }
 
-    rx_req[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] = req; // Save RX request
+    rx_req[can_idx] = req; // Save RX request
 
     if ((ch = MXC_DMA_AcquireChannel()) < E_NO_ERROR) { // Acquire DMA Channel
         return ch;
@@ -870,9 +919,9 @@ int MXC_CAN_RevA_MessageReadDMA(mxc_can_reva_regs_t *can, mxc_can_req_t *req,
         MXC_DMA_SetCallback(ch, dma_cb);
     }
 
-    if (MXC_CAN_GET_IDX((mxc_can_regs_t *)can) == 0) { // Configure DMA Channel
+    if (can_idx == 0) { // Configure DMA Channel
         srcdst.dest = dma_rx0;
-    } else if (MXC_CAN_GET_IDX((mxc_can_regs_t *)can) == 1) {
+    } else if (can_idx == 1) {
         srcdst.dest = dma_rx1;
     }
 
@@ -914,9 +963,13 @@ int MXC_CAN_RevA_MessageReadDMA(mxc_can_reva_regs_t *can, mxc_can_req_t *req,
 int MXC_CAN_RevA_Handler(mxc_can_reva_regs_t *can, uint8_t *intfl, uint8_t *eintfl)
 {
     uint8_t flg, ext_flg;
-
-    MXC_CAN_GetFlags(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), &flg, &ext_flg); // Get and clear flags
-    MXC_CAN_ClearFlags(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), flg, ext_flg);
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
+    MXC_CAN_GetFlags(can_idx, &flg, &ext_flg); // Get and clear flags
+    MXC_CAN_ClearFlags(can_idx, flg, ext_flg);
 
     if (intfl != NULL && eintfl != NULL) { // Return flags if able to
         *intfl = flg;
@@ -926,16 +979,16 @@ int MXC_CAN_RevA_Handler(mxc_can_reva_regs_t *can, uint8_t *intfl, uint8_t *eint
     if (flg & MXC_F_CAN_REVA_INTFL_ERWARN) {
         if (can->stat & MXC_F_CAN_REVA_STAT_BUS_OFF) {
             // Bus entered bus off state
-            MXC_CAN_SignalUnitEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+            MXC_CAN_SignalUnitEvent(can_idx,
                                     MXC_CAN_UNIT_EVT_BUS_OFF);
 
-            if (tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]) {
-                MXC_FreeLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+            if (tx_lock[can_idx]) {
+                MXC_FreeLock(&tx_lock[can_idx]);
             }
             return E_COMM_ERR;
         } else if (can->stat & MXC_F_CAN_REVA_STAT_ERR) {
             // Bus entered err warning state (> 127 errs)
-            MXC_CAN_SignalUnitEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+            MXC_CAN_SignalUnitEvent(can_idx,
                                     MXC_CAN_UNIT_EVT_WARNING);
         }
     }
@@ -943,43 +996,43 @@ int MXC_CAN_RevA_Handler(mxc_can_reva_regs_t *can, uint8_t *intfl, uint8_t *eint
     if (flg & MXC_F_CAN_REVA_INTFL_ERPSV) {
         if (can->txerr > MXC_CAN_ERRPSV_THRESH || can->rxerr > MXC_CAN_ERRPSV_THRESH) {
             // Bus entered error passive state
-            MXC_CAN_SignalUnitEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+            MXC_CAN_SignalUnitEvent(can_idx,
                                     MXC_CAN_UNIT_EVT_PASSIVE);
         } else {
             // Bus exited from error passive state
-            MXC_CAN_SignalUnitEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+            MXC_CAN_SignalUnitEvent(can_idx,
                                     MXC_CAN_UNIT_EVT_ACTIVE);
         }
     }
 
     if ((flg & MXC_F_CAN_REVA_INTFL_TX) && (can->inten & MXC_F_CAN_REVA_INTEN_TX)) {
         // TX completed
-        MXC_FreeLock(&tx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
-        MXC_CAN_SignalObjectEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+        MXC_FreeLock(&tx_lock[can_idx]);
+        MXC_CAN_SignalObjectEvent(can_idx,
                                   MXC_CAN_OBJ_EVT_TX_COMPLETE);
     }
 
     if ((flg & MXC_F_CAN_REVA_INTFL_RX) && ((can->inten & MXC_F_CAN_REVA_INTEN_RX) ||
-                                            rx_dma_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)])) {
+                                            rx_dma_lock[can_idx])) {
         // RX completed
-        mxc_can_req_t *msg_req = rx_req[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)];
+        mxc_can_req_t *msg_req = rx_req[can_idx];
 
-        if (rx_dma_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]) {
+        if (rx_dma_lock[can_idx]) {
             // Read from DMA RX Buffers for transactions
             MXC_CAN_RevA_ReadRXFIFO(can, msg_req->msg_info, msg_req->data, msg_req->data_sz, true);
-            MXC_FreeLock(&rx_dma_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+            MXC_FreeLock(&rx_dma_lock[can_idx]);
         } else {
             // Read CAN message
             MXC_CAN_RevA_ReadRXFIFO(can, msg_req->msg_info, msg_req->data, msg_req->data_sz, false);
         }
-        MXC_FreeLock(&rx_lock[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)]);
+        MXC_FreeLock(&rx_lock[can_idx]);
 
-        MXC_CAN_SignalObjectEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can), MXC_CAN_OBJ_EVT_RX);
+        MXC_CAN_SignalObjectEvent(can_idx, MXC_CAN_OBJ_EVT_RX);
     }
 
     // Data overrun
     if (flg & MXC_F_CAN_REVA_INTFL_DOR) {
-        MXC_CAN_SignalObjectEvent(MXC_CAN_GET_IDX((mxc_can_regs_t *)can),
+        MXC_CAN_SignalObjectEvent(can_idx,
                                   MXC_CAN_OBJ_EVT_RX_OVERRUN);
     }
 
@@ -1034,9 +1087,13 @@ int MXC_CAN_RevA_SetWakeupTimer(mxc_can_reva_regs_t *can, uint8_t prescaler, uin
 mxc_can_stat_t MXC_CAN_RevA_GetStatus(mxc_can_reva_regs_t *can)
 {
     mxc_can_stat_t stat;
-
+    int can_idx; 
+    
+    can_idx = MXC_CAN_GET_IDX((mxc_can_regs_t *)can);
+    MXC_ASSERT(can_idx >= 0);
+    
     // Get unit state
-    if (obj_state[MXC_CAN_GET_IDX((mxc_can_regs_t *)can)] == MXC_CAN_OBJ_CFG_INACTIVE) {
+    if (obj_state[can_idx] == MXC_CAN_OBJ_CFG_INACTIVE) {
         stat.unit_state = MXC_CAN_UNIT_STATE_INACTIVE;
     } else if (can->stat & MXC_F_CAN_REVA_STAT_BUS_OFF) {
         stat.unit_state = MXC_CAN_UNIT_STATE_BUS_OFF;

--- a/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
@@ -71,15 +71,20 @@ static void transfer_callback(int ch, int error);
 int MXC_DMA_RevA_Init(mxc_dma_reva_regs_t *dma)
 {
     int i, numCh, offset;
+    int dma_idx;
+
+    dma_idx = MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma);
+    MXC_ASSERT(dma_idx >= 0);
+
 #if TARGET_NUM == 32665
     numCh = MXC_DMA_CH_OFFSET;
-    offset = numCh * MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma);
+    offset = numCh * dma_idx;
 #else
     numCh = MXC_DMA_CHANNELS;
     offset = 0;
 #endif
 
-    if (dma_initialized[MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma)]) {
+    if (dma_initialized[dma_idx]) {
         return E_BAD_STATE;
     }
 
@@ -106,7 +111,7 @@ int MXC_DMA_RevA_Init(mxc_dma_reva_regs_t *dma)
         dma_resource[i].cb = NULL;
     }
 
-    dma_initialized[MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma)]++;
+    dma_initialized[dma_idx]++;
 #ifndef __riscv
     MXC_FreeLock(&dma_lock);
 #endif
@@ -116,21 +121,30 @@ int MXC_DMA_RevA_Init(mxc_dma_reva_regs_t *dma)
 
 void MXC_DMA_RevA_DeInit(mxc_dma_reva_regs_t *dma)
 {
-    dma_initialized[MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma)] = 0;
+    int dma_idx;
+
+    dma_idx = MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma);
+    MXC_ASSERT(dma_idx >= 0);
+
+    dma_initialized[dma_idx] = 0;
 }
 
 int MXC_DMA_RevA_AcquireChannel(mxc_dma_reva_regs_t *dma)
 {
     int i, channel, numCh, offset;
+    int dma_idx;
+
+    dma_idx = MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma);
+    MXC_ASSERT(dma_idx >= 0);
 
     /* Check for initialization */
-    if (!dma_initialized[MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma)]) {
+    if (!dma_initialized[dma_idx]) {
         return E_BAD_STATE;
     }
 
 #if TARGET_NUM == 32665
     numCh = MXC_DMA_CH_OFFSET;
-    offset = MXC_DMA_CH_OFFSET * MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma);
+    offset = MXC_DMA_CH_OFFSET * dma_idx;
 #else
     numCh = MXC_DMA_CHANNELS;
     offset = 0;
@@ -419,7 +433,13 @@ mxc_dma_ch_regs_t *MXC_DMA_RevA_GetCHRegs(int ch)
 void MXC_DMA_RevA_Handler(mxc_dma_reva_regs_t *dma)
 {
     int numCh = MXC_DMA_CHANNELS / MXC_DMA_INSTANCES;
-    int offset = numCh * MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma);
+    int dma_idx;
+    int offset;
+
+    dma_idx = MXC_DMA_GET_IDX((mxc_dma_regs_t *)dma);
+    MXC_ASSERT(dma_idx >= 0);
+
+    offset = numCh * dma_idx;
     /* Do callback, if enabled */
     for (int i = offset; i < (offset + numCh); i++) {
         if (CHECK_HANDLE(i)) {


### PR DESCRIPTION
### Description

Building with -Warray-bounds flags causes warnings, this pr includes fix for can and dma. 
Warnigns:

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/c4f1c919-5a1d-40d7-adaa-f854bbbade25)


### Checklist Before Requesting Review

- [ X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
