### PR TITLE
fix(BLE,Build): Fix default PAL_NVM_SIZE, add compiler checks for NVM erase functions

### DIFF
--- a/Libraries/Cordio/platform/targets/maxim/build/cordio.mk
+++ b/Libraries/Cordio/platform/targets/maxim/build/cordio.mk
@@ -64,7 +64,7 @@ PLATFORM        := maxim
 RTOS            ?= baremetal
 
 # Used for storing pairing/bonding information
-PAL_NVM_SIZE	?= 0x2000
+PAL_NVM_SIZE	?= 0x4000
 
 CFG_DEV         := BT_VER=$(BT_VER)
 CFG_DEV         += SCH_CHECK_LIST_INTEGRITY=1

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_flash.c
@@ -186,7 +186,7 @@ void PalFlashWrite(void *pBuf, uint32_t size, uint32_t dstAddr)
 /*!
  *  \brief  Erase sector.
  *
- *  \param[in] size       Data size in bytes to be erased.
+ *  \param[in] size       Data size in sectors to be erased.
  *  \param[in] startAddr  Word aligned address.
  *
  *  \return None.
@@ -206,7 +206,7 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
     MXC_FLC_PageErase(startAddr);
     WsfCsExit();
     startAddr += MXC_FLASH_PAGE_SIZE;
-    size -= MXC_FLASH_PAGE_SIZE;
+    size --;
   }
 }
 

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_flash.c
@@ -195,16 +195,23 @@ void PalFlashWrite(void *pBuf, uint32_t size, uint32_t dstAddr)
 void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
 {
   if(!PAL_NVM_IS_SECTOR_ALIGNED(startAddr)) {
-      WSF_ASSERT(FALSE);
+    PalSysAssertTrap();
   }
 
   /* Offset the address into flash */
+#if defined (__GNUC__)	
   startAddr += (uint32_t)&__pal_nvm_db_start__;
