### PR TITLE
fix(Examples): Fix RTC and RTC_Backup Example ERFO Initialization for MAX32655

### DIFF
--- a/Examples/MAX32655/RTC/main.c
+++ b/Examples/MAX32655/RTC/main.c
@@ -162,28 +162,10 @@ void printTime()
 int main(void)
 {
     int rtcTrim;
-    volatile int i;
-
-    /* Delay to prevent bricks */
-    for (i = 0; i < 0xFFFFFF; i++) {}
-
-    /* Set the system clock to the 32 MHz clock for the RTC trim */
-    /* Enable 32 MHz clock if not already enabled */
-    if (!(MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_ERFO_RDY)) {
-        /* Power VREGO_D */
-        MXC_SIMO->vrego_d = (0x3c << MXC_F_SIMO_VREGO_D_VSETD_POS);
-        while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYD)) {}
-
-        /* Restore btleldoctrl setting */
-        MXC_GCR->btleldoctrl = 0x3055;
-        while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYD)) {}
-
-        /* Enable 32Mhz oscillator */
-        MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERFO_EN;
-        while (!(MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_ERFO_RDY)) {}
-    }
+    MXC_Delay(MXC_DELAY_SEC(2)); // Delay to give debugger a window to connect
 
     /* Switch the system clock to the 32 MHz oscillator */
+    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
     MXC_SYS_Clock_Select(MXC_SYS_CLOCK_ERFO);
     MXC_SYS_SetClockDiv(MXC_SYS_CLOCK_DIV_1);
     SystemCoreClockUpdate();

--- a/Examples/MAX32655/RTC_Backup/main.c
+++ b/Examples/MAX32655/RTC_Backup/main.c
@@ -125,24 +125,10 @@ void printTime()
 int configureRTC()
 {
     int rtcTrim;
-    volatile int i;
+    MXC_Delay(MXC_DELAY_SEC(2)); // Delay to give debugger a window to connect
 
-    for (i = 0; i < 0xFFFFFF; i++) {}
-    // Prevent bricks
-
-    if (!(MXC_GCR->clkctrl &
-          MXC_F_GCR_CLKCTRL_ERFO_RDY)) { // Enable 32Mhz clock if not already enabled
-        MXC_SIMO->vrego_d = (0x3c << MXC_F_SIMO_VREGO_D_VSETD_POS); // Power VREGO_D
-        while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYD)) {}
-
-        MXC_GCR->btleldoctrl = 0x3055; // Restore btleldoctrl setting
-        while (!(MXC_SIMO->buck_out_ready & MXC_F_SIMO_BUCK_OUT_READY_BUCKOUTRDYD)) {}
-
-        MXC_GCR->clkctrl |= MXC_F_GCR_CLKCTRL_ERFO_EN; // Enable 32Mhz oscillator
-        while (!(MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_ERFO_RDY)) {}
-    }
-
-    MXC_SYS_Clock_Select(MXC_SYS_CLOCK_ERFO); // Set 32MHz clock as system clock
+    /* Switch the system clock to the 32 MHz oscillator */
+    MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERFO);
     MXC_SYS_SetClockDiv(MXC_SYS_CLOCK_DIV_1);
     SystemCoreClockUpdate();
 


### PR DESCRIPTION
### Description

The RTC and RTC_Backup example for the ME17 had some weird register-level initialization of the ERFO, which somehow reset the board and prevented the examples from running.

Replacing it with API calls fixes the problem and the examples run cleanly.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.