### PR TITLE
fix(Boards, Examples): Fix MAX32690 GPIO Example 

### DIFF
--- a/Examples/MAX32690/GPIO/main.c
+++ b/Examples/MAX32690/GPIO/main.c
@@ -67,7 +67,8 @@
 
 /***** Functions *****/
 
-void gpio_callback(void *cbdata) {
+void gpio_callback(void *cbdata)
+{
     mxc_gpio_cfg_t *cfg = cbdata;
     MXC_GPIO_OutToggle(cfg->port, cfg->mask);
 }

--- a/Examples/MAX32690/GPIO/main.c
+++ b/Examples/MAX32690/GPIO/main.c
@@ -66,14 +66,16 @@
 /***** Globals *****/
 
 /***** Functions *****/
-void gpio_isr(void *cbdata)
-{
-    MXC_Delay(MXC_DELAY_MSEC(100));
-    uint32_t flags = MXC_GPIO_GetFlags(MXC_GPIO_PORT_IN);
-    MXC_GPIO_ClearFlags(MXC_GPIO_PORT_IN, flags);
 
+void gpio_callback(void *cbdata) {
     mxc_gpio_cfg_t *cfg = cbdata;
     MXC_GPIO_OutToggle(cfg->port, cfg->mask);
+}
+
+void gpio_isr(void)
+{
+    MXC_Delay(MXC_DELAY_MSEC(100)); // Debounce
+    MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO_PORT_IN));
 }
 
 int main(void)
@@ -111,10 +113,11 @@ int main(void)
     gpio_interrupt.func = MXC_GPIO_FUNC_IN;
     gpio_interrupt.vssel = MXC_GPIO_VSSEL_VDDIOH;
     MXC_GPIO_Config(&gpio_interrupt);
-    MXC_GPIO_RegisterCallback(&gpio_interrupt, gpio_isr, &gpio_interrupt_status);
+    MXC_GPIO_RegisterCallback(&gpio_interrupt, gpio_callback, &gpio_interrupt_status);
     MXC_GPIO_IntConfig(&gpio_interrupt, MXC_GPIO_INT_FALLING);
     MXC_GPIO_EnableInt(gpio_interrupt.port, gpio_interrupt.mask);
     NVIC_EnableIRQ(MXC_GPIO_GET_IRQ(MXC_GPIO_GET_IDX(MXC_GPIO_PORT_IN)));
+    MXC_NVIC_SetVector(MXC_GPIO_GET_IRQ(MXC_GPIO_GET_IDX(MXC_GPIO_PORT_IN)), gpio_isr);
 
     /* Setup output pin. */
     gpio_out.port = MXC_GPIO_PORT_OUT;

--- a/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
@@ -107,7 +107,6 @@ __weak void GPIO2_IRQHandler(void)
     MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO2));
 }
 
-
 // Default handler for generic GPIO interrupts on port 4 (used by pushbutton)
 __weak void GPIO4_IRQHandler(void)
 {

--- a/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
@@ -107,12 +107,6 @@ __weak void GPIO2_IRQHandler(void)
     MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO2));
 }
 
-// Default handler for generic GPIO interrupts on port 4 (used by pushbutton)
-__weak void GPIO4_IRQHandler(void)
-{
-    MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO4));
-}
-
 /******************************************************************************/
 int Board_Init(void)
 {

--- a/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32690/EvKit_V1/Source/board.c
@@ -101,6 +101,19 @@ __weak void GPIOWAKE_IRQHandler(void)
     MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO4));
 }
 
+// Default handler for generic GPIO interrupts on port 2 (used by GPIO example)
+__weak void GPIO2_IRQHandler(void)
+{
+    MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO2));
+}
+
+
+// Default handler for generic GPIO interrupts on port 4 (used by pushbutton)
+__weak void GPIO4_IRQHandler(void)
+{
+    MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO4));
+}
+
 /******************************************************************************/
 int Board_Init(void)
 {


### PR DESCRIPTION
## Pull Request Template

### Description

Fixes #705 

This PR defines weak default handlers for the ports used by the pushbutton and GPIO example on the MAX32690 EVKIT.

The MAX32690 GPIO example has also been updated to be less reliant on these weak handlers, and to be less confusing in general.

### Test

GPIO Example now functions on the MAX32690EVKIT (LED1 blinks when PB0 is pressed).

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
