### PR TITLE
fix(Examples): Type overflow in ADC example

### DIFF
--- a/Examples/MAX32655/ADC/main.c
+++ b/Examples/MAX32655/ADC/main.c
@@ -54,7 +54,7 @@
 volatile unsigned int adc_done = 0;
 #endif
 
-static uint16_t adc_val;
+static int32_t adc_val;
 uint8_t overflow;
 
 /***** Functions *****/

--- a/Examples/MAX32680/ADC/main.c
+++ b/Examples/MAX32680/ADC/main.c
@@ -54,7 +54,7 @@
 volatile unsigned int adc_done = 0;
 #endif
 
-static uint16_t adc_val;
+static int32_t adc_val;
 uint8_t overflow;
 
 /***** Functions *****/


### PR DESCRIPTION
## Pull Request Template

### Description
In some driver versions, MXC_ADC_StartConversion directly returns the adc value. However, it may also returns an MXC error which can be negative. The data type of the adc value was unsigned. Therefore, the comparison is always false. This changes the type information such that the comparison can be made. 
