### PR TITLE
refactor(PeriphDrivers): Update UART Rev. A to support TransactionAsync calls from callback function

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32650/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/uart.h
@@ -607,19 +607,23 @@ void MXC_UART_DMACallback(int ch, int error);
  *
  * @param      uart    The uart
  * @param[in]  retVal  The ret value
+ * 
+ * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
-void MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal);
-void MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
-void MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
+int MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal);
+int MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
+int MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
 
 /**
  * @brief   stop any async callbacks
  *
  * @param   uart  The uart
+ * 
+ * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
-void MXC_UART_AsyncStop(mxc_uart_regs_t *uart);
-void MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart);
-void MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart);
+int MXC_UART_AsyncStop(mxc_uart_regs_t *uart);
+int MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart);
+int MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart);
 
 /**
  * @brief   Abort any asynchronous requests in progress.
@@ -629,10 +633,12 @@ void MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart);
  * has been terminated.
  *
  * @param   uart         Pointer to UART registers (selects the UART block used.)
+ * 
+ * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
-void MXC_UART_AbortAsync(mxc_uart_regs_t *uart);
-void MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart);
-void MXC_UART_RxAbortAsync(mxc_uart_regs_t *uart);
+int MXC_UART_AbortAsync(mxc_uart_regs_t *uart);
+int MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart);
+int MXC_UART_RxAbortAsync(mxc_uart_regs_t *uart);
 
 /**
  * @brief      UART interrupt handler.

--- a/Libraries/PeriphDrivers/Include/MAX32665/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/uart.h
@@ -644,6 +644,8 @@ void MXC_UART_DMACallback(int ch, int error);
  *
  * @param      uart    The uart
  * @param[in]  retVal  The ret value
+ * 
+ * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
 int MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal);
 int MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
@@ -653,6 +655,8 @@ int MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
  * @brief   stop any async callbacks
  *
  * @param   uart  The uart
+ * 
+ * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
 int MXC_UART_AsyncStop(mxc_uart_regs_t *uart);
 int MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart);
@@ -666,6 +670,8 @@ int MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart);
  * has been terminated.
  *
  * @param   uart         Pointer to UART registers (selects the UART block used.)
+ * 
+ * @return  See \ref MXC_Error_Codes for the list of error return codes.
  */
 int MXC_UART_AbortAsync(mxc_uart_regs_t *uart);
 int MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart);

--- a/Libraries/PeriphDrivers/Include/MAX32665/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/uart.h
@@ -645,18 +645,18 @@ void MXC_UART_DMACallback(int ch, int error);
  * @param      uart    The uart
  * @param[in]  retVal  The ret value
  */
-void MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal);
-void MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
-void MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
+int MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal);
+int MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
+int MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal);
 
 /**
  * @brief   stop any async callbacks
  *
  * @param   uart  The uart
  */
-void MXC_UART_AsyncStop(mxc_uart_regs_t *uart);
-void MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart);
-void MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart);
+int MXC_UART_AsyncStop(mxc_uart_regs_t *uart);
+int MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart);
+int MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart);
 
 /**
  * @brief   Abort any asynchronous requests in progress.
@@ -667,9 +667,9 @@ void MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart);
  *
  * @param   uart         Pointer to UART registers (selects the UART block used.)
  */
-void MXC_UART_AbortAsync(mxc_uart_regs_t *uart);
-void MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart);
-void MXC_UART_RxAbortAsync(mxc_uart_regs_t *uart);
+int MXC_UART_AbortAsync(mxc_uart_regs_t *uart);
+int MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart);
+int MXC_UART_RxAbortAsync(mxc_uart_regs_t *uart);
 
 /**
  * @brief   The processing function for asynchronous transactions.

--- a/Libraries/PeriphDrivers/Source/UART/uart_me10.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me10.c
@@ -450,57 +450,57 @@ void MXC_UART_DMACallback(int ch, int error)
 }
 
 /* ************************************************************************* */
-void MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal)
+int MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal)
 {
-    MXC_UART_RevA_AsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
+    return MXC_UART_RevA_AsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
 }
 
 /* ************************************************************************* */
