### PR TITLE
fix(CMSIS, PeriphDrivers): Fix "warning: _kill/_getpid is not implemented and will always fail" on GCC 12

### DIFF
--- a/Libraries/Boards/MAX32662/EvKit_V1/Include/board.h
+++ b/Libraries/Boards/MAX32662/EvKit_V1/Include/board.h
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifndef LIBRARIES_BOARDS_MAX32662_EVKIT_V1_INCLUDE_BOARD_H_
 #define LIBRARIES_BOARDS_MAX32662_EVKIT_V1_INCLUDE_BOARD_H_

--- a/Libraries/Boards/MAX32672/EvKit_V1/Include/board.h
+++ b/Libraries/Boards/MAX32672/EvKit_V1/Include/board.h
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifndef LIBRARIES_BOARDS_MAX32672_EVKIT_V1_INCLUDE_BOARD_H_
 #define LIBRARIES_BOARDS_MAX32672_EVKIT_V1_INCLUDE_BOARD_H_

--- a/Libraries/Boards/MAX32690/EvKit_V1/Include/board.h
+++ b/Libraries/Boards/MAX32690/EvKit_V1/Include/board.h
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifndef LIBRARIES_BOARDS_MAX32690_EVKIT_V1_INCLUDE_BOARD_H_
 #define LIBRARIES_BOARDS_MAX32690_EVKIT_V1_INCLUDE_BOARD_H_

--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
@@ -52,11 +52,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
@@ -47,6 +47,19 @@ extern void (*const __isr_vector[])(void);
 
 uint32_t SystemCoreClock = IPO_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
@@ -47,6 +47,19 @@ extern void (*const __isr_vector[])(void);
 
 uint32_t SystemCoreClock = ISO_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
@@ -52,11 +52,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
@@ -51,11 +51,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
@@ -46,6 +46,19 @@ extern void (*const __isr_vector[])(void);
 
 uint32_t SystemCoreClock = ISO_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_riscv_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_riscv_max32572.c
@@ -40,6 +40,19 @@
 volatile uint32_t mailbox __attribute__((section(".mailbox")));
 uint32_t SystemCoreClock __attribute__((section(".shared")));
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_riscv_max32572.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_riscv_max32572.c
@@ -45,11 +45,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
@@ -40,6 +40,8 @@
 #include "usbhs_regs.h"
 #include "flc_regs.h"
 #include "icc_regs.h"
+#include "mxc_sys.h"
+#include "mxc_errors.h"
 
 extern void (*const __isr_vector[])(void);
 uint32_t SystemCoreClock = 0;

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
@@ -45,6 +45,19 @@ extern void (*const __isr_vector[])(void);
 uint32_t SystemCoreClock = 0;
 uint8_t ChipRevision = 0;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
@@ -52,11 +52,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
@@ -40,7 +40,6 @@
 #include "usbhs_regs.h"
 #include "flc_regs.h"
 #include "icc_regs.h"
-#include "mxc_sys.h"
 #include "mxc_errors.h"
 
 extern void (*const __isr_vector[])(void);

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
@@ -50,11 +50,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
@@ -45,6 +45,19 @@ extern void (*const __isr_vector[])(void);
 
 uint32_t SystemCoreClock = HIRC_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
@@ -51,11 +51,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
@@ -37,6 +37,7 @@
 #include "max32655.h"
 #include "gcr_regs.h"
 #include "icc.h"
+#include "mxc_sys.h"
 
 #define MXC_NBBFC_REG4 *((volatile uint32_t *)(0x40000810))
 
@@ -44,6 +45,19 @@ uint32_t SystemCoreClock = HIRC_FREQ;
 static volatile int intContext;
 
 extern uint32_t *__isr_vector;
+
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
 
 void illegal_ISNHandler(void);
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
@@ -54,11 +54,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
@@ -49,6 +49,19 @@
 extern void (*const __isr_vector[])(void);
 uint32_t SystemCoreClock = HIRC96_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src, ovr;

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
@@ -47,6 +47,19 @@ extern void (*const __isr_vector[])(void);
 uint32_t SystemCoreClock __attribute__((section(".shared")));
 volatile uint32_t mailbox __attribute__((section(".mailbox")));
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
@@ -52,11 +52,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
@@ -56,11 +56,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
@@ -51,6 +51,19 @@ extern void (*const __isr_vector[])(void);
 // Part defaults to HIRC/2 out of reset
 uint32_t SystemCoreClock = HIRC_FREQ >> 1;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
@@ -50,11 +50,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
@@ -45,6 +45,19 @@ extern void (*const __isr_vector[])(void);
 
 uint32_t SystemCoreClock = HIRC_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
@@ -42,6 +42,19 @@ extern void (*const __isr_vector[])(void);
 
 uint32_t SystemCoreClock = HIRC_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
@@ -47,11 +47,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
@@ -49,11 +49,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
@@ -44,6 +44,19 @@ extern void (*const __isr_vector[])(void);
 
 uint32_t SystemCoreClock = HIRC_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
