### PR TITLE
fix(Examples): Fix 'this device cannot start COM port' error in MAX32665 USB_CDCACM example

### DIFF
--- a/Examples/MAX32665/USB_CDCACM/main.c
+++ b/Examples/MAX32665/USB_CDCACM/main.c
@@ -84,7 +84,7 @@ static void echoUSB(void);
 /***** File Scope Variables *****/
 
 /* This EP assignment must match the Configuration Descriptor */
-static const acm_cfg_t acm_cfg = {
+static acm_cfg_t acm_cfg = {
     1, /* EP OUT */
     MXC_USBHS_MAX_PACKET, /* OUT max packet size */
     2, /* EP IN */
@@ -279,6 +279,14 @@ static int setconfigCallback(MXC_USB_SetupPkt *sud, void *cbdata)
     if (sud->wValue == config_descriptor.config_descriptor.bConfigurationValue) {
         configured = 1;
         MXC_SETBIT(&event_flags, EVENT_ENUM_COMP);
+
+        acm_cfg.out_ep = config_descriptor.endpoint_descriptor_1.bEndpointAddress & 0x7;
+        acm_cfg.out_maxpacket = config_descriptor.endpoint_descriptor_1.wMaxPacketSize;
+        acm_cfg.in_ep = config_descriptor.endpoint_descriptor_2.bEndpointAddress & 0x7;
+        acm_cfg.in_maxpacket = config_descriptor.endpoint_descriptor_2.wMaxPacketSize;
+        acm_cfg.notify_ep = config_descriptor.endpoint_descriptor_3.bEndpointAddress & 0x7;
+        acm_cfg.notify_maxpacket = config_descriptor.endpoint_descriptor_3.wMaxPacketSize;
+
         return acm_configure(&acm_cfg); /* Configure the device class */
     } else if (sud->wValue == 0) {
         configured = 0;


### PR DESCRIPTION
### Description

COM20; i.e USB serial device, was showing "_**This device cannot start.(Code 10)**_" error. Therefore, it was not operating successfully.

Applying the below changes made the example work properly.
* `acm_cfg.out_maxpacket = config_descriptor.endpoint_descriptor_1.wMaxPacketSize = 64`
* `acm_cfg.in_maxpacket = config_descriptor.endpoint_descriptor_2.wMaxPacketSize = 64`
* `acm_cfg.notify_maxpacket = config_descriptor.endpoint_descriptor_3.wMaxPacketSize = 64`

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
