### PR TITLE
feat(PeriphDrivers): MSDK 1238: Add a way to remove clk and gpio initialization at compile time

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/dma.h
@@ -181,6 +181,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32520/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/tmr.h
@@ -117,6 +117,11 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief      Initialize timer module clock.
+ * @note       On default this function enables TMR peripheral clock and related GPIOs.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
+ *  
  * @param      tmr        Pointer to timer module to initialize.
  * @param      cfg        configuration object
  */

--- a/Libraries/PeriphDrivers/Include/MAX32520/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/wdt.h
@@ -82,7 +82,13 @@ typedef enum {
 
 /**
  * @brief       Initialize the Watchdog Timer
- * @param       wdt      Pointer to the watchdog registers
+ * @note        On default this function enables WDT peripheral clock.
+ *              if you wish to manage clock and gpio related things in upper level instead of here.
+ *              Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *              By this flag this function will remove clock and gpio related codes from file.
+ * 
+ * @param       wdt      Pointer to the watchdog registers, has no effect incase of
+ *                       MSDK_NO_GPIO_CLK_INIT has been defined.
  * @return      See \ref MXC_Error_Codes for the list of error codes. 
  */
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt);

--- a/Libraries/PeriphDrivers/Include/MAX32570/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/dma.h
@@ -236,6 +236,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32570/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/tmr.h
@@ -118,6 +118,11 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief      Initialize timer module clock.
+ * @note       On default this function enables TMR peripheral clock and related GPIOs.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param      tmr        Pointer to timer module to initialize.
  * @param      cfg        configuration object
  */

