### PR TITLE
fix(PeriphDrivers,CMSIS): SBISYS-216: Fix typos in SPI Rx Request Select, new SVD file for MAX32690

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
@@ -16256,7 +16256,7 @@ signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is se
   <peripheral derivedFrom="SPI0">
    <name>SPI1</name>
    <description>SPI peripheral. 1</description>
-   <baseAddress>0x400BE000</baseAddress>
+   <baseAddress>0x40047000</baseAddress>
    <interrupt>
     <name>SPI1</name>
     <description>SPI1 IRQ</description>
@@ -16267,7 +16267,7 @@ signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is se
   <peripheral derivedFrom="SPI0">
    <name>SPI2</name>
    <description>SPI peripheral. 2</description>
-   <baseAddress>0x400BE400</baseAddress>
+   <baseAddress>0x40048000</baseAddress>
    <interrupt>
     <name>SPI2</name>
     <description>SPI2 IRQ</description>

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
@@ -16275,6 +16275,28 @@ signal(s) on transition(s) from low to high or high to low when PM.USBWKEN is se
    </interrupt>
   </peripheral>
 <!--SPI2 SPI peripheral. 2-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI3</name>
+   <description>SPI peripheral. 3</description>
+   <baseAddress>0x400BE000</baseAddress>
+   <interrupt>
+    <name>SPI3</name>
+    <description>SPI3 IRQ</description>
+    <value>56</value>
+   </interrupt>
+  </peripheral>
+<!--SPI3 SPI peripheral. 3-->
+  <peripheral derivedFrom="SPI0">
+   <name>SPI4</name>
+   <description>SPI peripheral. 4</description>
+   <baseAddress>0x400BE400</baseAddress>
+   <interrupt>
+    <name>SPI4</name>
+    <description>SPI4 IRQ</description>
+    <value>105</value>
+   </interrupt>
+  </peripheral>
+<!--SPI4 SPI peripheral. 4-->
   <peripheral>
    <name>SPIXR</name>
    <description>SPIXR peripheral.</description>

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me18.c
@@ -427,13 +427,13 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
             reqselRx = MXC_DMA_REQUEST_SPI1RX;
             break;
         case 2:
-            reqselTx = MXC_DMA_REQUEST_SPI2RX;
+            reqselRx = MXC_DMA_REQUEST_SPI2RX;
             break;
         case 3:
-            reqselTx = MXC_DMA_REQUEST_SPI3RX;
+            reqselRx = MXC_DMA_REQUEST_SPI3RX;
             break;
         case 4:
-            reqselTx = MXC_DMA_REQUEST_SPI4RX;
+            reqselRx = MXC_DMA_REQUEST_SPI4RX;
             break;
         default:
             return E_BAD_PARAM;


### PR DESCRIPTION
### Description

* Fixed typos in SPI request select for SPI3 and SPI4. It was preventing SPI transactions from working in DMA mode for MAX32690GWE+
* Added updated SVD file for debugging MAX32690GWE+. Peripherals SPI3 and SPI4 were missing.
