### PR TITLE
fix(Build): Disable Parallel Execution When Creating common_riscv.ld for `RISCV_LOAD=1`

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/max78000.mk
@@ -166,6 +166,10 @@ rvcommonld: $(RISCV_COMMON_LD)
 # This is where the implementation gets complicated...  but what we want to do is simple.
 # 1) Parse the memory address of the "_riscv_boot" symbol.
 # 2) Write definitions for __FlashStart and __FlashLength in the auto-generated linkerfile.
+.NOTPARALLEL: $(RISCV_COMMON_LD)
+# ^ Note ".NOTPARALLEL" is used.  Despite explicitly listing the arm map file as a dependency,
+# parallel builds would sometimes break this target.  
+# (https://www.gnu.org/software/make/manual/make.html#Parallel-Disable)
 $(RISCV_COMMON_LD): $(ARM_MAP_FILE)
 	$(info - Detecting Arm code size and generating $(@))
 	$(info - Input file: $(ARM_MAP_FILE))

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/GCC/max78002.mk
@@ -164,6 +164,10 @@ rvcommonld: $(RISCV_COMMON_LD)
 # This is where the implementation gets complicated...  but what we want to do is simple.
 # 1) Parse the memory address of the "_riscv_boot" symbol.
 # 2) Write definitions for __FlashStart and __FlashLength in the auto-generated linkerfile.
+.NOTPARALLEL: $(RISCV_COMMON_LD)
+# ^ Note ".NOTPARALLEL" is used.  Despite explicitly listing the arm map file as a dependency,
+# parallel builds would sometimes break this target.
+# (https://www.gnu.org/software/make/manual/make.html#Parallel-Disable)
 $(RISCV_COMMON_LD): $(ARM_MAP_FILE)
 	$(info - Detecting Arm code size and generating $(@))
 	$(info - Input file: $(ARM_MAP_FILE))


### PR DESCRIPTION
## Pull Request Template

### Description

As of #653 some build errors starting showing up in the auto-tester, but just for the AI85 Aud01_RevA BSP.  (ex [here](https://github.com/Analog-Devices-MSDK/msdk/actions/runs/5802135079/job/15727888491?pr=702), [here](https://github.com/Analog-Devices-MSDK/msdk/actions/runs/5802113840/job/15727822359?pr=703))

This turned out to be an issue with parallel builds.  RV_ARM_Loader for the AI85/AI87 failed for other boards with `make -r -j`, but randomly.  The rule for creating `riscv_common.ld` seems to have an incomplete dependency tree.  I tried several solutions to make the dependency tree more explicit, but nothing seemed to work.  The file operations for parsing the .map file for the RISC-V boot address always had some chance of modifying files that were being worked on by other parallel threads.

TLDR: As a solution, I've disabled parallel builds for the step where `RISCV_LOAD=1` creates `riscv_common.ld`.  Impact on build speed is minimal, and this seems to work.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