--- a/Libraries/PeriphDrivers/Include/MAX32570/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/wdt.h
@@ -82,7 +82,13 @@ typedef enum {
 
 /**
  * @brief       Initialize the Watchdog Timer
- * @param       wdt      Pointer to the watchdog registers
+ * @note        On default this function enables WDT peripheral clock.
+ *              if you wish to manage clock and gpio related things in upper level instead of here.
+ *              Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *              By this flag this function will remove clock and gpio related codes from file.
+ * 
+ * @param       wdt      Pointer to the watchdog registers, has no effect incase of
+ *                       MSDK_NO_GPIO_CLK_INIT has been defined.
  * @return      See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt);

--- a/Libraries/PeriphDrivers/Include/MAX32572/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/dma.h
@@ -244,6 +244,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32572/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/tmr.h
@@ -122,6 +122,11 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief      Initialize timer module clock.
+ * @note       On default this function enables TMR peripheral clock and related GPIOs.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
+ *  
  * @param      tmr        Pointer to timer module to initialize.
  * @param      cfg        configuration object
  */

--- a/Libraries/PeriphDrivers/Include/MAX32572/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/wdt.h
@@ -82,7 +82,13 @@ typedef enum {
 
 /**
  * @brief       Initialize the Watchdog Timer
- * @param       wdt      Pointer to the watchdog registers
+ * @note        On default this function enables WDT peripheral clock.
+ *              if you wish to manage clock and gpio related things in upper level instead of here.
+ *              Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *              By this flag this function will remove clock and gpio related codes from file.
+ * 
+ * @param       wdt      Pointer to the watchdog registers, has no effect incase of
+ *                       MSDK_NO_GPIO_CLK_INIT has been defined.
  * @return      See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt);

--- a/Libraries/PeriphDrivers/Include/MAX32650/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/dma.h
@@ -245,6 +245,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32650/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/tmr.h
@@ -121,6 +121,11 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief      Initialize timer module clock.
+ * @note       On default this function enables TMR peripheral clock and related GPIOs.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param      tmr        Pointer to timer module to initialize.
  * @param      cfg        configuration object
  */

--- a/Libraries/PeriphDrivers/Include/MAX32650/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/wdt.h
@@ -82,8 +82,14 @@ typedef enum {
 
 /**
  * @brief Initialize the Watchdog Timer
- * @param      wdt      Pointer to the watchdog registers
- * @param      sys_cfg  The system configuration object
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ * 
+ * @param      wdt      Pointer to the watchdog registers, has no effect incase of
+ *                      MSDK_NO_GPIO_CLK_INIT has been defined.
+ * @return     See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt);
 

--- a/Libraries/PeriphDrivers/Include/MAX32655/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/dma.h
@@ -203,6 +203,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32655/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/i2c.h
@@ -184,6 +184,10 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
  * @brief   Initialize and enable I2C peripheral.
  * @note    This function sets the I2C Speed to 100kHz,  if another speed is
  *          desired use the MXC_I2C_SetFrequency() function to set it.
+ * @note    On default this function enables I2C peripheral clock and i2c gpio pins.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32655/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/spi.h
@@ -174,6 +174,11 @@ struct _mxc_spi_req_t {
  * SPI Width - SPI_WIDTH_STANDARD (even if quadModeUsed is set)
  *
  * These parameters can be modified after initialization using low level functions
+ * 
+ * @note    On default this function enables SPI peripheral clock and spi gpio pins.
+ * if you wish to manage clock and gpio related things in upper level instead of here.
+ * Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ * By this flag this function will remove clock and gpio related codes from file.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   masterMode      Whether to put the device in master or slave mode. Use
@@ -191,7 +196,8 @@ struct _mxc_spi_req_t {
  *                          will be returned by the function if successful. Used in
  *                          master mode only.
  * @param   pins            SPI pin structure. Pins selected as true will be initialized 
- *                          for the requested SPI block.
+ *                          for the requested SPI block. Has no effect incase of 
+ *                          MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  If successful, the actual clock frequency is returned. Otherwise, see
  *          \ref MXC_Error_Codes for a list of return codes.

--- a/Libraries/PeriphDrivers/Include/MAX32655/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/tmr.h
@@ -145,10 +145,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   init_pins  True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not
- *                     be used 
+ *                     be used, has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32655/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/uart.h
@@ -157,6 +157,11 @@ struct _mxc_uart_req_t {
  * 
  * These parameters can be modified after initialization using low level functions
  * 
+ * @note    On default this function enables UART peripheral clock.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   uart         Pointer to UART registers (selects the UART block used.)
  * @param   baud         The requested clock frequency. The actual clock frequency
  *                       will be returned by the function if successful.

--- a/Libraries/PeriphDrivers/Include/MAX32655/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/wdt.h
@@ -116,6 +116,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes.

--- a/Libraries/PeriphDrivers/Include/MAX32660/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/dma.h
@@ -185,6 +185,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32660/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/tmr.h
@@ -132,6 +132,11 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * 

--- a/Libraries/PeriphDrivers/Include/MAX32662/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/dma.h
@@ -193,6 +193,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32662/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/tmr.h
@@ -147,11 +147,17 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   init_pins  True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not
- *                     be used
- * @param   pin_sel    Selects which set of pins to initialize (if init_pins set to true) for the given timer instance  
+ *                     be used,  has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined.
+ * @param   pin_sel    Selects which set of pins to initialize (if init_pins set to true) for the given timer instance,
+ *                     has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  * 
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32662/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/wdt.h
@@ -116,6 +116,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes.

--- a/Libraries/PeriphDrivers/Include/MAX32665/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/dma.h
@@ -248,6 +248,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
  * @brief      Initialize DMA resources
  * @param 	   dma 	Pointer to DMA registers.
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(mxc_dma_regs_t *dma);

--- a/Libraries/PeriphDrivers/Include/MAX32665/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/i2c.h
@@ -185,6 +185,10 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
  * @brief   Initialize and enable I2C peripheral.
  * @note    This function sets the I2C Speed to 100kHz,  if another speed is
  *          desired use the MXC_I2C_SetFrequency() function to set it.
+ * @note    On default this function enables I2C peripheral clock and i2c gpio pins.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32665/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/spi.h
@@ -153,6 +153,11 @@ struct _mxc_spi_req_t {
  * SPI Width - SPI_WIDTH_STANDARD (even if quadModeUsed is set)
  *
  * These parameters can be modified after initialization using low level functions
+ * 
+ * @note    On default this function enables SPI peripheral clock and spi gpio pins.
+ * if you wish to manage clock and gpio related things in upper level instead of here.
+ * Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ * By this flag this function will remove clock and gpio related codes from file.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   masterMode      Whether to put the device in master or slave mode. Use
@@ -169,7 +174,8 @@ struct _mxc_spi_req_t {
  * @param   hz              The requested clock frequency. The actual clock frequency
  *                          will be returned by the function if successful. Used in
  *                          master mode only.
- * @param   map      		Mapping (MAP_A or MAP_B) to use for SPIO
+ * @param   map      		Mapping (MAP_A or MAP_B) to use for SPIO, Has no effect 
+ *                          incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  If successful, the actual clock frequency is returned. Otherwise, see
  *          \ref MXC_Error_Codes for a list of return codes.

--- a/Libraries/PeriphDrivers/Include/MAX32665/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/tmr.h
@@ -117,6 +117,11 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief      Initialize timer module clock.
+ * @note       On default this function enables TMR peripheral clock and related GPIOs.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param      tmr        Pointer to timer module to initialize.
  * @param      cfg        configuration object
  */

--- a/Libraries/PeriphDrivers/Include/MAX32665/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/uart.h
@@ -157,11 +157,17 @@ struct _mxc_uart_req_t {
  * UART Clock        - 7.37MHz Clock (for baud > 7372800, PCLK is used)
  *
  * These parameters can be modified after initialization using low level functions
+ * 
+ * @note    On default this function enables UART peripheral clock.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
  *
  * @param   uart            Pointer to UART registers (selects the UART block used.)
  * @param   baud            The requested clock frequency. The actual clock frequency
  *                          will be returned by the function if successful.
- * @param   map            	MAP_A or MAP_B uart pins select
+ * @param   map            	MAP_A or MAP_B uart pins select, Has no effect incase of 
+ *                          MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  If successful, the actual clock frequency is returned. Otherwise, see
  *          \ref MXC_Error_Codes for a list of return codes.

--- a/Libraries/PeriphDrivers/Include/MAX32665/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/wdt.h
@@ -82,7 +82,13 @@ typedef enum {
 
 /**
  * @brief       Initialize the Watchdog Timer
- * @param       wdt      Pointer to the watchdog registers
+ * @note        On default this function enables WDT peripheral clock.
+ *              if you wish to manage clock and gpio related things in upper level instead of here.
+ *              Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *              By this flag this function will remove clock and gpio related codes from file.
+ * 
+ * @param       wdt      Pointer to the watchdog registers, has no effect incase of
+ *                       MSDK_NO_GPIO_CLK_INIT has been defiend.
  * @return      See \ref MXC_Error_Codes for the list of error codes.
  */
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt);

--- a/Libraries/PeriphDrivers/Include/MAX32670/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/dma.h
@@ -203,6 +203,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32670/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/i2c.h
@@ -184,6 +184,10 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
  * @brief   Initialize and enable I2C peripheral.
  * @note    This function sets the I2C Speed to 100kHz,  if another speed is
  *          desired use the MXC_I2C_SetFrequency() function to set it.
+ * @note    On default this function enables I2C peripheral clock and i2c gpio pins.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32670/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/spi.h
@@ -153,6 +153,11 @@ struct _mxc_spi_req_t {
  * SPI Width - SPI_WIDTH_STANDARD (even if quadModeUsed is set)
  *
  * These parameters can be modified after initialization using low level functions
+ * 
+ * @note    On default this function enables SPI peripheral clock and spi gpio pins.
+ * if you wish to manage clock and gpio related things in upper level instead of here.
+ * Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ * By this flag this function will remove clock and gpio related codes from file.
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   masterMode      Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32670/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/tmr.h
@@ -145,10 +145,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   init_pins  True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not
- *                     be used 
+ *                     be used, has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32670/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/uart.h
@@ -159,6 +159,11 @@ struct _mxc_uart_req_t {
  * 
  * These parameters can be modified after initialization using low level functions
  * 
+ * @note    On default this function enables UART peripheral clock.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   uart         Pointer to UART registers (selects the UART block used.)
  * @param   baud         The requested clock frequency. The actual clock frequency
  *                       will be returned by the function if successful.

--- a/Libraries/PeriphDrivers/Include/MAX32670/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/wdt.h
@@ -116,6 +116,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes.

--- a/Libraries/PeriphDrivers/Include/MAX32672/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/dma.h
@@ -203,6 +203,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32672/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/tmr.h
@@ -145,10 +145,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   bool       True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not
- *                     be used 
+ *                     be used, has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined. 
  *
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32672/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/wdt.h
@@ -116,6 +116,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file. 
+ * 
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes.

--- a/Libraries/PeriphDrivers/Include/MAX32675/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/dma.h
@@ -203,6 +203,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32675/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/tmr.h
@@ -145,10 +145,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   init_pins  True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not
- *                     be used 
+ *                     be used, has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined. 
  *
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32675/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/wdt.h
@@ -120,6 +120,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes.

--- a/Libraries/PeriphDrivers/Include/MAX32680/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/dma.h
@@ -203,6 +203,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32680/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/tmr.h
@@ -146,6 +146,11 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   init_pins  True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not

--- a/Libraries/PeriphDrivers/Include/MAX32680/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/wdt.h
@@ -116,6 +116,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes.

--- a/Libraries/PeriphDrivers/Include/MAX32690/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/dma.h
@@ -209,6 +209,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX32690/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/i2c.h
@@ -184,6 +184,10 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
  * @brief   Initialize and enable I2C peripheral.
  * @note    This function sets the I2C Speed to 100kHz,  if another speed is
  *          desired use the MXC_I2C_SetFrequency() function to set it.
+ * @note    On default this function enables I2C peripheral clock and i2c gpio pins.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32690/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/spi.h
@@ -168,6 +168,11 @@ struct _mxc_spi_req_t {
  * SPI Width - SPI_WIDTH_STANDARD (even if quadModeUsed is set)
  *
  * These parameters can be modified after initialization using low level functions
+ * 
+ * @note    On default this function enables SPI peripheral clock and spi gpio pins.
+ * if you wish to manage clock and gpio related things in upper level instead of here.
+ * Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ * By this flag this function will remove clock and gpio related codes from file
  *
  * @param   spi             Pointer to SPI registers (selects the SPI block used.)
  * @param   masterMode      Whether to put the device in master or slave mode. Use
@@ -185,7 +190,8 @@ struct _mxc_spi_req_t {
  *                          will be returned by the function if successful. Used in
  *                          master mode only.
  * @param   pins            SPI pin structure. Pins selected as true will be initialized 
- *                          for the requested SPI block.
+ *                          for the requested SPI block. Has no effect incase of 
+ *                          MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  If successful, the actual clock frequency is returned. Otherwise, see
  *          \ref MXC_Error_Codes for a list of return codes.

--- a/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/tmr.h
@@ -147,10 +147,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   bool       True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not
- *                     be used
+ *                     be used, has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  * 
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX32690/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/uart.h
@@ -159,6 +159,11 @@ struct _mxc_uart_req_t {
  * 
  * These parameters can be modified after initialization using low level functions
  * 
+ * @note    On default this function enables UART peripheral clock.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   uart         Pointer to UART registers (selects the UART block used.)
  * @param   baud         The requested clock frequency. The actual clock frequency
  *                       will be returned by the function if successful.

--- a/Libraries/PeriphDrivers/Include/MAX32690/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wdt.h
@@ -116,6 +116,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes.

--- a/Libraries/PeriphDrivers/Include/MAX78000/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/dma.h
@@ -203,6 +203,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX78000/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/tmr.h
@@ -147,10 +147,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   init_pins  True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not
- *                     be used
+ *                     be used, has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  * 
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX78000/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/wdt.h
@@ -116,6 +116,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ *  
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes. 

--- a/Libraries/PeriphDrivers/Include/MAX78002/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/dma.h
@@ -201,6 +201,10 @@ typedef mxc_dma_srcdst_t (*mxc_dma_trans_chain_t)(mxc_dma_srcdst_t dest);
 /**
  * @brief      Initialize DMA resources
  * @details    This initialization is required before using the DMA driver functions.
+ * @note       On default this function enables DMA peripheral clock.
+ *             if you wish to manage clock and gpio related things in upper level instead of here.
+ *             Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *             By this flag this function will remove clock and gpio related codes from file.
  * @return     #E_NO_ERROR if successful
  */
 int MXC_DMA_Init(void);

--- a/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/tmr.h
@@ -146,10 +146,15 @@ typedef void (*mxc_tmr_complete_t)(int error);
 
 /**
  * @brief   Initialize timer module clock.
+ * @note    On default this function enables TMR peripheral clock and related GPIOs.
+ *          if you wish to manage clock and gpio related things in upper level instead of here.
+ *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *          By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param   tmr        Pointer to timer module to initialize.
  * @param   cfg        System configuration object
  * @param   init_pins  True will initialize pins corresponding to the TMR and False will not if pins are pinned out otherwise it will not
- *                     be used
+ *                     be used, has no effect incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  * 
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
  */

--- a/Libraries/PeriphDrivers/Include/MAX78002/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/wdt.h
@@ -116,6 +116,11 @@ typedef struct {
 
 /**
  * @brief Initialize the Watchdog Timer
+ * @note  On default this function enables WDT peripheral clock.
+ *        if you wish to manage clock and gpio related things in upper level instead of here.
+ *        Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 
+ *        By this flag this function will remove clock and gpio related codes from file.
+ * 
  * @param       wdt     Pointer to the watchdog registers
  * @param       cfg     watchdog configuration
  * @return      See \ref MXC_Error_Codes for the list of error codes. 

--- a/Libraries/PeriphDrivers/Source/DMA/dma_ai87.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_ai87.c
@@ -49,10 +49,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_es17.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_es17.c
@@ -45,10 +45,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me10.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me10.c
@@ -43,10 +43,12 @@
 /* ************************************************************************* */
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me11.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me11.c
@@ -51,10 +51,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me12.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me12.c
@@ -49,10 +49,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me13.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me13.c
@@ -45,10 +45,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me14.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me14.c
@@ -62,6 +62,7 @@ static mxc_dma_regs_t *getDMAInstance(int ch)
 
 int MXC_DMA_Init(mxc_dma_regs_t *dma)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     switch (MXC_DMA_GET_IDX(dma)) {
     case 0:
         if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
@@ -78,6 +79,7 @@ int MXC_DMA_Init(mxc_dma_regs_t *dma)
     default:
         return E_BAD_PARAM;
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)dma);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me15.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me15.c
@@ -45,10 +45,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me16.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me16.c
@@ -45,10 +45,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init();
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me17.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me17.c
@@ -49,10 +49,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me18.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me18.c
@@ -49,10 +49,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me21.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me21.c
@@ -45,10 +45,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/DMA/dma_me55.c
+++ b/Libraries/PeriphDrivers/Source/DMA/dma_me55.c
@@ -45,10 +45,12 @@
 
 int MXC_DMA_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (!MXC_SYS_IsClockEnabled(MXC_SYS_PERIPH_CLOCK_DMA)) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_DMA);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_DMA);
     }
+#endif
 
     return MXC_DMA_RevA_Init((mxc_dma_reva_regs_t *)MXC_DMA);
 }

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me14.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me14.c
@@ -60,6 +60,7 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_I2C_Shutdown(i2c); // Clear everything out
 
     if ((i2c == MXC_I2C0_BUS0) || (i2c == MXC_I2C0_BUS1)) {
@@ -74,6 +75,7 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
     } else {
         return E_NO_DEVICE;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_I2C_RevA_Init((mxc_i2c_reva_regs_t *)i2c, masterMode, slaveAddr);
 }

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me15.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me15.c
@@ -62,6 +62,7 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_I2C_Shutdown(i2c); // Clear everything out
 
     if (i2c == MXC_I2C0) {
@@ -78,6 +79,7 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
     } else {
         return E_NO_DEVICE;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_I2C_RevA_Init((mxc_i2c_reva_regs_t *)i2c, masterMode, slaveAddr);
 }

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me17.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me17.c
@@ -58,6 +58,7 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_I2C_Shutdown(i2c); // Clear everything out
 
     if (i2c == MXC_I2C0) {
@@ -72,6 +73,7 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
     } else {
         return E_NO_DEVICE;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_I2C_RevA_Init((mxc_i2c_reva_regs_t *)i2c, masterMode, slaveAddr);
 }

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_me18.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_me18.c
@@ -58,6 +58,7 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_I2C_Shutdown(i2c); // Clear everything out
 
     if (i2c == MXC_I2C0) {
@@ -72,6 +73,7 @@ int MXC_I2C_Init(mxc_i2c_regs_t *i2c, int masterMode, unsigned int slaveAddr)
     } else {
         return E_NO_DEVICE;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_I2C_RevA_Init((mxc_i2c_reva_regs_t *)i2c, masterMode, slaveAddr);
 }

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -61,6 +61,7 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
         return E_BAD_PARAM;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Configure GPIO for spi
     if (spi == MXC_SPI0) {
         MXC_GCR->rstr1 |= MXC_F_GCR_RSTR1_SPI0;
@@ -86,6 +87,9 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
     } else {
         return E_NO_DEVICE;
     }
+#else
+    (void)map;
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_SPI_RevA1_Init((mxc_spi_reva_regs_t *)spi, masterMode, quadModeUsed, numSlaves,
                               ssPolarity, hz);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
@@ -61,6 +61,7 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
         return E_BAD_PARAM;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Configure GPIO for spi
     if (spi == MXC_SPI0) {
 #if TARGET_NUM != 32675
@@ -79,6 +80,7 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
     } else {
         return E_NO_DEVICE;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_SPI_RevA1_Init((mxc_spi_reva_regs_t *)spi, masterMode, quadModeUsed, numSlaves,
                               ssPolarity, hz);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me17.c
@@ -68,6 +68,7 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
         return E_BAD_PARAM;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     mxc_gpio_cfg_t gpio_cfg_spi;
     gpio_cfg_spi.pad = MXC_GPIO_PAD_NONE;
     gpio_cfg_spi.port = MXC_GPIO0;
@@ -182,6 +183,9 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
     }
 
     MXC_GPIO_Config(&gpio_cfg_spi);
+#else
+    (void)pins;
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_SPI_RevA1_Init((mxc_spi_reva_regs_t *)spi, masterMode, quadModeUsed, numSlaves,
                               ssPolarity, hz);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -68,6 +68,7 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
         return E_BAD_PARAM;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Configure GPIO for spi
     if (spi == MXC_SPI0) {
         MXC_SYS_Reset_Periph(MXC_SYS_RESET0_SPI0);
@@ -159,6 +160,9 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
     } else {
         return E_NO_DEVICE;
     }
+#else
+    (void)pins;
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_SPI_RevA1_Init((mxc_spi_reva_regs_t *)spi, masterMode, quadModeUsed, numSlaves,
                               ssPolarity, hz);

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai85.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai85.c
@@ -110,6 +110,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
@@ -180,6 +181,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR5);
         break;
     }
+#else
+    (void)init_pins;
+#endif
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_ai87.c
@@ -98,6 +98,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
@@ -168,6 +169,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR5);
         break;
     }
+#else
+    (void)init_pins;
+#endif
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_es17.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_es17.c
@@ -37,6 +37,7 @@
 
 void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int tmr_id = MXC_TMR_GET_IDX(tmr);
     MXC_ASSERT(tmr_id >= 0);
 
@@ -66,6 +67,7 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
         MXC_GPIO_Config(&gpio_cfg_tmr3);
         break;
     }
