### PR TITLE
fix(CMSIS): Regenerate trng_regs.h using correct SVD file for MAX32670

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.svd
@@ -8775,15 +8775,9 @@
        <bitWidth>1</bitWidth>
       </field>
       <field>
-       <name>AESKG_USR</name>
+       <name>KEYGEN</name>
        <description>AES Key Generate. When enabled, the key for securing NVSRAM is generated and transferred to the secure key register automatically without user visibility or intervention. This bit is cleared by hardware once the key has been transferred to the secure key register.</description>
        <bitOffset>3</bitOffset>
-       <bitWidth>1</bitWidth>
-      </field>
-      <field>
-       <name>AESKG_SYS</name>
-       <description>AESKG_SYS.</description>
-       <bitOffset>4</bitOffset>
        <bitWidth>1</bitWidth>
       </field>
       <field>

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Include/trng_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Include/trng_regs.h
@@ -119,11 +119,8 @@ typedef struct {
 #define MXC_F_TRNG_CTRL_HEALTH_EN_POS                  2 /**< CTRL_HEALTH_EN Position */
 #define MXC_F_TRNG_CTRL_HEALTH_EN                      ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_HEALTH_EN_POS)) /**< CTRL_HEALTH_EN Mask */
 
-#define MXC_F_TRNG_CTRL_AESKG_USR_POS                  3 /**< CTRL_AESKG_USR Position */
-#define MXC_F_TRNG_CTRL_AESKG_USR                      ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_AESKG_USR_POS)) /**< CTRL_AESKG_USR Mask */
-
-#define MXC_F_TRNG_CTRL_AESKG_SYS_POS                  4 /**< CTRL_AESKG_SYS Position */
-#define MXC_F_TRNG_CTRL_AESKG_SYS                      ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_AESKG_SYS_POS)) /**< CTRL_AESKG_SYS Mask */
+#define MXC_F_TRNG_CTRL_KEYGEN_POS                     3 /**< CTRL_KEYGEN Position */
+#define MXC_F_TRNG_CTRL_KEYGEN                         ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_KEYGEN_POS)) /**< CTRL_KEYGEN Mask */
 
 #define MXC_F_TRNG_CTRL_KEYWIPE_POS                    15 /**< CTRL_KEYWIPE Position */
 #define MXC_F_TRNG_CTRL_KEYWIPE                        ((uint32_t)(0x1UL << MXC_F_TRNG_CTRL_KEYWIPE_POS)) /**< CTRL_KEYWIPE Mask */


### PR DESCRIPTION
### Description

The incorrect SVD file was used to generate the ME15's trng_regs.h file. Also, the ME15 only has one AES key.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.