### PR TITLE
fix(Examples,PeriphDrivers): Fix SPI FIFO register access causing swapped message ordering and other minor fixes

### DIFF
--- a/Examples/MAX78002/SPI_ControllerTarget/main.c
+++ b/Examples/MAX78002/SPI_ControllerTarget/main.c
@@ -215,6 +215,7 @@ int main(void)
     controller_req.rxData = (uint8_t *)controller_rx;
     controller_req.rxLen = DATA_LEN;
     controller_req.ssDeassert = 1;
+    controller_req.ssIdx = SPI_CONTROLLER_TSIDX;
     controller_req.completeCB = NULL;
 
     /***** Configure Target (L. Slave) *****/

--- a/Examples/MAX78002/TFT_Demo/Makefile
+++ b/Examples/MAX78002/TFT_Demo/Makefile
@@ -123,8 +123,7 @@ MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
 endif
 
 # Final recalculation of LIBS_DIR/CMSIS_ROOT
-# LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
-LIBS_DIR := ../../../Libraries
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
 CMSIS_ROOT := $(LIBS_DIR)/CMSIS
 
 # One final UC/LC check in case user set TARGET in project.mk

--- a/Examples/MAX78002/TFT_Demo/project.mk
+++ b/Examples/MAX78002/TFT_Demo/project.mk
@@ -20,6 +20,4 @@ TFT = NEWHAVEN
 VPATH += resources/tft
 IPATH += resources/tft
 
-MXC_SPI_BUILD_V1 = 0
-
-LIBS_DIR = ../../../Libraries
+MXC_SPI_VERSION = v1