+#endif
 
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me10.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me10.c
@@ -49,6 +49,7 @@
 /* ************************************************************************** */
 void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int tmr_id = MXC_TMR_GET_IDX(tmr);
 
     switch (tmr_id) {
@@ -85,6 +86,7 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     default:
         return;
     }
+#endif
 
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me11.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me11.c
@@ -37,6 +37,7 @@
 
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int tmr_id = MXC_TMR_GET_IDX(tmr);
 
     MXC_ASSERT(tmr_id >= 0);
@@ -60,6 +61,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR2);
         break;
     }
+#endif
 
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me12.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me12.c
@@ -101,6 +101,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins, sys_ma
         break;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
@@ -178,6 +179,10 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins, sys_ma
     default:
         return E_BAD_PARAM;
     }
+#else
+    (void)init_pins;
+    (void)pin_sel;
+#endif
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me13.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me13.c
@@ -37,6 +37,7 @@
 
 void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int tmr_id = MXC_TMR_GET_IDX(tmr);
     MXC_ASSERT(tmr_id >= 0);
 
@@ -113,6 +114,7 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
     if (cfg->pins != NULL) {
         MXC_GPIO_Config(cfg->pins);
     }
+#endif
 
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me14.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me14.c
@@ -37,6 +37,7 @@
 
 void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int tmr_id = MXC_TMR_GET_IDX(tmr);
     MXC_ASSERT(tmr_id >= 0);
 
