### PR TITLE
fix(PeriphDrivers): Fix `-Wcast-align` warning for MAX78000 & MAX78002 SYS Drivers

### DIFF
--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -151,8 +151,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    if (usn != NULL)
-        memcpy(usn, _usn_8, MXC_SYS_USN_LEN);
+    memcpy(usn, _usn_8, MXC_SYS_USN_LEN);
 
     return err;
 }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -80,25 +80,31 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    uint32_t _usn_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
+    // ^ Declare as uint32_t to preserve mem alignment
+    uint8_t *_usn_8 = (uint8_t *) _usn_32;
+    memset(_usn_8, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
-    usn[0] = (infoblock[0] & 0x007F8000) >> 15;
-    usn[1] = (infoblock[0] & 0x7F800000) >> 23;
-    usn[2] = (infoblock[1] & 0x0000007F) << 1;
-    usn[2] |= (infoblock[0] & 0x80000000) >> 31;
-    usn[3] = (infoblock[1] & 0x00007F80) >> 7;
-    usn[4] = (infoblock[1] & 0x007F8000) >> 15;
-    usn[5] = (infoblock[1] & 0x7F800000) >> 23;
-    usn[6] = (infoblock[2] & 0x007F8000) >> 15;
-    usn[7] = (infoblock[2] & 0x7F800000) >> 23;
-    usn[8] = (infoblock[3] & 0x0000007F) << 1;
-    usn[8] |= (infoblock[2] & 0x80000000) >> 31;
-    usn[9] = (infoblock[3] & 0x00007F80) >> 7;
-    usn[10] = (infoblock[3] & 0x007F8000) >> 15;
+    _usn_8[0] = (infoblock[0] & 0x007F8000) >> 15;
+    _usn_8[1] = (infoblock[0] & 0x7F800000) >> 23;
+    _usn_8[2] = (infoblock[1] & 0x0000007F) << 1;
+    _usn_8[2] |= (infoblock[0] & 0x80000000) >> 31;
+    _usn_8[3] = (infoblock[1] & 0x00007F80) >> 7;
+    _usn_8[4] = (infoblock[1] & 0x007F8000) >> 15;
+    _usn_8[5] = (infoblock[1] & 0x7F800000) >> 23;
+    _usn_8[6] = (infoblock[2] & 0x007F8000) >> 15;
+    _usn_8[7] = (infoblock[2] & 0x7F800000) >> 23;
+    _usn_8[8] = (infoblock[3] & 0x0000007F) << 1;
+    _usn_8[8] |= (infoblock[2] & 0x80000000) >> 31;
+    _usn_8[9] = (infoblock[3] & 0x00007F80) >> 7;
+    _usn_8[10] = (infoblock[3] & 0x007F8000) >> 15;
 
     /* If requested, verify and return the checksum */
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint32_t _check_csum_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
+        // ^ Declare as uint32_t to preserve mem alignment
+        memset(_check_csum_32, 0, (MXC_SYS_USN_CHECKSUM_LEN / 4) * sizeof(uint32_t));
+        uint8_t *check_csum = (uint8_t *)_check_csum_32;
         uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)
 
         // Read Checksum from the infoblock
@@ -117,8 +123,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Compute Checksum
         mxc_aes_req_t aes_req;
         aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
-        aes_req.inputData = (uint32_t *)usn;
-        aes_req.resultData = (uint32_t *)check_csum;
+        aes_req.inputData = _usn_32;
+        aes_req.resultData = _check_csum_32;
         aes_req.keySize = MXC_AES_128BITS;
         aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;
         aes_req.callback = NULL;
@@ -132,6 +138,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         MXC_AES_Shutdown();
 
         // Verify Checksum
+        // The checksum results will be in the least significant bytes of the aes output.
         if (check_csum[0] != checksum[1] || check_csum[1] != checksum[0]) {
             MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
             return E_INVALID;
@@ -139,10 +146,13 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     }
 
     /* Add the info block checksum to the USN */
-    usn[11] = ((infoblock[3] & 0x7F800000) >> 23);
-    usn[12] = ((infoblock[4] & 0x007F8000) >> 15);
+    _usn_8[11] = ((infoblock[3] & 0x7F800000) >> 23);
+    _usn_8[12] = ((infoblock[4] & 0x007F8000) >> 15);
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+
+    if (usn != NULL)
+        memcpy(usn, _usn_8, MXC_SYS_USN_LEN);
 
     return err;
 }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai85.c