--- a/Libraries/PeriphDrivers/Include/MAX78002/spi.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/spi.h
@@ -838,9 +838,6 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req);
 
 /**
  * @brief   Set up a blocking, non-interrupt-driven SPI controller transaction.
- *
- * The MXC_SPI_Init_v2(..). function must be called before using this transaction
- * function.
  * 
  * @param   req         Pointer to details of the transaction.
  *
@@ -853,9 +850,6 @@ int MXC_SPI_ControllerTransaction(mxc_spi_req_t *req);
  * 
  * The MXC_SPI_Handler function must be called in the selected SPI instance's
  * interrupt handler to process the transaction.
- * 
- * The MXC_SPI_Init_v2(..). function must be called before using this transaction
- * function.
  *
  * @param   req         Pointer to details of the transaction.
  *
@@ -866,7 +860,7 @@ int MXC_SPI_ControllerTransactionAsync(mxc_spi_req_t *req);
 /**
  * @brief   Set up a non-blocking, DMA-driven SPI controller transaction.
  * 
- * The MXC_SPI_Init_v2(..). or MXC_SPI_DMA_Init(..). functions must be
+ * The MXC_SPI_Config(...) or MXC_SPI_DMA_Init(..). functions must be
  * called before calling this DMA transaction function. This function
  * does not initialize the DMA.
  *
@@ -878,9 +872,6 @@ int MXC_SPI_ControllerTransactionDMA(mxc_spi_req_t *req);
 
 /**
  * @brief   Set up a blocking, DMA-driven SPI controller transaction.
- * 
- * The MXC_SPI_Init_v2(..). function must be called before using this transaction
- * function.
  *
  * @param   req         Pointer to details of the transaction.
  *
@@ -926,9 +917,6 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req);
 /**
  * @brief   Setup a blocking SPI Target transaction.
  * 
- * The MXC_SPI_Init_v2(..). function must be called before using this transaction
- * function.
- * 
  * @param   req         Pointer to details of the transaction.
  *
  * @return  See \ref MXC_Error_Codes for the list of error return codes.
@@ -938,9 +926,6 @@ int MXC_SPI_TargetTransaction(mxc_spi_req_t *req);
 /**
  * @brief   Setup an interrupt-driven, non-blocking SPI Target transaction.
  * 
- * The MXC_SPI_Init_v2(..). function must be called before using this transaction
- * function.
- * 
  * @param   req         Pointer to details of the transaction.
  *
  * @return  See \ref MXC_Error_Codes for the list of error return codes.
@@ -948,9 +933,9 @@ int MXC_SPI_TargetTransaction(mxc_spi_req_t *req);
 int MXC_SPI_TargetTransactionAsync(mxc_spi_req_t *req);
 
 /**
- * @brief   Setup a DMA driven SPI Target transaction.
+ * @brief   Setup a DMA-driven SPI Target transaction.
  *
- * The MXC_SPI_Init_v2(..). or MXC_SPI_DMA_Init(..). functions must be
+ * The MXC_SPI_Config(...) or MXC_SPI_DMA_Init(..). functions must be
  * called before calling this DMA transaction function. This function
  * does not initialize the DMA.
  *

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -532,9 +532,14 @@ unsigned int MXC_SPI_RevA1_ReadRXFIFO(mxc_spi_reva_regs_t *spi, unsigned char *b
 
     unsigned count = 0;
 
-    if (bits <= 8 || len >= 2) {
-        // Read from the FIFO
-        while (len) {
+    // Read from the FIFO
+    while (len) {
+        // Reading 2-8 bit wide messages from the FIFO16 or FIFO32 register
+        //  swaps the ordering of the message.
+        //  Example:
+        //      When the SPI FIFO receives the message '00, 01, 02, 03', reading the FIFO16
+        //      or FIFO32 register will result in '01, 00, 03, 02'.
+        if (bits > 8) {
             if (len > 3) {
                 memcpy((uint8_t *)(&bytes[count]), (void *)(&spi->fifo32), 4);
                 len -= 4;
@@ -543,16 +548,20 @@ unsigned int MXC_SPI_RevA1_ReadRXFIFO(mxc_spi_reva_regs_t *spi, unsigned char *b
                 memcpy((uint8_t *)(&bytes[count]), (void *)(&spi->fifo16[0]), 2);
                 len -= 2;
                 count += 2;
-
-            } else {
-                ((uint8_t *)bytes)[count++] = spi->fifo8[0];
-                len -= 1;
             }
 
-            // Don't read less than 2 bytes if we are using greater than 8 bit characters
-            if (len == 1 && bits > 8) {
+            // Don't read less than 2 bytes if we are using greater than 8 bit wide messages.
+            //  Due to the nature of how this function is called in the drivers, it should never
+            //  reach to this point.
+            if (len == 1) {
                 break;
             }
+
+        // 9-16 bit wide messages should not be read from the FIFO8 register (cuts
+        //  off the upper byte).
+        } else {
+            ((uint8_t *)bytes)[count++] = spi->fifo8[0];
+            len -= 1;
         }
     }
 
@@ -587,21 +596,28 @@ unsigned int MXC_SPI_RevA1_WriteTXFIFO(mxc_spi_reva_regs_t *spi, unsigned char *
     unsigned count = 0;
 
     while (len) {
-        if (len > 3) {
-            memcpy((void *)(&spi->fifo32), (uint8_t *)(&bytes[count]), 4);
+        // Writing 2-8 bit wide messages to the FIFO16 or FIFO32 register
+        //  swaps the ordering of the message.
+        //  Example:
+        //      SPI FIFO is expected to transmit the message '00, 01, 02, 03'.
+        //      Writing the four byte-wide characters to the FIFO16 or FIFO32 register
+        //      results in this message shifted out: '01, 00, 03, 02'.
+        if (bits > 8) {
+            if (len > 3) {
+                memcpy((void *)(&spi->fifo32), (uint8_t *)(&bytes[count]), 4);
+                len -= 4;
+                count += 4;
+            } else if (len > 1) {
+                memcpy((void *)(&spi->fifo16[0]), (uint8_t *)(&bytes[count]), 2);
+                len -= 2;
+                count += 2;
+            }
 
-            len -= 4;
-            count += 4;
-
-        } else if (len > 1) {
-            memcpy((void *)(&spi->fifo16[0]), (uint8_t *)(&bytes[count]), 2);
-
-            len -= 2;
-            count += 2;
-
-        } else if (bits <= 8) {
+        // 9-16 bit wide messages should not be written to the FIFO8 register (cuts
+        //  off the upper byte).
+        } else {
             spi->fifo8[0] = ((uint8_t *)bytes)[count++];
-            len--;
+            len -= 1;
         }
     }
 
@@ -753,6 +769,7 @@ int MXC_SPI_RevA1_TransSetup(mxc_spi_reva_req_t *req)
     } else {
         states[spi_num].txrx_req = false;
     }
+
     (req->spi)->dma |= (MXC_F_SPI_REVA_DMA_TX_FLUSH | MXC_F_SPI_REVA_DMA_RX_FLUSH);
     (req->spi)->ctrl0 |= (MXC_F_SPI_REVA_CTRL0_EN);
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -538,7 +538,7 @@ unsigned int MXC_SPI_RevA1_ReadRXFIFO(mxc_spi_reva_regs_t *spi, unsigned char *b
         //  swaps the ordering of the message.
         //  Example:
         //      When the SPI FIFO receives the message '00, 01, 02, 03', reading the FIFO16
-        //      or FIFO32 register will result in '01, 00, 03, 02'.
+        //      or FIFO32 register could result in '01, 00, 03, 02' - depending on the part.
         if (bits > 8) {
             if (len > 3) {
                 memcpy((uint8_t *)(&bytes[count]), (void *)(&spi->fifo32), 4);
@@ -600,8 +600,8 @@ unsigned int MXC_SPI_RevA1_WriteTXFIFO(mxc_spi_reva_regs_t *spi, unsigned char *
         //  swaps the ordering of the message.
         //  Example:
         //      SPI FIFO is expected to transmit the message '00, 01, 02, 03'.
-        //      Writing the four byte-wide characters to the FIFO16 or FIFO32 register
-        //      results in this message shifted out: '01, 00, 03, 02'.
+        //      Writing the four byte-wide characters to the FIFO16 or FIFO32 register could
+        //      result in this message shifted out: '01, 00, 03, 02' - depending on the part.
         if (bits > 8) {
             if (len > 3) {
                 memcpy((void *)(&spi->fifo32), (uint8_t *)(&bytes[count]), 4);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
@@ -557,8 +557,8 @@ unsigned int MXC_SPI_RevA1_ReadRXFIFO(mxc_spi_reva_regs_t *spi, unsigned char *b
                 break;
             }
 
-        // 9-16 bit wide messages should not be read from the FIFO8 register (cuts
-        //  off the upper byte).
+            // 9-16 bit wide messages should not be read from the FIFO8 register (cuts
+            //  off the upper byte).
         } else {
             ((uint8_t *)bytes)[count++] = spi->fifo8[0];
             len -= 1;
@@ -613,8 +613,8 @@ unsigned int MXC_SPI_RevA1_WriteTXFIFO(mxc_spi_reva_regs_t *spi, unsigned char *
                 count += 2;
             }
 
-        // 9-16 bit wide messages should not be written to the FIFO8 register (cuts
-        //  off the upper byte).
+            // 9-16 bit wide messages should not be written to the FIFO8 register (cuts
+            //  off the upper byte).
         } else {
             spi->fifo8[0] = ((uint8_t *)bytes)[count++];
             len -= 1;


### PR DESCRIPTION
### Description

- Fix SPI FIFO register access which can cause the swapped message ordering for some parts (e.g. Transmitting or receiving the expected `00 01 02 03` message results in `01 00 03 02`).
- Add missing SPI_ControllerTarget ssIdx selection on AI87
- Remove leftover comments in AI87 spi.h
- Fix TFT_Demo makefile changes.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.