@@ -84,6 +85,7 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
         MXC_GPIO_Config(&gpio_cfg_tmr5);
         break;
     }
+#endif
 
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me15.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me15.c
@@ -103,6 +103,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
@@ -187,6 +188,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 
         break;
     }
+#else
+    (void)init_pins;
+#endif
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me16.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me16.c
@@ -98,6 +98,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
@@ -167,6 +168,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         return E_NOT_SUPPORTED;
         break;
     }
+#else
+    (void)init_pins;
+#endif
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me17.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me17.c
@@ -97,6 +97,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
@@ -165,6 +166,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR5);
         break;
     }
+#else
+    (void)init_pins;
+#endif
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me18.c
@@ -117,6 +117,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
@@ -187,6 +188,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TMR5);
         break;
     }
+#else
+    (void)init_pins;
+#endif
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
@@ -98,6 +98,7 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
         break;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     //enable peripheral clock and configure gpio pins
     switch (tmr_id) {
     case 0:
@@ -181,6 +182,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
     default:
         return E_NOT_SUPPORTED;
     }
+#else
+    (void)init_pins;
+#endif
 
     return MXC_TMR_RevB_Init((mxc_tmr_revb_regs_t *)tmr, cfg, clockSource);
 }

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me55.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me55.c
@@ -37,6 +37,7 @@
 
 void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int tmr_id = MXC_TMR_GET_IDX(tmr);
     MXC_ASSERT(tmr_id >= 0);
 
