### PR TITLE
perf(Build): Set Compressed Instruction Set as Default for RISC-V

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -451,7 +451,9 @@ ifeq "$(CYGWIN)" "True"
 endif
 
 # The rule for linking the application.
-${BUILD_DIR}/%.elf: $(PROJECTMK) | $(BUILD_DIR)
+# Note "RISCV_COMMON_LD" in the dependency tree.  Part-specific makefiles (ie. max78000.mk)
+# are responsible for defining this optional variable.
+${BUILD_DIR}/%.elf: $(PROJECTMK) $(RISCV_COMMON_LD) | $(BUILD_DIR)
 # This rule parses the linker arguments into a text file to work around issues
 # with string length limits on the command line
 ifeq "$(_OS)" "windows_msys"

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -218,9 +218,9 @@ ifeq "$(PREFIX)" "riscv-none-elf"
 # With the upgrade to riscv-none-elf came a new ISA spec
 # See https://groups.google.com/a/groups.riscv.org/g/sw-dev/c/aE1ZeHHCYf4
 # BASE = RV32I
-# EXTENSION = M
+# EXTENSION = MC
 # EXTRAS = _zicsr_zifencei as recommended above
-MARCH ?= rv32im_zicsr_zifencei
+MARCH ?= rv32imc_zicsr_zifencei
 endif
 
 # Default option (riscv-none-embed)


### PR DESCRIPTION
### Description

This PR enables the compressed instruction set extension by default for RISC-V builds.  `MARCH` has been changed from `rv32im_zicsr_zifencei` to `rv32imc_zicsr_zifencei`.

This reduces the code size of RISC-V builds.

@rotx-maxim has also reported some performance improvements when using the compressed instruction set, so it seems (at least for now) that there are not significant performance vs code-size tradeoffs.

**Uncompressed AI85 PeriphDriver Size**
```
   text    data     bss     dec     hex filename
      4       0       0       4       4 mxc_assert.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    128       0       0     128      80 mxc_delay.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
     12       0       0      12       c mxc_lock.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
      0       0       0       0       0 nvic_table.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1200       0       0    1200     4b0 pins_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   2472       0       0    2472     9a8 sys_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1541       0       0    1541     605 adc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   5583       0      25    5608    15e8 adc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    480       0       0     480     1e0 aes_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   2568       0      16    2584     a18 aes_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    332       0       0     332     14c cameraif_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    208       0       0     208      d0 cameraif_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    248       0       0     248      f8 crc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    780       0       4     784     310 crc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    728       0       0     728     2d8 dma_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   3437       0     456    3893     f35 dma_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    644       0       0     644     284 flc_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1168       0       0    1168     490 flc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1744       4       0    1748     6d4 flc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    586       0    1025    1611     64b gpio_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   2108       0       0    2108     83c gpio_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    672       0       0     672     2a0 gpio_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1108       4       0    1112     458 i2c_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   9684       0     108    9792    2640 i2c_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    576       0       0     576     240 i2s_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   4412       0      76    4488    1188 i2s_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
     72       0       0      72      48 icc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    172       0       0     172      ac icc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
      8       0       0       8       8 lp_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    608       0       4     612     264 lpcmp_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    180       0       0     180      b4 lpcmp_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    772       0       0     772     304 owm_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   2544       0       8    2552     9f8 owm_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1173       0       0    1173     495 pt_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1290       0       0    1290     50a pt_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    448       0       0     448     1c0 rtc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1752       0       0    1752     6d8 rtc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    220       0       0     220      dc sema_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    902       8      24     934     3a6 sema_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1313       0       0    1313     521 spi_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   9566       0      40    9606    2586 spi_reva1.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    188       0       0     188      bc trng_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    905       0      16     921     399 trng_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    628       0       0     628     274 tmr_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   2542       0       0    2542     9ee tmr_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   4392       0      48    4440    1158 tmr_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1704       0       0    1704     6a8 uart_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    128       0       0     128      80 uart_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   7200       0      80    7280    1c70 uart_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
      0       0       0       0       0 wdt_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    320       0       0     320     140 wdt_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    492       0       0     492     1ec wdt_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1492       0      28    1520     5f0 wut_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1028       0       8    1036     40c wut_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
```

**Compressed AI85 PeriphDriver Size**
```
   text    data     bss     dec     hex filename
      2       0       0       2       2 mxc_assert.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
     88       0       0      88      58 mxc_delay.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
      6       0       0       6       6 mxc_lock.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
      0       0       0       0       0 nvic_table.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1200       0       0    1200     4b0 pins_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1712       0       0    1712     6b0 sys_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1197       0       0    1197     4ad adc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   3863       0      25    3888     f30 adc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    428       0       0     428     1ac aes_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1712       0      16    1728     6c0 aes_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    286       0       0     286     11e cameraif_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    110       0       0     110      6e cameraif_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    206       0       0     206      ce crc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    456       0       4     460     1cc crc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    524       0       0     524     20c dma_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   2291       0     456    2747     abb dma_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    450       0       0     450     1c2 flc_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    858       0       0     858     35a flc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1092       4       0    1096     448 flc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    456       0    1025    1481     5c9 gpio_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1594       0       0    1594     63a gpio_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    402       0       0     402     192 gpio_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    916       4       0     920     398 i2c_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   6572       0     108    6680    1a18 i2c_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    492       0       0     492     1ec i2s_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   2960       0      76    3036     bdc i2s_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
     56       0       0      56      38 icc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    114       0       0     114      72 icc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
      6       0       0       6       6 lp_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    450       0       4     454     1c6 lpcmp_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
     98       0       0      98      62 lpcmp_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    640       0       0     640     280 owm_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1640       0       8    1648     670 owm_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    941       0       0     941     3ad pt_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    868       0       0     868     364 pt_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    362       0       0     362     16a rtc_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1034       0       0    1034     40a rtc_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    182       0       0     182      b6 sema_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    644       8      24     676     2a4 sema_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1033       0       0    1033     409 spi_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   6356       0      40    6396    18fc spi_reva1.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    148       0       0     148      94 trng_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    647       0      16     663     297 trng_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    414       0       0     414     19e tmr_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   2132       0       0    2132     854 tmr_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   3360       0      48    3408     d50 tmr_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1334       0       0    1334     536 uart_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
     80       0       0      80      50 uart_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   5138       0      80    5218    1462 uart_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
      0       0       0       0       0 wdt_common.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    260       0       0     260     104 wdt_me17.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    298       0       0     298     12a wdt_revb.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
   1190       0      28    1218     4c2 wut_ai85.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
    676       0       8     684     2ac wut_reva.o (ex /home/jakecarter/repos/fork/msdk/Libraries/PeriphDrivers/bin/MAX78000/softfp_riscv/libPeriphDriver_softfp.a)
```

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