+#elif defined (__CC_ARM)
+  startAddr += (uint32_t)__pal_nvm_db_start__;	
+#elif defined (__ICCARM__)
+  startAddr += (uint32_t)__pal_nvm_db_start__;	
+#endif 
 
   while(size) {
     WsfCsEnter();
     MXC_FLC_PageErase(startAddr);
     WsfCsExit();
+
     startAddr += MXC_FLASH_PAGE_SIZE;
     size --;
   }

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_flash.c
@@ -226,7 +226,7 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
 /*************************************************************************************************/
 void PalFlashEraseChip(void)
 {
-uint32_t startAddr, size;
+  uint32_t startAddr, size;
 
 #if defined (__GNUC__)
   /* Offset the address into flash */

--- a/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32655/sources/pal_flash.c
@@ -226,16 +226,27 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
 /*************************************************************************************************/
 void PalFlashEraseChip(void)
 {
-  uint32_t startAddr, size;
+uint32_t startAddr, size;
 
+#if defined (__GNUC__)
   /* Offset the address into flash */
   startAddr = (uint32_t)&__pal_nvm_db_start__;
   size = (uint32_t)&__pal_nvm_db_end__ - (uint32_t)&__pal_nvm_db_start__;
+#elif defined (__CC_ARM)
+  /* Offset the address into flash */
+  startAddr = (uint32_t)__pal_nvm_db_start__;
+  size = (uint32_t)__pal_nvm_db_end__ - (uint32_t)__pal_nvm_db_start__;
+#elif defined (__ICCARM__)
+  /* Offset the address into flash */
+  startAddr = (uint32_t)__pal_nvm_db_start__;
+  size = (uint32_t)__pal_nvm_db_end__ - (uint32_t)__pal_nvm_db_start__ -1;
+#endif 
 
   while(size) {
     WsfCsEnter();
     MXC_FLC_PageErase(startAddr);
     WsfCsExit();
+
     startAddr += MXC_FLASH_PAGE_SIZE;
     size -= MXC_FLASH_PAGE_SIZE;
   }

--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_flash.c
@@ -197,10 +197,19 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
   }
 
   /* Offset the address into flash */
+#if defined (__GNUC__)	
   startAddr += (uint32_t)&__pal_nvm_db_start__;
+#elif defined (__CC_ARM)
+  startAddr += (uint32_t)__pal_nvm_db_start__;	
+#elif defined (__ICCARM__)
+  startAddr += (uint32_t)__pal_nvm_db_start__;	
+#endif 
 
   while(size) {
+    WsfCsEnter();
     MXC_FLC_PageErase(startAddr);
+    WsfCsExit();
+
     startAddr += MXC_FLASH_PAGE_SIZE;
     size --;
   }

--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_flash.c
@@ -224,7 +224,7 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
 /*************************************************************************************************/
 void PalFlashEraseChip(void)
 {
-uint32_t startAddr, size;
+  uint32_t startAddr, size;
 
 #if defined (__GNUC__)
   /* Offset the address into flash */

--- a/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32665/sources/pal_flash.c
@@ -224,14 +224,27 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
 /*************************************************************************************************/
 void PalFlashEraseChip(void)
 {
-  uint32_t startAddr, size;
+uint32_t startAddr, size;
 
+#if defined (__GNUC__)
   /* Offset the address into flash */
   startAddr = (uint32_t)&__pal_nvm_db_start__;
   size = (uint32_t)&__pal_nvm_db_end__ - (uint32_t)&__pal_nvm_db_start__;
+#elif defined (__CC_ARM)
+  /* Offset the address into flash */
+  startAddr = (uint32_t)__pal_nvm_db_start__;
+  size = (uint32_t)__pal_nvm_db_end__ - (uint32_t)__pal_nvm_db_start__;
+#elif defined (__ICCARM__)
+  /* Offset the address into flash */
+  startAddr = (uint32_t)__pal_nvm_db_start__;
+  size = (uint32_t)__pal_nvm_db_end__ - (uint32_t)__pal_nvm_db_start__ -1;
+#endif 
 
   while(size) {
+    WsfCsEnter();
     MXC_FLC_PageErase(startAddr);
+    WsfCsExit();
+
     startAddr += MXC_FLASH_PAGE_SIZE;
     size -= MXC_FLASH_PAGE_SIZE;
   }

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_flash.c
@@ -259,7 +259,7 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
 /*************************************************************************************************/
 void PalFlashEraseChip(void)
 {
-uint32_t startAddr, size;
+  uint32_t startAddr, size;
 
 #if defined (__GNUC__)
   /* Offset the address into flash */

--- a/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_flash.c
+++ b/Libraries/Cordio/platform/targets/maxim/max32690/sources/pal_flash.c
@@ -219,7 +219,7 @@ void PalFlashWrite(void *pBuf, uint32_t size, uint32_t dstAddr)
 /*!
  *  \brief  Erase sector.
  *
- *  \param[in] size       Data size in bytes to be erased.
+ *  \param[in] size       Data size in sectors to be erased.
  *  \param[in] startAddr  Word aligned address.
  *
  *  \return None.
@@ -246,7 +246,7 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
     WsfCsExit();
 
     startAddr += MXC_FLASH_PAGE_SIZE;
-    size -= MXC_FLASH_PAGE_SIZE;
+    size --;
   }
 }
 
@@ -259,7 +259,7 @@ void PalFlashEraseSector(uint32_t size, uint32_t startAddr)
 /*************************************************************************************************/
 void PalFlashEraseChip(void)
 {
-  uint32_t startAddr, size;
+uint32_t startAddr, size;
 
 #if defined (__GNUC__)
   /* Offset the address into flash */


### PR DESCRIPTION
### Description
Deeper look into this, the original fix in #726 was for `PalFlashEraseSector` since this is called by `WsfNvmEraseDataAll` and was caught at some point. However nothing calls `PalFlashEraseChip` , nonetheless PAL_NVM_SIZE should be a multiple of MXC_FLASH_PAGE_SIZE
Fixes #771 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