@@ -82,7 +82,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     uint32_t _usn_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
     // ^ Declare as uint32_t to preserve mem alignment
-    uint8_t *_usn_8 = (uint8_t *) _usn_32;
+    uint8_t *_usn_8 = (uint8_t *)_usn_32;
     memset(_usn_8, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     _usn_8[0] = (infoblock[0] & 0x007F8000) >> 15;

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
@@ -80,25 +80,31 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* Read the USN from the info block */
     MXC_FLC_UnlockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    memset(usn, 0, MXC_SYS_USN_CHECKSUM_LEN);
+    uint32_t _usn_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
+    // ^ Declare as uint32_t to preserve mem alignment
+    uint8_t *_usn_8 = (uint8_t *) _usn_32;
+    memset(_usn_8, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
-    usn[0] = (infoblock[0] & 0x007F8000) >> 15;
-    usn[1] = (infoblock[0] & 0x7F800000) >> 23;
-    usn[2] = (infoblock[1] & 0x0000007F) << 1;
-    usn[2] |= (infoblock[0] & 0x80000000) >> 31;
-    usn[3] = (infoblock[1] & 0x00007F80) >> 7;
-    usn[4] = (infoblock[1] & 0x007F8000) >> 15;
-    usn[5] = (infoblock[1] & 0x7F800000) >> 23;
-    usn[6] = (infoblock[2] & 0x007F8000) >> 15;
-    usn[7] = (infoblock[2] & 0x7F800000) >> 23;
-    usn[8] = (infoblock[3] & 0x0000007F) << 1;
-    usn[8] |= (infoblock[2] & 0x80000000) >> 31;
-    usn[9] = (infoblock[3] & 0x00007F80) >> 7;
-    usn[10] = (infoblock[3] & 0x007F8000) >> 15;
+    _usn_8[0] = (infoblock[0] & 0x007F8000) >> 15;
+    _usn_8[1] = (infoblock[0] & 0x7F800000) >> 23;
+    _usn_8[2] = (infoblock[1] & 0x0000007F) << 1;
+    _usn_8[2] |= (infoblock[0] & 0x80000000) >> 31;
+    _usn_8[3] = (infoblock[1] & 0x00007F80) >> 7;
+    _usn_8[4] = (infoblock[1] & 0x007F8000) >> 15;
+    _usn_8[5] = (infoblock[1] & 0x7F800000) >> 23;
+    _usn_8[6] = (infoblock[2] & 0x007F8000) >> 15;
+    _usn_8[7] = (infoblock[2] & 0x7F800000) >> 23;
+    _usn_8[8] = (infoblock[3] & 0x0000007F) << 1;
+    _usn_8[8] |= (infoblock[2] & 0x80000000) >> 31;
+    _usn_8[9] = (infoblock[3] & 0x00007F80) >> 7;
+    _usn_8[10] = (infoblock[3] & 0x007F8000) >> 15;
 
     /* If requested, verify and return the checksum */
     if (checksum != NULL) {
-        uint8_t check_csum[MXC_SYS_USN_CHECKSUM_LEN];
+        uint32_t _check_csum_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
+        // ^ Declare as uint32_t to preserve mem alignment        
+        uint8_t *check_csum = (uint8_t *)_check_csum_32;
+        memset(check_csum, 0, MXC_SYS_USN_CHECKSUM_LEN);
         uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)
 
         // Read Checksum from the infoblock
@@ -117,8 +123,8 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
         // Compute Checksum
         mxc_aes_req_t aes_req;
         aes_req.length = MXC_SYS_USN_CHECKSUM_LEN / 4;
-        aes_req.inputData = (uint32_t *)usn;
-        aes_req.resultData = (uint32_t *)check_csum;
+        aes_req.inputData = _usn_32;
+        aes_req.resultData = _check_csum_32;
         aes_req.keySize = MXC_AES_128BITS;
         aes_req.encryption = MXC_AES_ENCRYPT_EXT_KEY;
         aes_req.callback = NULL;
@@ -139,10 +145,13 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     }
 
     /* Add the info block checksum to the USN */
-    usn[11] = ((infoblock[3] & 0x7F800000) >> 23);
-    usn[12] = ((infoblock[4] & 0x007F8000) >> 15);
+    _usn_8[11] = ((infoblock[3] & 0x7F800000) >> 23);
+    _usn_8[12] = ((infoblock[4] & 0x007F8000) >> 15);
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
+
+    if (usn != NULL)
+        memcpy(usn, _usn_8, MXC_SYS_USN_LEN);
 
     return err;
 }

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
@@ -82,7 +82,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     uint32_t _usn_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
     // ^ Declare as uint32_t to preserve mem alignment