@@ -78,6 +79,7 @@ void MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg)
         MXC_GPIO_Config(&gpio_cfg_tmr5);
         break;
     }
+#endif
 
     MXC_TMR_RevA_Init((mxc_tmr_reva_regs_t *)tmr, cfg);
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me14.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me14.c
@@ -76,6 +76,7 @@ void MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, sys_map_t map)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
@@ -112,6 +113,9 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, sys_map_t map)
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART2);
         break;
     }
+#else
+    (void)map;
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_UART_RevA_Init((mxc_uart_reva_regs_t *)uart, baud);
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -57,6 +57,7 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
@@ -120,6 +121,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_NOT_SUPPORTED;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me17.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me17.c
@@ -57,6 +57,7 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
@@ -104,6 +105,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_BAD_PARAM;
     }
+#endif // MSDK_NO_GPIO_CLK_INIT
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me18.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me18.c
@@ -57,6 +57,7 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
@@ -106,6 +107,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
     default:
         return E_BAD_PARAM;
     }
+#endif
 
     return MXC_UART_RevB_Init((mxc_uart_revb_regs_t *)uart, baud, clock);
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_ai87.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_ai87.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -54,6 +55,7 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     MXC_WDT_RevB_Init((mxc_wdt_revb_regs_t *)wdt, (mxc_wdt_revb_cfg_t *)cfg);
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_es17.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_es17.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
         MXC_SYS_Reset_Periph(MXC_SYS_RESET_WDT0);
