### PR TITLE
fix(Examples): Update Flash examples to use MXC_FLC_Read to resolve IAR/Keil build errors

### DIFF
--- a/Examples/MAX32520/Flash/main.c
+++ b/Examples/MAX32520/Flash/main.c
@@ -238,7 +238,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32572/Flash/main.c
+++ b/Examples/MAX32572/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32650/Flash/main.c
+++ b/Examples/MAX32650/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32655/Flash/main.c
+++ b/Examples/MAX32655/Flash/main.c
@@ -211,7 +211,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32660/Flash/main.c
+++ b/Examples/MAX32660/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32662/Flash/main.c
+++ b/Examples/MAX32662/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32665/Flash/main.c
+++ b/Examples/MAX32665/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32670/Flash/main.c
+++ b/Examples/MAX32670/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32672/Flash/main.c
+++ b/Examples/MAX32672/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32675/Flash/main.c
+++ b/Examples/MAX32675/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32680/Flash/main.c
+++ b/Examples/MAX32680/Flash/main.c
@@ -210,7 +210,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX32690/Flash/main.c
+++ b/Examples/MAX32690/Flash/main.c
@@ -207,7 +207,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX78000/Flash/main.c
+++ b/Examples/MAX78000/Flash/main.c
@@ -212,7 +212,7 @@ int erase_magic()
     }; // 8192 bytes per page / 4 bytes = 2048 uint32_t
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);

--- a/Examples/MAX78002/Flash/main.c
+++ b/Examples/MAX78002/Flash/main.c
@@ -208,7 +208,7 @@ int erase_magic()
     uint32_t buffer[MXC_FLASH_PAGE_SIZE >> 2] = { 0xFFFFFFFF };
 
     printf("Buffering page...\n");
-    memcpy(buffer, (void *)TEST_ADDRESS, MXC_FLASH_PAGE_SIZE);
+    MXC_FLC_Read(TEST_ADDRESS, buffer, MXC_FLASH_PAGE_SIZE);
 
     printf("Erasing page...\n");
     err = MXC_FLC_PageErase(TEST_ADDRESS);


### PR DESCRIPTION
In the last release we fixed a Flash read bug in the Flash examples by changing this line of code to use void* typecast instead of a uint32_t* typecast. That change solved the bug in the code but introduced a build error on the IAR/Keil side. The solution to both of these problems is to use MXC_FLC_Read instead of the call to memcpy.
