### PR TITLE
fix(workflow): Add token secret to clang-format-run workflow to retrigger other actions upon successful completion

### DIFF
--- a/.github/workflows/clang-format-run-pr.yml
+++ b/.github/workflows/clang-format-run-pr.yml
@@ -56,6 +56,7 @@ jobs:
         repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
         ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
         fetch-depth: 0
+        token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: clang-format-run
       run: |

--- a/.github/workflows/clang-format-run-pr.yml
+++ b/.github/workflows/clang-format-run-pr.yml
@@ -56,7 +56,7 @@ jobs:
         repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
         ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
         fetch-depth: 0
-        token: ${{ secrets.WORKFLOW_TOKEN }}
+        token: ${{ secrets.GITHUB_CI_TOKEN }}
 
     - name: clang-format-run
       run: |


### PR DESCRIPTION
### Description

The other actions don't re-trigger whenever the clang-format-run workflow successfully commits the newly formatted files. That's because the repo is checked out using the built-in, default `GITHUB_TOKEN` secret. GitHub sees the bot push event as something generated by the CI instead of by an actual user, and GitHub has set up checks where any event by the CI does not re-trigger any of the other actions to avoid unintentional check loops.

The fix, **hopefully**, is to set up a personal access token secret, within the scope of the repo, with permissions to re-trigger all the checks whenever the clang-format-run workflow successfully commits the formatted files. Also due to the fact the workflow is PR-comment triggered, there are no worries about any unintentional check loops caused by this particular workflow. These changes aren't testable until it's merged into main, but it should not break anything if the token fails.

The Generate_Register_Files workflow does not have this issue because that action runs on the BTM-CI machine and not GitHub's `ubuntu-latest` servers. The BTM-CI is already configured with its own PAT.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.