### PR TITLE
fix(PeriphDrivers): MSDK-1242: Fix false stop detection in I2C interrupt handler

### DIFF
--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -1556,7 +1556,7 @@ void MXC_I2C_RevA_SlaveAsyncHandler(mxc_i2c_reva_regs_t *i2c, mxc_i2c_reva_slave
     if (int_en[0] & MXC_F_I2C_REVA_INTFL0_ADDR_MATCH) {
         if (tFlags & MXC_F_I2C_REVA_INTFL0_ADDR_MATCH) {
             // Address match occurred, prepare for transaction
-            if(tFlags & MXC_F_I2C_REVA_INTFL0_STOP && !(tFlags & MXC_F_I2C_REVA_INTFL0_DONE)) {
+            if (tFlags & MXC_F_I2C_REVA_INTFL0_STOP && !(tFlags & MXC_F_I2C_REVA_INTFL0_DONE)) {
                 // Clear stop flag if it was asserted in a previous transaction
                 i2c->intfl0 = MXC_F_I2C_REVA_INTFL0_STOP;
             }

--- a/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2C/i2c_reva.c
@@ -1531,9 +1531,36 @@ void MXC_I2C_RevA_SlaveAsyncHandler(mxc_i2c_reva_regs_t *i2c, mxc_i2c_reva_slave
         }
     }
 
+    // Check if transaction completed or restart occurred
+    if (int_en[0] & MXC_F_I2C_REVA_INTFL0_DONE) {
+        if (tFlags & MXC_F_I2C_REVA_INTFL0_STOP) {
+            // Stop/NACK condition occurred, transaction complete
+            *retVal = E_NO_ERROR;
+
+            if (callback != NULL) {
+                callback(i2c, MXC_I2C_REVA_EVT_TRANS_COMP, retVal);
+            }
+
+            i2c->intfl0 = MXC_F_I2C_REVA_INTFL0_STOP;
+            int_en[0] = 0;
+            int_en[1] = 0;
+            AsyncRequests[MXC_I2C_GET_IDX((mxc_i2c_regs_t *)i2c)] = NULL;
+        } else if (tFlags & MXC_F_I2C_REVA_INTFL0_DONE) {
+            // Restart detected, re-arm address match interrupt
+            i2c->intfl0 = MXC_F_I2C_REVA_INTFL0_DONE;
+            int_en[0] = MXC_F_I2C_REVA_INTFL0_ADDR_MATCH;
+        }
+    }
+
     // Check for address match interrupt
     if (int_en[0] & MXC_F_I2C_REVA_INTFL0_ADDR_MATCH) {
         if (tFlags & MXC_F_I2C_REVA_INTFL0_ADDR_MATCH) {
+            // Address match occurred, prepare for transaction
+            if(tFlags & MXC_F_I2C_REVA_INTFL0_STOP && !(tFlags & MXC_F_I2C_REVA_INTFL0_DONE)) {
+                // Clear stop flag if it was asserted in a previous transaction
+                i2c->intfl0 = MXC_F_I2C_REVA_INTFL0_STOP;
+            }
+
             if (i2c->ctrl & MXC_F_I2C_REVA_CTRL_READ) {
                 // Read request received from the master
                 if (callback != NULL) {
@@ -1559,27 +1586,6 @@ void MXC_I2C_RevA_SlaveAsyncHandler(mxc_i2c_reva_regs_t *i2c, mxc_i2c_reva_slave
                             MXC_I2C_REVA_ERROR;
                 int_en[1] = MXC_F_I2C_REVA_INTFL1_RX_OV;
             }
-        }
-    }
-
-    // Check if transaction completed or restart occurred
-    if (int_en[0] & MXC_F_I2C_REVA_INTFL0_DONE) {
-        if (tFlags & MXC_F_I2C_REVA_INTFL0_STOP) {
-            // Stop/NACK condition occurred, transaction complete
-            *retVal = E_NO_ERROR;
-
-            if (callback != NULL) {
-                callback(i2c, MXC_I2C_REVA_EVT_TRANS_COMP, retVal);
-            }
-
-            i2c->intfl0 = MXC_F_I2C_REVA_INTFL0_STOP;
-            int_en[0] = 0;
-            int_en[1] = 0;
-            AsyncRequests[MXC_I2C_GET_IDX((mxc_i2c_regs_t *)i2c)] = NULL;
-        } else if (tFlags & MXC_F_I2C_REVA_INTFL0_DONE) {
-            // Restart detected, re-arm address match interrupt
-            i2c->intfl0 = MXC_F_I2C_REVA_INTFL0_DONE;
-            int_en[0] = MXC_F_I2C_REVA_INTFL0_ADDR_MATCH;
         }
     }
 }


### PR DESCRIPTION
A customer reported that they were seeing the I2C callback function being called early when an I2C transaction with another slave device was executed before the master initiated an I2C transaction with our micro. Upon inspection it was discovered that the I2C will always assert the STOP flag when a stop condition is detected on the bus even if our micro is not the slave device involved in the I2C communication. When our micro received an address match the handler logic would think that the transaction had been completed and would immediately enter the callback function.

This PR adds a logic block to clear the STOP interrupt flag if it has been asserted as a result of a separate I2C transaction and re-arranges logic blocks in the I2C handler to avoid entering the callback function immediately after an address match.