@@ -49,11 +49,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
@@ -44,6 +44,19 @@ extern void (*const __isr_vector[])(void);
 
 uint32_t SystemCoreClock = HIRC_FREQ;
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_riscv_max32680.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_riscv_max32680.c
@@ -51,11 +51,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_riscv_max32680.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_riscv_max32680.c
@@ -37,6 +37,7 @@
 #include "max32680.h"
 #include "gcr_regs.h"
 #include "icc.h"
+#include "mxc_sys.h"
 
 #define MXC_NBBFC_REG4 *((volatile uint32_t *)(0x40000810))
 
@@ -44,6 +45,19 @@ uint32_t SystemCoreClock = HIRC_FREQ;
 static volatile int intContext;
 
 extern uint32_t *__isr_vector;
+
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
 
 void illegal_ISNHandler(void);
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
@@ -44,6 +44,19 @@ extern void (*const __isr_vector[])(void);
 uint32_t SystemCoreClock;
 volatile uint32_t mailbox __attribute__((section(".mailbox")));
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
@@ -49,11 +49,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_riscv_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_riscv_max32690.c
@@ -37,8 +37,22 @@
 #include "max32690.h"
 #include "gcr_regs.h"
 #include "icc.h"
+#include "mxc_sys.h"
 
 uint32_t SystemCoreClock;
+
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
 
 __weak void SystemCoreClockUpdate(void)
 {

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_riscv_max32690.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_riscv_max32690.c
@@ -46,11 +46,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
@@ -44,6 +44,19 @@ extern void (*const __isr_vector[])(void);
 uint32_t SystemCoreClock __attribute__((section(".shared")));
 volatile uint32_t mailbox __attribute__((section(".mailbox")));
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
@@ -49,11 +49,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_riscv_max78000.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_riscv_max78000.c
@@ -46,11 +46,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_riscv_max78000.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_riscv_max78000.c
@@ -36,9 +36,23 @@
 #include <stdlib.h>
 #include "max78000.h"
 #include "gcr_regs.h"
+#include "mxc_sys.h"
 
 volatile uint32_t mailbox __attribute__((section(".mailbox")));
 uint32_t SystemCoreClock __attribute__((section(".shared")));
+
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
 
 void __enable_irq(void)
 {

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
@@ -48,11 +48,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
@@ -43,6 +43,19 @@ extern void (*const __isr_vector[])(void);
 uint32_t SystemCoreClock __attribute__((section(".shared")));
 volatile uint32_t mailbox __attribute__((section(".mailbox")));
 
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
+
 __weak void SystemCoreClockUpdate(void)
 {
     uint32_t base_freq, div, clk_src;

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_riscv_max78002.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_riscv_max78002.c
@@ -46,11 +46,13 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void) {
+int _getpid(void)
+{
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void) {
+int _kill(void)
+{
     return E_NOT_SUPPORTED;
 }
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_riscv_max78002.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_riscv_max78002.c
@@ -36,9 +36,23 @@
 #include <stdlib.h>
 #include "max78002.h"
 #include "gcr_regs.h"
+#include "mxc_sys.h"
 
 volatile uint32_t mailbox __attribute__((section(".mailbox")));
 uint32_t SystemCoreClock __attribute__((section(".shared")));
+
+/*
+The libc implementation from GCC 11+ depends on _getpid and _kill in some places.
+There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
+we implement stub functions that return an error code to resolve linker warnings.
+*/
+int _getpid(void) {
+    return E_NOT_SUPPORTED;
+}
+
+int _kill(void) {
+    return E_NOT_SUPPORTED;
+}
 
 void __enable_irq(void)
 {


### PR DESCRIPTION
### Description

The newlib implementation from GCC 12 depends on `_getpid` and `_kill` in some places.  Attempting to link any project using GCC 12 throws the following warnings.

```shell
/home/jakecarter/MaximSDK/Tools/GNUTools/12.3/bin/../lib/gcc/arm-none-eabi/12.3.1/../../../../arm-none-eabi/bin/ld: /home/jakecarter/MaximSDK/Tools/GNUTools/12.3/bin/../lib/gcc/arm-none-eabi/12.3.1/../../../../arm-none-eabi/lib/thumb/v7e-m+fp/softfp/libc.a(libc_a-signalr.o): in function `_getpid_r':
signalr.c:(.text._getpid_r+0x0): warning: _getpid is not implemented and will always fail
/home/jakecarter/MaximSDK/Tools/GNUTools/12.3/bin/../lib/gcc/arm-none-eabi/12.3.1/../../../../arm-none-eabi/bin/ld: /home/jakecarter/MaximSDK/Tools/GNUTools/12.3/bin/../lib/gcc/arm-none-eabi/12.3.1/../../../../arm-none-eabi/lib/thumb/v7e-m+fp/softfp/libc.a(libc_a-signalr.o): in function `_kill_r':
signalr.c:(.text._kill_r+0x12): warning: _kill is not implemented and will always fail
```

This PR adds stub implementations of the missing functions to our system files for each micro.

The `c_nano` and `nosys` libraries seem not depend on these functions, so these are safe to add (No conflicts will occur - tested on GCC 12.3).

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