@@ -52,6 +53,9 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
     } else {
         return E_BAD_PARAM;
     }
+#else
+    (void)wdt;
+#endif
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me10.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me10.c
@@ -48,6 +48,7 @@
 /* ************************************************************************** */
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_Reset_Periph(MXC_SYS_RESET_WDT);
     } else if (wdt == MXC_WDT1) {
@@ -55,6 +56,9 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
     } else {
         return E_BAD_PARAM;
     }
+#else
+    (void)wdt;
+#endif
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me12.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me12.c
@@ -43,11 +43,13 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT);
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     MXC_WDT_RevB_Init((mxc_wdt_revb_regs_t *)wdt, (mxc_wdt_revb_cfg_t *)cfg);
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me13.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me13.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -50,6 +51,7 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me13.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me13.c
@@ -51,6 +51,8 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
     } else {
         return E_BAD_PARAM;
     }
+#else
+    (void)wdt;
 #endif
 
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me14.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me14.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -52,6 +53,9 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
     } else {
         return E_BAD_PARAM;
     }
+#else
+    (void)wdt;
+#endif
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me15.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me15.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -50,6 +51,7 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     MXC_WDT_RevB_Init((mxc_wdt_revb_regs_t *)wdt, (mxc_wdt_revb_cfg_t *)cfg);
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me16.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me16.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -50,6 +51,7 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     MXC_WDT_RevB_Init(wdt, cfg);
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -50,6 +51,7 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     MXC_WDT_RevB_Init((mxc_wdt_revb_regs_t *)wdt, (mxc_wdt_revb_cfg_t *)cfg);
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -50,6 +51,7 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     MXC_WDT_RevB_Init((mxc_wdt_revb_regs_t *)wdt, (mxc_wdt_revb_cfg_t *)cfg);
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me21.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me21.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -50,6 +51,7 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt, mxc_wdt_cfg_t *cfg)
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     MXC_WDT_RevB_Init((mxc_wdt_revb_regs_t *)wdt, (mxc_wdt_revb_cfg_t *)cfg);
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me55.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me55.c
@@ -43,6 +43,7 @@
 
 int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (wdt == MXC_WDT0) {
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_WDT0);
     } else if (wdt == MXC_WDT1) {
@@ -50,6 +51,9 @@ int MXC_WDT_Init(mxc_wdt_regs_t *wdt)
     } else {
         return E_BAD_PARAM;
     }
+#else
+    (void)wdt;
+#endif
 
     return E_NO_ERROR;
 }


### PR DESCRIPTION
## Pull Request Template

### Description

Add a method to disable clock and gpio initialization at compile time
This solution is applied while porting [Zephyr](https://github.com/zephyrproject-rtos/zephyr) on MAX32xxx MCUs. 
The main purpose is to remove delta between [hal_adi](https://github.com/analogdevicesinc/hal_adi) and MSDK repository to able to use MSDK peripherals as it is (as possible as) on zephyr side.

Applied for UART, DMA, SPI, I2C, WDT, TMR , it will be propagated to other peripherals and MCUs.

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.