-void MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal)
+int MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal)
 {
-    MXC_UART_RevA_TxAsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
+    return MXC_UART_RevA_TxAsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
 }
 
 /* ************************************************************************* */
-void MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal)
+int MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal)
 {
-    MXC_UART_RevA_RxAsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
+    return MXC_UART_RevA_RxAsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
 }
 
 /* ************************************************************************* */
-void MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
+int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_AsyncStop((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_AsyncStop((mxc_uart_reva_regs_t *)uart);
 }
 
 /* ************************************************************************* */
-void MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart)
+int MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_TxAsyncStop((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_TxAsyncStop((mxc_uart_reva_regs_t *)uart);
 }
 
 /* ************************************************************************* */
-void MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart)
+int MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_RxAsyncStop((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_RxAsyncStop((mxc_uart_reva_regs_t *)uart);
 }
 
 /* ************************************************************************* */
-void MXC_UART_AbortAsync(mxc_uart_regs_t *uart)
+int MXC_UART_AbortAsync(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_AbortAsync((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_AbortAsync((mxc_uart_reva_regs_t *)uart);
 }
 
 /* ************************************************************************* */
-void MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart)
+int MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_TxAbortAsync((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_TxAbortAsync((mxc_uart_reva_regs_t *)uart);
 }
 
 /* ************************************************************************* */
-void MXC_UART_RxAbortAsync(mxc_uart_regs_t *uart)
+int MXC_UART_RxAbortAsync(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_RxAbortAsync((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_RxAbortAsync((mxc_uart_reva_regs_t *)uart);
 }
 
 /* ************************************************************************* */

--- a/Libraries/PeriphDrivers/Source/UART/uart_me14.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me14.c
@@ -44,34 +44,34 @@ void MXC_UART_DMACallback(int ch, int error)
     MXC_UART_RevA_DMACallback(ch, error);
 }
 
-void MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal)
+int MXC_UART_AsyncCallback(mxc_uart_regs_t *uart, int retVal)
 {
-    MXC_UART_RevA_AsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
+    return MXC_UART_RevA_AsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
 }
 
-void MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal)
+int MXC_UART_TxAsyncCallback(mxc_uart_regs_t *uart, int retVal)
 {
-    MXC_UART_RevA_TxAsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
+    return MXC_UART_RevA_TxAsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
 }
 
-void MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal)
+int MXC_UART_RxAsyncCallback(mxc_uart_regs_t *uart, int retVal)
 {
-    MXC_UART_RevA_RxAsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
+    return MXC_UART_RevA_RxAsyncCallback((mxc_uart_reva_regs_t *)uart, retVal);
 }
 
-void MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
+int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_AsyncStop((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_AsyncStop((mxc_uart_reva_regs_t *)uart);
 }
 
-void MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart)
+int MXC_UART_TxAsyncStop(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_TxAsyncStop((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_TxAsyncStop((mxc_uart_reva_regs_t *)uart);
 }
 
-void MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart)
+int MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_RxAsyncStop((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_RxAsyncStop((mxc_uart_reva_regs_t *)uart);
 }
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, sys_map_t map)
@@ -417,19 +417,19 @@ int MXC_UART_TransactionDMA(mxc_uart_req_t *req, mxc_dma_regs_t *dma)
     return MXC_UART_RevA_TransactionDMA((mxc_uart_reva_req_t *)req, dma);
 }
 
-void MXC_UART_AbortAsync(mxc_uart_regs_t *uart)
+int MXC_UART_AbortAsync(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_AbortAsync((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_AbortAsync((mxc_uart_reva_regs_t *)uart);
 }
 
-void MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart)
+int MXC_UART_TxAbortAsync(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_TxAbortAsync((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_TxAbortAsync((mxc_uart_reva_regs_t *)uart);
 }
 
-void MXC_UART_RxAbortAsync(mxc_uart_regs_t *uart)
+int MXC_UART_RxAbortAsync(mxc_uart_regs_t *uart)
 {
-    MXC_UART_RevA_RxAbortAsync((mxc_uart_reva_regs_t *)uart);
+    return MXC_UART_RevA_RxAbortAsync((mxc_uart_reva_regs_t *)uart);
 }
 
 void MXC_UART_AsyncHandler(mxc_uart_regs_t *uart)

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -875,18 +875,21 @@ int MXC_UART_RevA_Transaction(mxc_uart_reva_req_t *req)
 int MXC_UART_RevA_TransactionAsync(mxc_uart_reva_req_t *req)
 {
     unsigned int numToWrite, numToRead;
+    int uart_num = MXC_UART_GET_IDX((mxc_uart_regs_t *)(req->uart));
 
-    if (MXC_UART_GET_IDX((mxc_uart_regs_t *)(req->uart)) < 0) {
+    if (uart_num < 0) {
         return E_BAD_PARAM;
     }
 
     if (req->txLen) {
-        if (req->txData == NULL) {
+        if (TxAsyncRequests[uart_num] != NULL) {
+            return E_BAD_STATE;
+        } else if (req->txData == NULL) {
             return E_BAD_PARAM;
         }
 
         req->txCnt = 0;
-        TxAsyncRequests[MXC_UART_GET_IDX((mxc_uart_regs_t *)(req->uart))] = (void *)req;
+        TxAsyncRequests[uart_num] = (void *)req;
 
         // Enable TX Threshold interrupt
         MXC_UART_EnableInt((mxc_uart_regs_t *)(req->uart), MXC_F_UART_REVA_INT_EN_TX_FIFO_THRESH);
@@ -898,13 +901,15 @@ int MXC_UART_RevA_TransactionAsync(mxc_uart_reva_req_t *req)
     }
 
     if (req->rxLen) {
-        if (req->rxData == NULL) {
+        if (RxAsyncRequests[uart_num] != NULL) {
+            return E_BAD_STATE;
+        } else if (req->rxData == NULL) {
             MXC_UART_DisableInt((mxc_uart_regs_t *)(req->uart), 0xFFFFFFFF);
             return E_BAD_PARAM;
         }
 
         req->rxCnt = 0;
-        RxAsyncRequests[MXC_UART_GET_IDX((mxc_uart_regs_t *)(req->uart))] = (void *)req;
+        RxAsyncRequests[uart_num] = (void *)req;
 
         // All error interrupts are related to RX
         MXC_UART_EnableInt((mxc_uart_regs_t *)(req->uart), MXC_UART_REVA_ERRINT_EN);
@@ -1018,12 +1023,16 @@ void MXC_UART_RevA_DMACallback(int ch, int error)
 
 int MXC_UART_RevA_RxAsyncCallback(mxc_uart_reva_regs_t *uart, int retVal)
 {
-    if (MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) < 0) {
+    mxc_uart_reva_req_t *req;
+    int uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);  
+
+    if (uartNum < 0) {
         return E_BAD_PARAM;
+    } else if (RxAsyncRequests[uartNum] == NULL) {
+        return E_BAD_STATE;
     }
 
-    mxc_uart_reva_req_t *req =
-        (mxc_uart_reva_req_t *)RxAsyncRequests[MXC_UART_GET_IDX((mxc_uart_regs_t *)uart)];
+    req = (mxc_uart_reva_req_t *)RxAsyncRequests[uartNum];
 
     if (req->callback != NULL) {
         req->callback((mxc_uart_req_t *)req, retVal);
@@ -1034,12 +1043,16 @@ int MXC_UART_RevA_RxAsyncCallback(mxc_uart_reva_regs_t *uart, int retVal)
 
 int MXC_UART_RevA_TxAsyncCallback(mxc_uart_reva_regs_t *uart, int retVal)
 {
-    if (MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) < 0) {
+    mxc_uart_reva_req_t *req;
+    int uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
+
+    if (uartNum < 0) {
         return E_BAD_PARAM;
+    } else if (TxAsyncRequests[uartNum] == NULL) {
+        return E_BAD_STATE;
     }
 
-    mxc_uart_reva_req_t *req =
-        (mxc_uart_reva_req_t *)TxAsyncRequests[MXC_UART_GET_IDX((mxc_uart_regs_t *)uart)];
+    req = (mxc_uart_reva_req_t *)TxAsyncRequests[uartNum];
 
     if (req->callback != NULL) {
         req->callback((mxc_uart_req_t *)req, retVal);
@@ -1050,34 +1063,25 @@ int MXC_UART_RevA_TxAsyncCallback(mxc_uart_reva_regs_t *uart, int retVal)
 
 int MXC_UART_RevA_AsyncCallback(mxc_uart_reva_regs_t *uart, int retVal)
 {
-    int retvalTx, retvalRx;
-    bool reqMatch;
+    int err;
 
-    // If the requests are identical, only call one callback
-    if (TxAsyncRequests[MXC_UART_GET_IDX((mxc_uart_regs_t *)uart)] ==
-        RxAsyncRequests[MXC_UART_GET_IDX((mxc_uart_regs_t *)uart)]) {
-        reqMatch = TRUE;
-    } else {
-        reqMatch = FALSE;
+    int uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
+    if (uartNum < 0) {
+        return E_BAD_PARAM;
     }
 
-    retvalTx = MXC_UART_RevA_TxAsyncCallback(uart, retVal);
-
-    if (!reqMatch) {
-        retvalRx = MXC_UART_RevA_RxAsyncCallback(uart, retVal);
-    } else {
-        retvalRx = E_NO_ERROR;
+    // Call TX callback
+    err = MXC_UART_TxAsyncCallback((mxc_uart_regs_t *)uart, retVal);
+    if (err != E_NO_ERROR) {
+        return err;
     }
 
-    if (retvalTx != E_NO_ERROR) {
-        return retvalTx;
-    }
+    // Call RX callback if the TX and RX requests are not the same request
+    if (TxAsyncRequests[uartNum] != RxAsyncRequests[uartNum]) {
+        err = MXC_UART_RxAsyncCallback((mxc_uart_regs_t *)uart, retVal);
+    } 
 
-    if (retvalRx != E_NO_ERROR) {
-        return retvalRx;
-    }
-
-    return E_NO_ERROR;
+    return err;
 }
 
 int MXC_UART_RevA_TxAsyncStop(mxc_uart_reva_regs_t *uart)
@@ -1107,22 +1111,19 @@ int MXC_UART_RevA_RxAsyncStop(mxc_uart_reva_regs_t *uart)
 
 int MXC_UART_RevA_AsyncStop(mxc_uart_reva_regs_t *uart)
 {
-    int uartNum;
+    int uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
+    mxc_uart_reva_req_t *req;
 
-    if (MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) < 0) {
+    if (uartNum < 0) {
         return E_BAD_PARAM;
     }
 
-    uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
-
-    mxc_uart_reva_req_t *req = (mxc_uart_reva_req_t *)TxAsyncRequests[uartNum];
-
+    req = (mxc_uart_reva_req_t *)TxAsyncRequests[uartNum];
     if (req != NULL) {
         MXC_UART_TxAsyncStop((mxc_uart_regs_t *)uart);
     }
 
     req = (mxc_uart_reva_req_t *)RxAsyncRequests[uartNum];
-
     if (req != NULL) {
         MXC_UART_RxAsyncStop((mxc_uart_regs_t *)uart);
     }
@@ -1132,16 +1133,14 @@ int MXC_UART_RevA_AsyncStop(mxc_uart_reva_regs_t *uart)
 
 int MXC_UART_RevA_TxAbortAsync(mxc_uart_reva_regs_t *uart)
 {
-    int uartNum;
+    int uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
 
-    if (MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) < 0) {
+    if (uartNum < 0) {
         return E_BAD_PARAM;
     }
 
-    uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
-
     mxc_uart_reva_req_t *req = (mxc_uart_reva_req_t *)TxAsyncRequests[uartNum];
-
+    
     if (req != NULL) {
         MXC_UART_TxAsyncCallback((mxc_uart_regs_t *)uart, E_ABORT);
         MXC_UART_TxAsyncStop((mxc_uart_regs_t *)uart);
@@ -1149,15 +1148,14 @@ int MXC_UART_RevA_TxAbortAsync(mxc_uart_reva_regs_t *uart)
 
     return E_NO_ERROR;
 }
+
 int MXC_UART_RevA_RxAbortAsync(mxc_uart_reva_regs_t *uart)
 {
-    int uartNum;
+    int uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
 
-    if (MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) < 0) {
+    if (uartNum < 0) {
         return E_BAD_PARAM;
     }
-
-    uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
 
     mxc_uart_reva_req_t *req = (mxc_uart_reva_req_t *)RxAsyncRequests[uartNum];
 
@@ -1168,23 +1166,23 @@ int MXC_UART_RevA_RxAbortAsync(mxc_uart_reva_regs_t *uart)
 
     return E_NO_ERROR;
 }
+
 int MXC_UART_RevA_AbortAsync(mxc_uart_reva_regs_t *uart)
 {
-    int retvalTx, retvalRx;
+    int err;
 
-    retvalTx = MXC_UART_RevA_TxAbortAsync(uart);
-
-    retvalRx = MXC_UART_RevA_RxAbortAsync(uart);
-
-    if (retvalTx != E_NO_ERROR) {
-        return retvalTx;
+    if (MXC_UART_GET_IDX((mxc_uart_regs_t *)uart) < 0) {
+        return E_BAD_PARAM;
     }
 
-    if (retvalRx != E_NO_ERROR) {
-        return retvalRx;
+    // Call appropriate callback
+    err = MXC_UART_AsyncCallback((mxc_uart_regs_t *)uart, E_ABORT);
+    if (err != E_NO_ERROR) {
+        return err;
     }
 
-    return E_NO_ERROR;
+    // Disable interrupts and clear async request
+    return MXC_UART_AsyncStop((mxc_uart_regs_t *)uart);
 }
 
 int MXC_UART_RevA_AsyncHandler(mxc_uart_reva_regs_t *uart)
@@ -1200,8 +1198,15 @@ int MXC_UART_RevA_AsyncHandler(mxc_uart_reva_regs_t *uart)
     flags = MXC_UART_GetFlags((mxc_uart_regs_t *)uart);
 
     if (flags & MXC_UART_REVA_ERRINT_FL & uart->int_en) {
+        MXC_UART_DisableInt((mxc_uart_regs_t *)uart, (MXC_F_UART_REVA_INT_EN_TX_FIFO_THRESH |
+                                                      MXC_UART_REVA_ERRINT_EN |
+                                                      MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
+        
         MXC_UART_AsyncCallback((mxc_uart_regs_t *)uart, E_COMM_ERR);
-        MXC_UART_AsyncStop((mxc_uart_regs_t *)uart);
+
+        RxAsyncRequests[uartNum] = NULL;
+        TxAsyncRequests[uartNum] = NULL;
+
         return E_INVALID;
     }
 
@@ -1215,29 +1220,55 @@ int MXC_UART_RevA_AsyncHandler(mxc_uart_reva_regs_t *uart)
         MXC_UART_ClearFlags((mxc_uart_regs_t *)(req->uart), MXC_F_UART_REVA_INT_FL_TX_FIFO_THRESH);
     }
 
-    if (req->txCnt == req->txLen) {
-        MXC_UART_TxAsyncCallback((mxc_uart_regs_t *)uart, E_NO_ERROR);
-        MXC_UART_TxAsyncStop((mxc_uart_regs_t *)uart);
-    }
-
     req = (mxc_uart_reva_req_t *)RxAsyncRequests[uartNum];
 
     if ((flags & MXC_F_UART_REVA_INT_FL_RX_FIFO_THRESH) && (req != NULL) && (req->rxLen)) {
         numToRead = MXC_UART_GetRXFIFOAvailable((mxc_uart_regs_t *)(req->uart));
         numToRead = numToRead > (req->rxLen - req->rxCnt) ? req->rxLen - req->rxCnt : numToRead;
-        req->rxCnt += MXC_UART_ReadRXFIFO((mxc_uart_regs_t *)(req->uart), &req->rxData[req->rxCnt],
-                                          numToRead);
-
-        if ((req->rxLen - req->rxCnt) < MXC_UART_GetRXThreshold((mxc_uart_regs_t *)(req->uart))) {
-            MXC_UART_SetRXThreshold((mxc_uart_regs_t *)(req->uart), req->rxLen - req->rxCnt);
-        }
-
+        req->rxCnt += MXC_UART_ReadRXFIFO((mxc_uart_regs_t *)(req->uart), &req->rxData[req->rxCnt], numToRead);
         MXC_UART_ClearFlags((mxc_uart_regs_t *)(req->uart), MXC_F_UART_REVA_INT_FL_RX_FIFO_THRESH);
     }
 
-    if (req->rxCnt == req->rxLen) {
-        MXC_UART_RxAsyncCallback((mxc_uart_regs_t *)uart, E_NO_ERROR);
-        MXC_UART_RxAsyncStop((mxc_uart_regs_t *)uart);
+    if (RxAsyncRequests[uartNum] == TxAsyncRequests[uartNum]) {
+        if ((req != NULL) && (req->rxCnt == req->rxLen) && (req->txCnt == req->txLen)) {
+            MXC_UART_DisableInt((mxc_uart_regs_t *)uart, (MXC_F_UART_REVA_INT_EN_TX_FIFO_THRESH |
+                                                          MXC_UART_REVA_ERRINT_EN |
+                                                          MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
+
+            RxAsyncRequests[uartNum] = NULL;
+            TxAsyncRequests[uartNum] = NULL;
+
+            if (req->callback != NULL) {
+                req->callback((mxc_uart_req_t *)req, E_NO_ERROR);
+            }
+        }
+
+        return E_NO_ERROR;
+    }
+
+    req = TxAsyncRequests[uartNum];
+    if (req != NULL && req->txCnt == req->txLen) {
+        MXC_UART_DisableInt((mxc_uart_regs_t *)uart, MXC_F_UART_REVA_INT_EN_TX_FIFO_THRESH);
+        TxAsyncRequests[uartNum] = NULL;
+
+        if (req->callback != NULL) {
+            req->callback((mxc_uart_req_t *)req, E_NO_ERROR);
+        }
+
+        return E_NO_ERROR;
+    }
+
+    req = RxAsyncRequests[uartNum];
+    if (req != NULL && req->rxCnt == req->rxLen) {
+        MXC_UART_DisableInt((mxc_uart_regs_t *)uart, (MXC_UART_REVA_ERRINT_EN |
+                                                      MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
+        RxAsyncRequests[uartNum] = NULL;
+
+        if (req->callback != NULL) {
+            req->callback((mxc_uart_req_t *)req, E_NO_ERROR);
+        }
+
+        return E_NO_ERROR;
     }
 
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/UART/uart_reva.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_reva.c
@@ -1024,7 +1024,7 @@ void MXC_UART_RevA_DMACallback(int ch, int error)
 int MXC_UART_RevA_RxAsyncCallback(mxc_uart_reva_regs_t *uart, int retVal)
 {
     mxc_uart_reva_req_t *req;
-    int uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);  
+    int uartNum = MXC_UART_GET_IDX((mxc_uart_regs_t *)uart);
 
     if (uartNum < 0) {
         return E_BAD_PARAM;
@@ -1079,7 +1079,7 @@ int MXC_UART_RevA_AsyncCallback(mxc_uart_reva_regs_t *uart, int retVal)
     // Call RX callback if the TX and RX requests are not the same request
     if (TxAsyncRequests[uartNum] != RxAsyncRequests[uartNum]) {
         err = MXC_UART_RxAsyncCallback((mxc_uart_regs_t *)uart, retVal);
-    } 
+    }
 
     return err;
 }
@@ -1140,7 +1140,7 @@ int MXC_UART_RevA_TxAbortAsync(mxc_uart_reva_regs_t *uart)
     }
 
     mxc_uart_reva_req_t *req = (mxc_uart_reva_req_t *)TxAsyncRequests[uartNum];
-    
+
     if (req != NULL) {
         MXC_UART_TxAsyncCallback((mxc_uart_regs_t *)uart, E_ABORT);
         MXC_UART_TxAsyncStop((mxc_uart_regs_t *)uart);
@@ -1198,10 +1198,10 @@ int MXC_UART_RevA_AsyncHandler(mxc_uart_reva_regs_t *uart)
     flags = MXC_UART_GetFlags((mxc_uart_regs_t *)uart);
 
     if (flags & MXC_UART_REVA_ERRINT_FL & uart->int_en) {
-        MXC_UART_DisableInt((mxc_uart_regs_t *)uart, (MXC_F_UART_REVA_INT_EN_TX_FIFO_THRESH |
-                                                      MXC_UART_REVA_ERRINT_EN |
-                                                      MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
-        
+        MXC_UART_DisableInt((mxc_uart_regs_t *)uart,
+                            (MXC_F_UART_REVA_INT_EN_TX_FIFO_THRESH | MXC_UART_REVA_ERRINT_EN |
+                             MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
+
         MXC_UART_AsyncCallback((mxc_uart_regs_t *)uart, E_COMM_ERR);
 
         RxAsyncRequests[uartNum] = NULL;
@@ -1225,15 +1225,16 @@ int MXC_UART_RevA_AsyncHandler(mxc_uart_reva_regs_t *uart)
     if ((flags & MXC_F_UART_REVA_INT_FL_RX_FIFO_THRESH) && (req != NULL) && (req->rxLen)) {
         numToRead = MXC_UART_GetRXFIFOAvailable((mxc_uart_regs_t *)(req->uart));
         numToRead = numToRead > (req->rxLen - req->rxCnt) ? req->rxLen - req->rxCnt : numToRead;
-        req->rxCnt += MXC_UART_ReadRXFIFO((mxc_uart_regs_t *)(req->uart), &req->rxData[req->rxCnt], numToRead);
+        req->rxCnt += MXC_UART_ReadRXFIFO((mxc_uart_regs_t *)(req->uart), &req->rxData[req->rxCnt],
+                                          numToRead);
         MXC_UART_ClearFlags((mxc_uart_regs_t *)(req->uart), MXC_F_UART_REVA_INT_FL_RX_FIFO_THRESH);
     }
 
     if (RxAsyncRequests[uartNum] == TxAsyncRequests[uartNum]) {
         if ((req != NULL) && (req->rxCnt == req->rxLen) && (req->txCnt == req->txLen)) {
-            MXC_UART_DisableInt((mxc_uart_regs_t *)uart, (MXC_F_UART_REVA_INT_EN_TX_FIFO_THRESH |
-                                                          MXC_UART_REVA_ERRINT_EN |
-                                                          MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
+            MXC_UART_DisableInt((mxc_uart_regs_t *)uart,
+                                (MXC_F_UART_REVA_INT_EN_TX_FIFO_THRESH | MXC_UART_REVA_ERRINT_EN |
+                                 MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
 
             RxAsyncRequests[uartNum] = NULL;
             TxAsyncRequests[uartNum] = NULL;
@@ -1260,8 +1261,8 @@ int MXC_UART_RevA_AsyncHandler(mxc_uart_reva_regs_t *uart)
 
     req = RxAsyncRequests[uartNum];
     if (req != NULL && req->rxCnt == req->rxLen) {
-        MXC_UART_DisableInt((mxc_uart_regs_t *)uart, (MXC_UART_REVA_ERRINT_EN |
-                                                      MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
+        MXC_UART_DisableInt((mxc_uart_regs_t *)uart,
+                            (MXC_UART_REVA_ERRINT_EN | MXC_F_UART_REVA_INT_EN_RX_FIFO_THRESH));
         RxAsyncRequests[uartNum] = NULL;
 
         if (req->callback != NULL) {


### PR DESCRIPTION
While updating the MAX32650 SDHC_FAT example to use the new CLI library it was discovered that the UART Rev. A driver did not allow async transactions to be initiated from the UART callback function, a mechanism that the CLI library heavily relies on. The faulty behavior was caused by the driver calling the callback function before stopping the transaction. Calling the functions in this order disables interrupts immediately after enabling them in MXC_UART_TransactionAsync, meaning the CLI would never  detect when another character had been received. 

This PR updates the UART Rev. A library to call the callback function after the previous transaction has been stopped, thereby allowing for the next async transaction to be initiated in the callback function. While I was making those I changes, I also cleaned up several functions used in async transactions.