### PR TITLE
docs(BLE): Updated documentation regarding BLE_periphs intentional use case

### DIFF
--- a/Examples/MAX32655/BLE_periph/README.md
+++ b/Examples/MAX32655/BLE_periph/README.md
@@ -1,6 +1,8 @@
 # BLE_periph
 Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph.md) documentation in the Cordio Library.
 
+# NOTE: BLE_periph is a bare bones example with no security and is not guarenteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
+
 ## Software
 
 ### Project Usage

--- a/Examples/MAX32655/BLE_periph/README.md
+++ b/Examples/MAX32655/BLE_periph/README.md
@@ -1,7 +1,7 @@
 # BLE_periph
 Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph.md) documentation in the Cordio Library.
 
-# NOTE: BLE_periph is a bare bones example with no security and is not guarenteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
+# NOTE: BLE_periph is a bare bones example with no security and is not guaranteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
 
 ## Software
 

--- a/Examples/MAX32665/BLE_periph/README.md
+++ b/Examples/MAX32665/BLE_periph/README.md
@@ -1,6 +1,8 @@
 # BLE_periph
 Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph.md) documentation in the Cordio Library.
 
+# NOTE: BLE_periph is a bare bones example with no security and is not guarenteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
+
 ## Software
 
 ### Project Usage

--- a/Examples/MAX32665/BLE_periph/README.md
+++ b/Examples/MAX32665/BLE_periph/README.md
@@ -1,7 +1,7 @@
 # BLE_periph
 Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph.md) documentation in the Cordio Library.
 
-# NOTE: BLE_periph is a bare bones example with no security and is not guarenteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
+# NOTE: BLE_periph is a bare bones example with no security and is not guaranteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
 
 ## Software
 

--- a/Examples/MAX32690/BLE_periph/README.md
+++ b/Examples/MAX32690/BLE_periph/README.md
@@ -1,6 +1,8 @@
 # BLE_periph
 Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph.md) documentation in the Cordio Library.
 
+# NOTE: BLE_periph is a bare bones example with no security and is not guarenteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
+
 ## Software
 
 ### Project Usage

--- a/Examples/MAX32690/BLE_periph/README.md
+++ b/Examples/MAX32690/BLE_periph/README.md
@@ -1,7 +1,7 @@
 # BLE_periph
 Refer to the [BLE_periph](../../../Libraries/Cordio/docs/Applications/BLE_periph.md) documentation in the Cordio Library.
 
-# NOTE: BLE_periph is a bare bones example with no security and is not guarenteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
+# NOTE: BLE_periph is a bare bones example with no security and is not guaranteed nor intended to work with Windows, IOS, Android, etc. The example is only designed to operate with other embedded devices with loose security requirements. For a more fully featured application, please checkout BLE_dat(c/s)
 
 ## Software
 


### PR DESCRIPTION
## Pull Request Template

### Description
Updated documentation for BLE_periph example noting the application shows bear bones use. 
Documents issue brought up in  #710

BLE_periph is a bare bones example with no security features and therefore is not guaranteed to connect to platforms like IOS or Android. The example is intended to be used with loosely controlled embedded devices for demonstration purposes only.

