### PR TITLE
fix(SDHC): Remove second definition of SDHC_CLK_FREQ in sdhc_lib.h to resolve build warning

### DIFF
--- a/Libraries/SDHC/Include/sdhc_lib.h
+++ b/Libraries/SDHC/Include/sdhc_lib.h
@@ -52,8 +52,6 @@
 #include "sdhc.h"
 #include "sdhc_resp_regs.h"
 
-#define SDHC_CLK_FREQ 10000000
-
 /**
  * @brief SDHC target clock frequency.
  * @details Max freq. is limited by GCR register to be @ref SystemCoreClock / 2 or @ref SystemCoreClock / 4.


### PR DESCRIPTION
Remove definition of SDHC_CLK_FREQ to resolve SDHC library multiple definitions build warning.
