### PR TITLE
fix(BLE): Fix PalFlashEraseSector, Decrement Erase by Sector Size

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_flash.c
@@ -184,7 +184,7 @@ void PalFlashWrite(void *pBuf, uint32_t size, uint32_t dstAddr)
 /*!
  *  \brief  Erase sector.
  *
- *  \param[in] size       Data size in bytes to be erased.
+ *  \param[in] size       Data size in sectors to be erased.
  *  \param[in] startAddr  Word aligned address.
  *
  *  \return None.
@@ -202,7 +202,7 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
   while(size) {
     MXC_FLC_PageErase(startAddr);
     startAddr += MXC_FLASH_PAGE_SIZE;
-    size -= MXC_FLASH_PAGE_SIZE;
+    size --;
   }
 }
 


### PR DESCRIPTION
### Description

The PalFlashEraseSector function comments and behavior are that of a `byte` erase function which is incorrect. The function is called assuming size is in terms of `sectors`  which it should be. In the function below `PalFlashEraseSector` is passed a value of `1` to erase one sector at a time, `PalFlashEraseSector` then decrements `1 -MXC_FLASH_PAGE_SIZE` and causes size to  underflow and the number becomes really big since it is unsigned and the function erases lots of sectors causing application to crash and be unrecoverable. 
``` 
void WsfNvmEraseDataAll(WsfNvmCompEvent_t compCback)
{
  for (uint32_t eraseAddr = WSF_NVM_START_ADDR; eraseAddr < wsfNvmCb.availAddr; eraseAddr += wsfNvmCb.sectorSize) {
    PalFlashEraseSector(1, eraseAddr);
  }
  wsfNvmCb.availAddr = WSF_NVM_START_ADDR;

  if (compCback) {
    compCback(TRUE);
  }
}
```
### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
