### PR TITLE
fix(Build): Add statement to MAX32680 linker description file placing flash functions in SRAM

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Source/GCC/max32680.ld
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Source/GCC/max32680.ld
@@ -145,6 +145,7 @@ SECTIONS {
         _data = ALIGN(., 4);
         *(vtable)
         *(.data*)           /*read-write initialized data: initialized global variable*/
+        *(.flashprog*)
 
         /* These array sections are used by __libc_init_array to call static C++ constructors */
         . = ALIGN(4);


### PR DESCRIPTION
Add missing flashprog statement to .data section.  Without it the flash erase and write functions were located in Flash causing a HardFault to occur whenever they were executed.
