### PR TITLE
fix(PeriphDrivers): Explicitly set the LPCMP Polarity Setting (Rising/Falling)

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32655/lpcmp.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/lpcmp.h
@@ -54,8 +54,8 @@ extern "C" {
  * 
  */
 typedef enum {
-    MXC_LPCMP_POL_RISE, //< Comparator interrupt happens on rising edge of comparator output
-    MXC_LPCMP_POL_FALL, //< Comparator interrupt occurs on falling edge of comparator output
+    MXC_LPCMP_POL_RISE = 0, //< Comparator interrupt happens on rising edge of comparator output
+    MXC_LPCMP_POL_FALL = 1, //< Comparator interrupt occurs on falling edge of comparator output
 } mxc_lpcmp_polarity_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32680/lpcmp.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/lpcmp.h
@@ -54,8 +54,8 @@ extern "C" {
  * 
  */
 typedef enum {
-    MXC_LPCMP_POL_RISE, //< Comparator interrupt happens on rising edge of comparator output
-    MXC_LPCMP_POL_FALL, //< Comparator interrupt occurs on falling edge of comparator output
+    MXC_LPCMP_POL_RISE = 0, //< Comparator interrupt happens on rising edge of comparator output
+    MXC_LPCMP_POL_FALL = 1, //< Comparator interrupt occurs on falling edge of comparator output
 } mxc_lpcmp_polarity_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32690/lpcmp.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/lpcmp.h
@@ -54,8 +54,8 @@ extern "C" {
  * 
  */
 typedef enum {
-    MXC_LPCMP_POL_RISE, //< Comparator interrupt happens on rising edge of comparator output
-    MXC_LPCMP_POL_FALL, //< Comparator interrupt occurs on falling edge of comparator output
+    MXC_LPCMP_POL_RISE = 0, //< Comparator interrupt happens on rising edge of comparator output
+    MXC_LPCMP_POL_FALL = 1, //< Comparator interrupt occurs on falling edge of comparator output
 } mxc_lpcmp_polarity_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78000/lpcmp.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/lpcmp.h
@@ -54,8 +54,8 @@ extern "C" {
  * 
  */
 typedef enum {
-    MXC_LPCMP_POL_RISE, //< Comparator interrupt happens on rising edge of comparator output
-    MXC_LPCMP_POL_FALL, //< Comparator interrupt occurs on falling edge of comparator output
+    MXC_LPCMP_POL_RISE = 0, //< Comparator interrupt happens on rising edge of comparator output
+    MXC_LPCMP_POL_FALL = 1, //< Comparator interrupt occurs on falling edge of comparator output
 } mxc_lpcmp_polarity_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX78002/lpcmp.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/lpcmp.h
@@ -54,8 +54,8 @@ extern "C" {
  * 
  */
 typedef enum {
-    MXC_LPCMP_POL_RISE, //< Comparator interrupt happens on rising edge of comparator output
-    MXC_LPCMP_POL_FALL, //< Comparator interrupt occurs on falling edge of comparator output
+    MXC_LPCMP_POL_RISE = 0, //< Comparator interrupt happens on rising edge of comparator output
+    MXC_LPCMP_POL_FALL = 1, //< Comparator interrupt occurs on falling edge of comparator output
 } mxc_lpcmp_polarity_t;
 
 /**


### PR DESCRIPTION
### Description

The `MXC_LPCMP_POL_RISE` and `MXC_LPCMP_POL_FALL` enumeration values are used to set the polarity setting for the LPCMP. However, they weren't explicitly set with the values 0 and 1, respectively, which can cause the H->L transition setting to be selected when using the `MXC_LPCMP_POL_RISE` enum value (should be `MXC_LPCMP_POL_FALL` that selects the H->L transition setting) and vice versa.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.