-    uint8_t *_usn_8 = (uint8_t *) _usn_32;
+    uint8_t *_usn_8 = (uint8_t *)_usn_32;
     memset(_usn_8, 0, MXC_SYS_USN_CHECKSUM_LEN);
 
     _usn_8[0] = (infoblock[0] & 0x007F8000) >> 15;
@@ -102,7 +102,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
     /* If requested, verify and return the checksum */
     if (checksum != NULL) {
         uint32_t _check_csum_32[MXC_SYS_USN_CHECKSUM_LEN / 4];
-        // ^ Declare as uint32_t to preserve mem alignment        
+        // ^ Declare as uint32_t to preserve mem alignment
         uint8_t *check_csum = (uint8_t *)_check_csum_32;
         memset(check_csum, 0, MXC_SYS_USN_CHECKSUM_LEN);
         uint8_t aes_key[MXC_SYS_USN_CHECKSUM_LEN] = { 0 }; // NULL Key (per checksum spec)

--- a/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_ai87.c
@@ -150,8 +150,7 @@ int MXC_SYS_GetUSN(uint8_t *usn, uint8_t *checksum)
 
     MXC_FLC_LockInfoBlock(MXC_INFO0_MEM_BASE);
 
-    if (usn != NULL)
-        memcpy(usn, _usn_8, MXC_SYS_USN_LEN);
+    memcpy(usn, _usn_8, MXC_SYS_USN_LEN);
 
     return err;
 }


### PR DESCRIPTION
## Pull Request Template

### Description

This PR fixes the `-Wcast-align` errors for the MAX78000 & MAX78002 USN calculations.  Our AES struct enforces 32-bit data alignment, so this solution uses an intermediate buffer and `memcpy`'s out to the user's buffers.

```shell
- CC /home/jakecarter/repos/fork/msdk/Libraries/CMSIS/../PeriphDrivers/Source/SYS/sys_ai85.c
/home/jakecarter/repos/fork/msdk/Libraries/CMSIS/../PeriphDrivers/Source/SYS/sys_ai85.c: In function 'MXC_SYS_GetUSN':
/home/jakecarter/repos/fork/msdk/Libraries/CMSIS/../PeriphDrivers/Source/SYS/sys_ai85.c:120:29: warning: cast increases required alignment of target type [-Wcast-align]
  120 |         aes_req.inputData = (uint32_t *)usn;
      |                             ^
/home/jakecarter/repos/fork/msdk/Libraries/CMSIS/../PeriphDrivers/Source/SYS/sys_ai85.c:121:30: warning: cast increases required alignment of target type [-Wcast-align]
  121 |         aes_req.resultData = (uint32_t *)check_csum;
      |                              ^
```

### Test Program

```Makefile
// project.mk
PROJ_CFLAGS += -Wcast-align -Werror
```

```C
// main.c
#include "mxc_sys.h"

int main(void) {
    uint8_t usn[MXC_SYS_USN_LEN];
    uint8_t checksum[MXC_SYS_USN_CSUM_FIELD_LEN];

    int err = MXC_SYS_GetUSN(usn, checksum);
    if (err)
        printf("USN error: %i\n", err);

    printf("USN: 0x");
    for (int i = 0; i < MXC_SYS_USN_LEN; i++) {
        printf("%x", usn[i]);
    }
    printf("\n");
    printf("Checksum: 0x%x\n", checksum[0] | (checksum[1] << 8));

   return 0;
}
```

- [x] MA78000 (PASS):
```serial
USN: 0xa184932241e4effdaee9bc
Checksum: 0xbce9
```

- [x] MAX78002 (PASS):
```serial
USN: 0xa186889024015501ce32f7
Checksum: 0xf732
```

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
