### PR TITLE
fix(PeriphDrivers): Added update to force scale select sample to occur with ADC and ADC RefSelect for REVA API

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/adc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/adc_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/aeskeys_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/aeskeys_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/dma_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/dma_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/dvs_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/dvs_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/fcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/fcr_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/flc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/flc_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/gcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/gcr_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/gpio_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/gpio_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/htmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/htmr_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/i2c_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/i2c_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/icc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/icc_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/max32665.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/max32665.svd
@@ -68,6 +68,16 @@
        <description>ADC Reference Select</description>
        <bitRange>[4:4]</bitRange>
        <access>read-write</access>
+       <enumeratedValues>
+        <enumeratedValue>
+         <name>MXC_ADC_REF_INT</name>
+         <value>0</value>
+        </enumeratedValue>
+        <enumeratedValue>
+         <name>MXC_ADC_REF_EXT</name>
+         <value>1</value>
+        </enumeratedValue>
+       </enumeratedValues>
       </field>
       <field>
        <name>ref_scale</name>

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/mcr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/mcr_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/owm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/owm_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/pt_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/pt_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/ptg_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/ptg_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/pwrseq_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/pwrseq_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/rpu_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/rpu_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/rtc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/rtc_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/sdhc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/sdhc_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/sema_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/sema_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/simo_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/simo_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/sir_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/sir_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/smon_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/smon_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spi_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spi_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spixfc_fifo_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spixfc_fifo_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spixfc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spixfc_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spixfm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spixfm_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spixr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/spixr_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/srcc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/srcc_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/tmr_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/tmr_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/tpu_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/tpu_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/trimsir_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/trimsir_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/trng_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/trng_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/uart_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/uart_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/usbhs_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/usbhs_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/wdt_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/wdt_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/CMSIS/Device/Maxim/MAX32665/Include/wut_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32665/Include/wut_regs.h
@@ -6,6 +6,23 @@
  */
 
 /******************************************************************************
+ *
+ * Copyright 2023 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************
+ *
  * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a

--- a/Libraries/PeriphDrivers/Include/MAX32650/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/adc.h
@@ -125,6 +125,14 @@ typedef void (*mxc_adc_complete_cb_t)(void *req, int error);
 typedef void (*mxc_adc_monitor_cb_t)(void *req, int error);
 
 /**
+ * Enumeration type for ADC reference sources
+ */
+typedef enum {
+    MXC_ADC_REF_INT, // Selects internal bandgap reference
+    MXC_ADC_REF_EXT, // Selects external reference pins
+} mxc_adc_ref_t;
+
+/**
  * @brief   Used to set up a monitor to watch a channel
  *
  */

--- a/Libraries/PeriphDrivers/Include/MAX32665/adc.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/adc.h
@@ -128,6 +128,13 @@ typedef enum {
     MXC_ADC_SCALE_6, ///< ADC Scale by 1/6 (this uses 1/3 and an additional 1/2 scaling)
     MXC_ADC_SCALE_8, ///< ADC Scale by 1/8 (this uses 1/4 and an additional 1/2 scaling)
 } mxc_adc_scale_t;
