### PR TITLE
feat(Examples): Add I2C DMA to I2C examples for MAX32670 and MAX32675

### DIFF
--- a/Examples/MAX32670/I2C/main.c
+++ b/Examples/MAX32670/I2C/main.c
@@ -50,22 +50,24 @@
 #include <string.h>
 #include "mxc_device.h"
 #include "mxc_delay.h"
+#include "mxc_errors.h"
 #include "nvic_table.h"
 #include "i2c.h"
 #include "dma.h"
+#include "led.h"
 
 /***** Definitions *****/
-// #define MASTERDMA
+#define MASTERDMA //Comment this line out if standard I2C transaction is required
 
-#define I2C_MASTER MXC_I2C1
-#define I2C_SLAVE MXC_I2C0
+#define I2C_MASTER MXC_I2C0
+#define I2C_SLAVE MXC_I2C2
 
 #define I2C_FREQ 100000
 // This example may become unreliable at I2C frequencies above 100kHz.
 // This is only an issue in the loopback configuration, where the I2C block is
 // connected to itself.
 #define I2C_SLAVE_ADDR (0x51)
-#define I2C_BYTES 100
+#define I2C_BYTES 255
 
 /***** Globals *****/
 static uint8_t Stxdata[I2C_BYTES];
@@ -77,14 +79,28 @@ volatile int I2C_FLAG;
 volatile int txnum = 0;
 volatile int txcnt = 0;
 volatile int rxnum = 0;
-volatile int num;
+
 /***** Functions *****/
 
 //Slave interrupt handler
-void I2C0_IRQHandler(void)
+void I2C2_IRQHandler(void)
 {
     MXC_I2C_AsyncHandler(I2C_SLAVE);
     return;
+}
+
+void DMA0_IRQHandler(void)
+{
+    MXC_DMA_Handler();
+    MXC_DMA_ReleaseChannel(0);
+    DMA_FLAG = 1;
+}
+
+void DMA1_IRQHandler(void)
+{
+    MXC_DMA_Handler();
+    MXC_DMA_ReleaseChannel(1);
+    DMA_FLAG = 1;
 }
 
 //I2C callback function
@@ -102,43 +118,33 @@ int slaveHandler(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_t event, void *data)
         // Clear bytes written
         rxnum = 0;
         break;
-
     case MXC_I2C_EVT_MASTER_RD:
-
         // Serve as a 16 byte loopback, returning data*2
         for (int i = 0; i < I2C_BYTES; i++) {
             Stxdata[i] = Srxdata[i];
         }
-
         txnum = I2C_BYTES;
         txcnt = 0;
         i2c->intfl0 = MXC_F_I2C_INTFL0_TX_LOCKOUT | MXC_F_I2C_INTFL0_ADDR_MATCH;
         break;
-
     case MXC_I2C_EVT_RX_THRESH:
     case MXC_I2C_EVT_OVERFLOW:
         rxnum += MXC_I2C_ReadRXFIFO(i2c, &Srxdata[rxnum], MXC_I2C_GetRXFIFOAvailable(i2c));
-
         if (rxnum == I2C_BYTES) {
-            i2c->inten0 |= MXC_F_I2C_INTFL0_ADDR_MATCH;
+            i2c->inten0 |= MXC_F_I2C_INTEN0_ADDR_MATCH;
         }
-
         break;
-
     case MXC_I2C_EVT_TX_THRESH:
     case MXC_I2C_EVT_UNDERFLOW:
-
         // Write as much data as possible into TX FIFO
         // Unless we're at the end of the transaction (only write what's needed)
         if (txcnt >= txnum) {
             break;
         }
-
         int num = MXC_I2C_GetTXFIFOAvailable(i2c);
         num = (num > (txnum - txcnt)) ? (txnum - txcnt) : num;
         txcnt += MXC_I2C_WriteTXFIFO(i2c, &Stxdata[txcnt], num);
         break;
-
     default:
         if (*((int *)data) == E_COMM_ERR) {
             printf("I2C Slave Error!\n");
@@ -152,7 +158,6 @@ int slaveHandler(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_t event, void *data)
             return 1;
         }
     }
-
     return 0;
 }
 
@@ -161,13 +166,11 @@ void printData(void)
 {
     int i;
     printf("\n-->TxData: ");
-
     for (i = 0; i < sizeof(txdata); ++i) {
         printf("%02x ", txdata[i]);
     }
 
     printf("\n\n-->RxData: ");
-
     for (i = 0; i < sizeof(rxdata); ++i) {
         printf("%02x ", rxdata[i]);
     }
@@ -181,13 +184,11 @@ void printData(void)
 int verifyData(void)
 {
     int i, fails = 0;
-
     for (i = 0; i < I2C_BYTES; ++i) {
         if (txdata[i] != rxdata[i]) {
             ++fails;
         }
     }
-
     if (fails > 0) {
         return E_FAIL;
     }
@@ -209,25 +210,21 @@ int main()
 
     //Setup the I2CM
     error = MXC_I2C_Init(I2C_MASTER, 1, 0);
-
     if (error != E_NO_ERROR) {
-        printf("-->Failed master\n");
+        printf("Failed master\n");
         return error;
-    } else {
-        printf("\n-->I2C Master Initialization Complete");
     }
 
     //Setup the I2CS
     error = MXC_I2C_Init(I2C_SLAVE, 0, I2C_SLAVE_ADDR);
-
     if (error != E_NO_ERROR) {
         printf("Failed slave\n");
         return error;
-    } else {
-        printf("\n-->I2C Slave Initialization Complete");
     }
 
-    NVIC_EnableIRQ(I2C0_IRQn);
+    MXC_NVIC_SetVector(I2C2_IRQn, I2C2_IRQHandler);
+    NVIC_EnableIRQ(I2C2_IRQn);
+    __enable_irq();
 
     MXC_I2C_SetFrequency(I2C_MASTER, I2C_FREQ);
 
@@ -237,8 +234,6 @@ int main()
     for (i = 0; i < I2C_BYTES; i++) {
         txdata[i] = i;
         rxdata[i] = 0;
-        Stxdata[i] = i;
-        Srxdata[i] = 0;
     }
 
     // This will write data to slave
@@ -261,23 +256,38 @@ int main()
         return error;
     }
 
+#ifdef MASTERDMA
+    MXC_DMA_ReleaseChannel(0);
+    MXC_DMA_ReleaseChannel(1);
+
+    NVIC_EnableIRQ(DMA0_IRQn);
+    NVIC_EnableIRQ(DMA1_IRQn);
+    __enable_irq();
+
+    if ((error = MXC_I2C_MasterTransactionDMA(&reqMaster)) != 0) {
+        printf("Error writing: %d\n", error);
+        return error;
+    }
+    while (DMA_FLAG == 0) {}
+#else
     if ((error = MXC_I2C_MasterTransaction(&reqMaster)) != 0) {
         printf("Error writing: %d\n", error);
         return error;
     }
 
     while (I2C_FLAG == 1) {}
+#endif
 
     printf("\n-->Result: \n");
-
     printData();
-
     printf("\n");
 
     if (verifyData() == E_NO_ERROR) {
         printf("\n-->I2C Transaction Successful\n");
+        LED_On(LED_GREEN);
     } else {
         printf("\n-->I2C Transaction Failed\n");
+        LED_On(LED_RED);
         return E_FAIL;
     }
 


### PR DESCRIPTION
### Description

This change adds I2C DMA to the I2C examples for the ME15 and ME16.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.