### PR TITLE
fix(Examples): Fix ImgCapture RGB888 Conversions

### DIFF
--- a/Examples/MAX78000/CameraIF/pc_utility/imgConverter.py
+++ b/Examples/MAX78000/CameraIF/pc_utility/imgConverter.py
@@ -72,8 +72,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]

--- a/Examples/MAX78000/CameraIF_Debayer/pc_utility/imgConverter.py
+++ b/Examples/MAX78000/CameraIF_Debayer/pc_utility/imgConverter.py
@@ -78,8 +78,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]

--- a/Examples/MAX78000/CameraIF_Debayer/pc_utility/temo/imgConverter.py
+++ b/Examples/MAX78000/CameraIF_Debayer/pc_utility/temo/imgConverter.py
@@ -78,8 +78,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]

--- a/Examples/MAX78000/ImgCapture/main.c
+++ b/Examples/MAX78000/ImgCapture/main.c
@@ -115,10 +115,11 @@ img_data_t capture_img(uint32_t w, uint32_t h, pixformat_t pixel_format, dmamode
     // camera.h drivers will allocate an SRAM buffer whose size is equal to
     // width * height * bytes_per_pixel.  See camera.c for implementation details.
     printf("Configuring camera\n");
+    fifomode_t fifo_mode = (pixel_format == PIXFORMAT_RGB888) ? FIFO_THREE_BYTE : FIFO_FOUR_BYTE;
     int ret = camera_setup(w, // width
                            h, // height
                            pixel_format, // pixel format
-                           FIFO_FOUR_BYTE, // FIFO mode (four bytes is suitable for most cases)
+                           fifo_mode, // FIFO mode (four bytes is suitable for most cases)
                            dma_mode, // DMA (enabling DMA will drastically decrease capture time)
                            dma_channel); // Allocate the DMA channel retrieved in initialization
 
@@ -239,10 +240,11 @@ cnn_img_data_t stream_img(uint32_t w, uint32_t h, pixformat_t pixel_format, int 
     // 1. Configure the camera.  This is the same as the standard blocking capture, except
     // the DMA mode is set to "STREAMING_DMA".
     printf("Configuring camera\n");
+    fifomode_t fifo_mode = (pixel_format == PIXFORMAT_RGB888) ? FIFO_THREE_BYTE : FIFO_FOUR_BYTE;
     int ret = camera_setup(w, // width
                            h, // height
                            pixel_format, // pixel format
-                           FIFO_FOUR_BYTE, // FIFO mode
+                           fifo_mode, // FIFO mode
                            STREAMING_DMA, // Set streaming mode
                            dma_channel); // Allocate the DMA channel retrieved in initialization
 
@@ -621,7 +623,7 @@ int main(void)
     g_app_settings.dma_mode = USE_DMA;
     g_app_settings.imgres_w = IMAGE_XRES;
     g_app_settings.imgres_h = IMAGE_YRES;
-    g_app_settings.pixel_format = PIXFORMAT_RGB565; // This default may change during initialization
+    g_app_settings.pixel_format = PIXFORMAT_RGB888; // This default may change during initialization
 
 #if defined(CAMERA_MONO)
     g_app_settings.pixel_format = PIXFORMAT_BAYER;

--- a/Examples/MAX78000/ImgCapture/utils/imgConverter.py
+++ b/Examples/MAX78000/ImgCapture/utils/imgConverter.py
@@ -105,8 +105,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]

--- a/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/utils/imgConverter.py
+++ b/Examples/MAX78002/CNN/pascalvoc-retinanetv7_3/utils/imgConverter.py
@@ -105,8 +105,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]

--- a/Examples/MAX78002/CSI2/utils/imgConverter.py
+++ b/Examples/MAX78002/CSI2/utils/imgConverter.py
@@ -105,8 +105,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]

--- a/Examples/MAX78002/CameraIF/pc_utility/imgConverter.py
+++ b/Examples/MAX78002/CameraIF/pc_utility/imgConverter.py
@@ -72,8 +72,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]

--- a/Examples/MAX78002/CameraIF_Debayer/pc_utility/imgConverter.py
+++ b/Examples/MAX78002/CameraIF_Debayer/pc_utility/imgConverter.py
@@ -78,8 +78,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]

--- a/Examples/MAX78002/ImgCapture/main.c
+++ b/Examples/MAX78002/ImgCapture/main.c
@@ -120,10 +120,11 @@ img_data_t capture_img(uint32_t w, uint32_t h, pixformat_t pixel_format, dmamode
     // camera.h drivers will allocate an SRAM buffer whose size is equal to
     // width * height * bytes_per_pixel.  See camera.c for implementation details.
     printf("Configuring camera\n");
+    fifomode_t fifo_mode = (pixel_format == PIXFORMAT_RGB888) ? FIFO_THREE_BYTE : FIFO_FOUR_BYTE;
     int ret = camera_setup(w, // width
                            h, // height
                            pixel_format, // pixel format
-                           FIFO_FOUR_BYTE, // FIFO mode (four bytes is suitable for most cases)
+                           fifo_mode, // FIFO mode (four bytes is suitable for most cases)
                            dma_mode, // DMA (enabling DMA will drastically decrease capture time)
                            dma_channel); // Allocate the DMA channel retrieved in initialization
 
@@ -244,10 +245,11 @@ cnn_img_data_t stream_img(uint32_t w, uint32_t h, pixformat_t pixel_format, int 
     // 1. Configure the camera.  This is the same as the standard blocking capture, except
     // the DMA mode is set to "STREAMING_DMA".
     printf("Configuring camera\n");
+    fifomode_t fifo_mode = (pixel_format == PIXFORMAT_RGB888) ? FIFO_THREE_BYTE : FIFO_FOUR_BYTE;
     int ret = camera_setup(w, // width
                            h, // height
                            pixel_format, // pixel format
-                           FIFO_FOUR_BYTE, // FIFO mode
+                           fifo_mode, // FIFO mode
                            STREAMING_DMA, // Set streaming mode
                            dma_channel); // Allocate the DMA channel retrieved in initialization
 

--- a/Examples/MAX78002/ImgCapture/utils/imgConverter.py
+++ b/Examples/MAX78002/ImgCapture/utils/imgConverter.py
@@ -105,8 +105,8 @@ def yuv422_to_blackAndWhite(bytesequence):
 
 def rgb888_to_rgb(bytesequence):
 	img = []
-	for i in range(len(bytesequence) // 3):
-		offset = i * 3
+	for i in range(len(bytesequence) // 4):
+		offset = i * 4
 		byte1 = bytesequence[offset + 0]
 		byte2 = bytesequence[offset + 1]
 		byte3 = bytesequence[offset + 2]


### PR DESCRIPTION
## Pull Request Template

### Description

Fixes #681 

There was a typo in the `rgb888_to_rgb` conversions.  They assumed 3 byte RGB sequences.  However, for RGB888 conversions the camera drivers enforce FIFO_THREE_BYTE, which outputs a 4-byte word with the MSB filled with 0.

Before:

![Image](https://github.com/Analog-Devices-MSDK/msdk/assets/38844790/5a974632-9c83-4bfa-923a-0141c88a2d98)

After (ceiling tile ftw):

![Image](https://github.com/Analog-Devices-MSDK/msdk/assets/38844790/1be2e046-f7f1-4672-82bd-e04316cc6953)


### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