+/**
+ * Enumeration type for ADC reference sources
+ */
+typedef enum {
+    MXC_ADC_REF_INT, // Selects internal bandgap reference
+    MXC_ADC_REF_EXT, // Selects external reference pins
+} mxc_adc_ref_t;
 
 /**
  * @brief   Callback used when a conversion event is complete

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me10.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me10.c
@@ -140,7 +140,11 @@ void MXC_ADC_SetExtScale(mxc_adc_scale_t scale)
 {
     MXC_ADC_RevA_SetExtScale((mxc_adc_reva_regs_t *)MXC_ADC, scale);
 }
-
+// **************************************************************************
+void MXC_ADC_RefSelect(mxc_adc_ref_t ref)
+{
+    MXC_ADC_RevA_RefSelect((mxc_adc_reva_regs_t *)MXC_ADC, ref);
+}
 // **************************************************************************
 void MXC_ADC_EnableMonitor(mxc_adc_monitor_t monitor)
 {

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me13.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me13.c
@@ -136,7 +136,10 @@ void MXC_ADC_SetExtScale(mxc_adc_scale_t scale)
 {
     MXC_ADC_RevA_SetExtScale((mxc_adc_reva_regs_t *)MXC_ADC, scale);
 }
-
+void MXC_ADC_RefSelect(mxc_adc_ref_t ref)
+{
+    MXC_ADC_RevA_RefSelect((mxc_adc_reva_regs_t *)MXC_ADC, ref);
+}
 void MXC_ADC_EnableMonitor(mxc_adc_monitor_t monitor)
 {
     MXC_ADC_RevA_EnableMonitor((mxc_adc_reva_regs_t *)MXC_ADC, monitor);

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me14.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me14.c
@@ -132,7 +132,10 @@ void MXC_ADC_SetExtScale(mxc_adc_scale_t scale)
 {
     MXC_ADC_RevA_SetExtScale((mxc_adc_reva_regs_t *)MXC_ADC, scale);
 }
-
+void MXC_ADC_RefSelect(mxc_adc_ref_t ref)
+{
+    MXC_ADC_RevA_RefSelect((mxc_adc_reva_regs_t *)MXC_ADC, ref);
+}
 void MXC_ADC_EnableMonitor(mxc_adc_monitor_t monitor)
 {
     MXC_ADC_RevA_EnableMonitor((mxc_adc_reva_regs_t *)MXC_ADC, monitor);

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me17.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me17.c
@@ -169,7 +169,10 @@ void MXC_ADC_SetExtScale(mxc_adc_scale_t scale)
 {
     MXC_ADC_RevA_SetExtScale((mxc_adc_reva_regs_t *)MXC_ADC, scale);
 }
-
+void MXC_ADC_RefSelect(mxc_adc_ref_t ref)
+{
+    MXC_ADC_RevA_RefSelect((mxc_adc_reva_regs_t *)MXC_ADC, ref);
+}
 void MXC_ADC_EnableMonitor(mxc_adc_monitor_t monitor)
 {
     MXC_ADC_RevA_EnableMonitor((mxc_adc_reva_regs_t *)MXC_ADC, monitor);

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me55.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me55.c
@@ -137,7 +137,10 @@ void MXC_ADC_SetExtScale(mxc_adc_scale_t scale)
 {
     MXC_ADC_RevA_SetExtScale((mxc_adc_reva_regs_t *)MXC_ADC, scale);
 }
-
+void MXC_ADC_RefSelect(mxc_adc_ref_t ref)
+{
+    MXC_ADC_RevA_RefSelect((mxc_adc_reva_regs_t *)MXC_ADC, ref);
+}
 void MXC_ADC_EnableMonitor(mxc_adc_monitor_t monitor)
 {
     MXC_ADC_RevA_EnableMonitor((mxc_adc_reva_regs_t *)MXC_ADC, monitor);

--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
@@ -234,19 +234,16 @@ void MXC_ADC_RevA_SetExtScale(mxc_adc_reva_regs_t *adc, mxc_adc_scale_t scale)
 }
 void MXC_ADC_RevA_RefSelect(mxc_adc_reva_regs_t *adc, mxc_adc_ref_t ref)
 {
-    
-    switch (ref)
-    {
+    switch (ref) {
     case MXC_ADC_REF_INT:
     case MXC_ADC_REF_EXT:
         adc->ctrl &= ~MXC_F_ADC_REVA_CTRL_REF_SEL;
-        adc->ctrl |= (ref << MXC_F_ADC_REVA_CTRL_REF_SEL_POS) ;
+        adc->ctrl |= (ref << MXC_F_ADC_REVA_CTRL_REF_SEL_POS);
         break;
     default:
-    
+
         break;
     }
-
 }
 void MXC_ADC_RevA_EnableMonitor(mxc_adc_reva_regs_t *adc, mxc_adc_monitor_t monitor)
 {

--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
@@ -232,7 +232,22 @@ void MXC_ADC_RevA_SetExtScale(mxc_adc_reva_regs_t *adc, mxc_adc_scale_t scale)
     //Reset the channel to original selected channel
     adc->ctrl ^= (1 << MXC_F_ADC_REVA_CTRL_CH_SEL_POS);
 }
+void MXC_ADC_RevA_RefSelect(mxc_adc_reva_regs_t *adc, mxc_adc_ref_t ref)
+{
+    
+    switch (ref)
+    {
+    case MXC_ADC_REF_INT:
+    case MXC_ADC_REF_EXT:
+        adc->ctrl &= ~MXC_F_ADC_REVA_CTRL_REF_SEL;
+        adc->ctrl |= (ref << MXC_F_ADC_REVA_CTRL_REF_SEL_POS) ;
+        break;
+    default:
+    
+        break;
+    }
 
+}
 void MXC_ADC_RevA_EnableMonitor(mxc_adc_reva_regs_t *adc, mxc_adc_monitor_t monitor)
 {
     MXC_ASSERT(monitor < MXC_MONITOR_NUM);

--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
@@ -226,6 +226,12 @@ void MXC_ADC_RevA_SetExtScale(mxc_adc_reva_regs_t *adc, mxc_adc_scale_t scale)
         adc->ctrl &= ~MXC_F_ADC_REVA_CTRL_SCALE;
         break;
     }
+
+    //Force sampling of adc scale register
+    adc->ctrl ^= (1 << MXC_F_ADC_REVA_CTRL_CH_SEL_POS);
+    //Reset the channel to original selected channel
+    adc->ctrl ^= (1 << MXC_F_ADC_REVA_CTRL_CH_SEL_POS);
+
 }
 
 void MXC_ADC_RevA_EnableMonitor(mxc_adc_reva_regs_t *adc, mxc_adc_monitor_t monitor)

--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva.c
@@ -231,7 +231,6 @@ void MXC_ADC_RevA_SetExtScale(mxc_adc_reva_regs_t *adc, mxc_adc_scale_t scale)
     adc->ctrl ^= (1 << MXC_F_ADC_REVA_CTRL_CH_SEL_POS);
     //Reset the channel to original selected channel
     adc->ctrl ^= (1 << MXC_F_ADC_REVA_CTRL_CH_SEL_POS);
-
 }
 
 void MXC_ADC_RevA_EnableMonitor(mxc_adc_reva_regs_t *adc, mxc_adc_monitor_t monitor)

--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva.h
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva.h
@@ -76,6 +76,7 @@ int MXC_ADC_RevA_SetConversionSpeed(mxc_adc_reva_regs_t *adc, uint32_t hz);
 int MXC_ADC_RevA_GetConversionSpeed(uint8_t divider);
 void MXC_ADC_RevA_SetDataAlignment(mxc_adc_reva_regs_t *adc, int msbJustify);
 void MXC_ADC_RevA_SetExtScale(mxc_adc_reva_regs_t *adc, mxc_adc_scale_t scale);
+void MXC_ADC_RevA_RefSelect(mxc_adc_reva_regs_t *adc, mxc_adc_ref_t ref);
 void MXC_ADC_RevA_EnableMonitor(mxc_adc_reva_regs_t *adc, mxc_adc_monitor_t monitor);
 void MXC_ADC_RevA_DisableMonitor(mxc_adc_reva_regs_t *adc, mxc_adc_monitor_t monitor);
 void MXC_ADC_RevA_SetMonitorHighThreshold(mxc_adc_reva_regs_t *adc, mxc_adc_monitor_t monitor,

--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva_me14.svd
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva_me14.svd
@@ -48,6 +48,16 @@
             <description>ADC Reference Select</description>
             <bitRange>[4:4]</bitRange>
             <access>read-write</access>
+            <enumeratedValues>
+              <enumeratedValue>
+                <name>MXC_ADC_REF_INT</name>
+                <value>0</value>
+              </enumeratedValue>
+                            <enumeratedValue>
+                <name>MXC_ADC_REF_EXT</name>
+                <value>1</value>
+              </enumeratedValue>
+            </enumeratedValues>
           </field>
           <field>
             <name>ref_scale</name>

--- a/Libraries/PeriphDrivers/Source/ADC/adc_reva_me14.svd
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_reva_me14.svd
@@ -48,16 +48,6 @@
             <description>ADC Reference Select</description>
             <bitRange>[4:4]</bitRange>
             <access>read-write</access>
-            <enumeratedValues>
-              <enumeratedValue>
-                <name>MXC_ADC_REF_INT</name>
-                <value>0</value>
-              </enumeratedValue>
-                            <enumeratedValue>
-                <name>MXC_ADC_REF_EXT</name>
-                <value>1</value>
-              </enumeratedValue>
-            </enumeratedValues>
           </field>
           <field>
             <name>ref_scale</name>


### PR DESCRIPTION


### Description
For chips with an ADC which allows for external voltage division, the scale select is only sampled after the channel select is switched to a new channel. So when using channel one, the external scale will not take effect since 0 is the default channel and is not switched even if configured. This fix forcefully toggles the channel selected anytime the ExtScale is set.


Also added is the API for ADC RefSelect for REVA