### PR TITLE
fix(SDHC): Fix SDHC Get Capacity and Implement Get Sectors functionality 

### DIFF
--- a/Libraries/SDHC/Include/sdhc_lib.h
+++ b/Libraries/SDHC/Include/sdhc_lib.h
@@ -91,7 +91,7 @@ int MXC_SDHC_Lib_SetRCA(void);
 int MXC_SDHC_Lib_GetCSD(mxc_sdhc_csd_regs_t *csd);
 
 /* ************************************************************************** */
-unsigned int MXC_SDHC_Lib_GetCapacity(mxc_sdhc_csd_regs_t* csd);
+unsigned long long MXC_SDHC_Lib_GetCapacity(mxc_sdhc_csd_regs_t* csd);
 
 /* ************************************************************************** */
 unsigned int MXC_SDHC_Lib_GetSectors(mxc_sdhc_csd_regs_t* csd);

--- a/Libraries/SDHC/Source/sdhc_lib.c
+++ b/Libraries/SDHC/Source/sdhc_lib.c
@@ -163,7 +163,7 @@ unsigned long long MXC_SDHC_Lib_GetCapacity(mxc_sdhc_csd_regs_t* csd)
 {
     unsigned int size = csd->csd.c_size;
 
-    return ((unsigned long long)size)*((unsigned long long)512*1024);
+    return ((unsigned long long)(size+1))*((unsigned long long)512*1024);
 }
 
 /* ************************************************************************** */

--- a/Libraries/SDHC/Source/sdhc_lib.c
+++ b/Libraries/SDHC/Source/sdhc_lib.c
@@ -159,11 +159,17 @@ int MXC_SDHC_Lib_GetCSD(mxc_sdhc_csd_regs_t *csd)
 }
 
 /* ************************************************************************** */
-unsigned int MXC_SDHC_Lib_GetCapacity(mxc_sdhc_csd_regs_t* csd)
+unsigned long long MXC_SDHC_Lib_GetCapacity(mxc_sdhc_csd_regs_t* csd)
 {
     unsigned int size = csd->csd.c_size;
 
-    return (size*(512*1024));
+    return ((unsigned long long)size)*((unsigned long long)512*1024);
+}
+
+/* ************************************************************************** */
+unsigned int MXC_SDHC_Lib_GetSectors(mxc_sdhc_csd_regs_t* csd)
+{
+    return csd->csd.c_size;
 }
 
 /* ************************************************************************** */


### PR DESCRIPTION
### Description

`unsigned int MXC_SDHC_Lib_GetCapacity(mxc_sdhc_csd_regs_t* csd)` function returns wrong value.
If 32 GB card is inserted to the SD card slot, `MXC_SDHC_Lib_GetCapacity` function can return at most *UINT32_MAX* as a result.
Therefore, the function prototype is changed to `unsigned long long MXC_SDHC_Lib_GetCapacity(mxc_sdhc_csd_regs_t* csd)` to get the correct result.

`unsigned int MXC_SDHC_Lib_GetSectors(mxc_sdhc_csd_regs_t* csd, int i)` function is implemented in *sdhc_lib.c* file.


### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
