### PR TITLE
fix(MiscDrivers): Allow valid param `address + txlen <= W25_DEVICE_SIZE` when calling Ext_Flash_Program_Page()

### DIFF
--- a/Libraries/MiscDrivers/ExtMemory/Ext_Flash.h
+++ b/Libraries/MiscDrivers/ExtMemory/Ext_Flash.h
@@ -267,7 +267,7 @@ int Ext_Flash_Write_SR(uint8_t value, Ext_Flash_StatusReg_t reg_num);
  * @retval      0           Success
  * @retval      Non-zero    Error condition    
  */
-int Ext_Flash_Flash_Block_WP(uint32_t addr, uint32_t begin);
+int Ext_Flash_Block_WP(uint32_t addr, uint32_t begin);
 
 /**
  * @brief       Returns the start and end address of the available flash memory based on the current write protection scheme

--- a/Libraries/MiscDrivers/ExtMemory/w25.c
+++ b/Libraries/MiscDrivers/ExtMemory/w25.c
@@ -385,7 +385,7 @@ int Ext_Flash_Program_Page(uint32_t address, uint8_t *tx_buf, uint32_t tx_len,
     }
 
     // if flash address is out-of-range
-    if ((address >= W25_DEVICE_SIZE) || ((address + tx_len) >= W25_DEVICE_SIZE)) {
+    if ((address >= W25_DEVICE_SIZE) || ((address + tx_len) > W25_DEVICE_SIZE)) {
         return EF_E_BAD_PARAM; // attempt to write outside flash memory size
     }
 


### PR DESCRIPTION
I bumped into this minor issue recently, thought I would pass it along.

Also fixed a typo in declaration of Ext_Flash_Block_WP().