### PR TITLE
fix(Examples): Bug fix for MAX32670 SPI example

### DIFF
--- a/Examples/MAX32670/SPI/main.c
+++ b/Examples/MAX32670/SPI/main.c
@@ -162,6 +162,7 @@ int main(void)
 #endif
 
 #if MASTERASYNC
+        MXC_NVIC_SetVector(SPI_IRQ, SPI_IRQHandler);
         NVIC_EnableIRQ(SPI_IRQ);
         MXC_SPI_MasterTransactionAsync(&req);
 


### PR DESCRIPTION
Tested all MAX32670 examples for the September '23 release. Only found a bug in the SPI example when the ISR vector was not set and the example would hang in the default SPI0 IRQ handler. This PR just adds the MXC_NVIC_SetVector call in the SPI example.