### PR TITLE
fix(BLE): feat to allow advertising updates while advertising

### DIFF
--- a/Libraries/Cordio/ble-host/sources/stack/dm/dm_adv_leg.c
+++ b/Libraries/Cordio/ble-host/sources/stack/dm/dm_adv_leg.c
@@ -142,7 +142,7 @@ void dmAdvActSetData(dmAdvMsg_t *pMsg)
 
   DM_TRACE_INFO1("dmAdvActSetData: state: %d", dmAdvCb.advState[DM_ADV_HANDLE_DEFAULT]);
 
-  if (dmAdvCb.advState[DM_ADV_HANDLE_DEFAULT] == DM_ADV_STATE_IDLE)
+  if ((dmAdvCb.advState[DM_ADV_HANDLE_DEFAULT] == DM_ADV_STATE_IDLE) || (dmAdvCb.advState[DM_ADV_HANDLE_DEFAULT] == DM_ADV_STATE_ADVERTISING))
   {
     /* set new data in HCI */
     if (pMsg->apiSetData.location == DM_DATA_LOC_ADV)


### PR DESCRIPTION
### Description
Allows the update of advertising data on the fly, per use case of iRhythm, and the project our interns worked on.
Low leve function that does the ultimate updating is protected in critical section guards so I do not see updating on the fly as an issue, Nordics SDK does the same. 
### TODO
I will write some documentation on this to the user guide since updating on the fly needs a specific workflow.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.


