### PR TITLE
fix(Documentation): Remove Misleading Doxygen Comment for I2C Init (Doesn't Set Speed)

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32520/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32520/i2c.h
@@ -180,8 +180,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32570/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/i2c.h
@@ -177,8 +177,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32572/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/i2c.h
@@ -183,8 +183,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32650/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/i2c.h
@@ -180,8 +180,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32655/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/i2c.h
@@ -183,8 +183,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  * @note    On default this function enables I2C peripheral clock and i2c gpio pins.
  *          if you wish to manage clock and gpio related things in upper level instead of here.
  *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 

--- a/Libraries/PeriphDrivers/Include/MAX32660/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/i2c.h
@@ -184,8 +184,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32662/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/i2c.h
@@ -177,8 +177,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32665/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/i2c.h
@@ -185,8 +185,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  * @note    On default this function enables I2C peripheral clock and i2c gpio pins.
  *          if you wish to manage clock and gpio related things in upper level instead of here.
  *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 

--- a/Libraries/PeriphDrivers/Include/MAX32670/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/i2c.h
@@ -184,8 +184,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  * @note    On default this function enables I2C peripheral clock and i2c gpio pins.
  *          if you wish to manage clock and gpio related things in upper level instead of here.
  *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 

--- a/Libraries/PeriphDrivers/Include/MAX32672/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/i2c.h
@@ -184,8 +184,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32675/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/i2c.h
@@ -184,8 +184,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32680/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/i2c.h
@@ -183,8 +183,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX32690/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/i2c.h
@@ -183,8 +183,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  * @note    On default this function enables I2C peripheral clock and i2c gpio pins.
  *          if you wish to manage clock and gpio related things in upper level instead of here.
  *          Define MSDK_NO_GPIO_CLK_INIT flag in project.mk file. 

--- a/Libraries/PeriphDrivers/Include/MAX78000/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/i2c.h
@@ -177,8 +177,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use

--- a/Libraries/PeriphDrivers/Include/MAX78002/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/i2c.h
@@ -183,8 +183,7 @@ typedef int (*mxc_i2c_slave_handler_t)(mxc_i2c_regs_t *i2c, mxc_i2c_slave_event_
 
 /**
  * @brief   Initialize and enable I2C peripheral.
- * @note    This function sets the I2C Speed to 100kHz,  if another speed is
- *          desired use the MXC_I2C_SetFrequency() function to set it.
+ *
  *
  * @param   i2c         Pointer to I2C registers (selects the I2C block used.)
  * @param   masterMode  Whether to put the device in master or slave mode. Use


### PR DESCRIPTION
### Description

Closes #752 

None of our I2C init functions actually set the I2C frequency.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [x] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
