### PR TITLE
feat(PeriphDrivers): Add Ability to Set UART Pin Mapping for MAX32672

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32672/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/mxc_pins.h
@@ -41,6 +41,9 @@
 
 #include "gpio.h"
 
+// Pin mapping to use (i.e. UART0A, UART0B)
+typedef enum { MAP_A, MAP_B } sys_map_t;
+
 /***** Global Variables *****/
 // Predefined GPIO Configurations
 extern const mxc_gpio_cfg_t gpio_cfg_extclk;
@@ -55,12 +58,21 @@ extern const mxc_gpio_cfg_t gpio_cfg_i2c2c;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable;
+extern const mxc_gpio_cfg_t gpio_cfg_uart0b;
+extern const mxc_gpio_cfg_t gpio_cfg_uart0b_flow;
+extern const mxc_gpio_cfg_t gpio_cfg_uart0b_flow_disable;
 extern const mxc_gpio_cfg_t gpio_cfg_uart1;
 extern const mxc_gpio_cfg_t gpio_cfg_uart1_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable;
+extern const mxc_gpio_cfg_t gpio_cfg_uart1b;
+extern const mxc_gpio_cfg_t gpio_cfg_uart1b_flow;
+extern const mxc_gpio_cfg_t gpio_cfg_uart1b_flow_disable;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable;
+extern const mxc_gpio_cfg_t gpio_cfg_uart2b;
+extern const mxc_gpio_cfg_t gpio_cfg_uart2b_flow;
+extern const mxc_gpio_cfg_t gpio_cfg_uart2b_flow_disable;
 extern const mxc_gpio_cfg_t gpio_cfg_uart3;
 extern const mxc_gpio_cfg_t gpio_cfg_uart3_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart3_flow_disable;

--- a/Libraries/PeriphDrivers/Include/MAX32672/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/uart.h
@@ -147,6 +147,23 @@ struct _mxc_uart_req_t {
 /* ************************************************************************* */
 
 /**
+ * @brief   Set the UART pin mapping to use.  This should be called *before* MXC_UART_Init!
+ * 
+ * @param   uart  Pointer to UART registers to set the pin mapping for
+ * @param   pin_mapping  Pin mapping to use (i.e. UART0A, UART0B).  See datasheet for mapping assignments.
+ * @return  E_NO_ERROR if successful, error code otherwise.
+ */
+int MXC_UART_SetPinMapping(mxc_uart_regs_t *uart, sys_map_t pin_mapping);
+
+/**
+ * @brief   Get the current UART pin mapping to use.
+ * 
+ * @param   uart  Pointer to UART registers to get the pin mapping for
+ * @return  The current pin mapping.
+ */
+sys_map_t MXC_UART_GetPinMapping(mxc_uart_regs_t *uart);
+
+/**
  * @brief   Initialize and enable UART peripheral.
  * 
  * This function initializes everything necessary to call a UART transaction function.

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me21.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me21.c
@@ -64,18 +64,41 @@ const mxc_gpio_cfg_t gpio_cfg_uart0_flow = { MXC_GPIO0, (MXC_GPIO_PIN_10 | MXC_G
                                              MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11), MXC_GPIO_FUNC_IN,
                                                      MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
+const mxc_gpio_cfg_t gpio_cfg_uart0b = { MXC_GPIO0, (MXC_GPIO_PIN_24 | MXC_GPIO_PIN_25), MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0};
+const mxc_gpio_cfg_t gpio_cfg_uart0b_flow = { MXC_GPIO0, (MXC_GPIO_PIN_26 | MXC_GPIO_PIN_27), MXC_GPIO_FUNC_ALT2,
+                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart0b_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_26 | MXC_GPIO_PIN_27), MXC_GPIO_FUNC_IN,
+                                                     MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
 const mxc_gpio_cfg_t gpio_cfg_uart1 = { MXC_GPIO0, (MXC_GPIO_PIN_28 | MXC_GPIO_PIN_29), MXC_GPIO_FUNC_ALT1,
                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart1_flow = { MXC_GPIO0, (MXC_GPIO_PIN_30 | MXC_GPIO_PIN_31), MXC_GPIO_FUNC_ALT1,
                                              MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_30 | MXC_GPIO_PIN_31), MXC_GPIO_FUNC_IN,
                                                      MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_uart2 = { MXC_GPIO0, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_ALT2,
+
+const mxc_gpio_cfg_t gpio_cfg_uart1b = { MXC_GPIO0, (MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3), MXC_GPIO_FUNC_ALT2,
                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_uart2_flow = { MXC_GPIO0, (MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17), MXC_GPIO_FUNC_ALT2,
+const mxc_gpio_cfg_t gpio_cfg_uart1b_flow = { MXC_GPIO0, (MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5), MXC_GPIO_FUNC_ALT2,
                                              MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17), MXC_GPIO_FUNC_IN,
+const mxc_gpio_cfg_t gpio_cfg_uart1b_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5), MXC_GPIO_FUNC_IN,
                                                      MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
+const mxc_gpio_cfg_t gpio_cfg_uart2 = { MXC_GPIO1, (MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6), MXC_GPIO_FUNC_ALT1,
+                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart2_flow = { MXC_GPIO1, (MXC_GPIO_PIN_7 | MXC_GPIO_PIN_8), MXC_GPIO_FUNC_ALT1,
+                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_7 | MXC_GPIO_PIN_8), MXC_GPIO_FUNC_IN,
+                                                     MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
+const mxc_gpio_cfg_t gpio_cfg_uart2b = { MXC_GPIO0, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_ALT2,
+                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart2b_flow = { MXC_GPIO0, (MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17), MXC_GPIO_FUNC_ALT2,
+                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart2b_flow_disable = { MXC_GPIO0, (MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17), MXC_GPIO_FUNC_IN,
+                                                     MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
 const mxc_gpio_cfg_t gpio_cfg_uart3 = { MXC_GPIO0, (MXC_GPIO_PIN_26 | MXC_GPIO_PIN_27), MXC_GPIO_FUNC_ALT1,
                                         MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_uart3_flow = { MXC_GPIO0, (MXC_GPIO_PIN_24 | MXC_GPIO_PIN_25), MXC_GPIO_FUNC_ALT1,

--- a/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -40,6 +40,30 @@
 #include "mcr_regs.h"
 #include "dma.h"
 
+sys_map_t uart_pin_mapping[4] = { MAP_A, MAP_A, MAP_A, MAP_A };
+/* Note(JC):               ^ Ideally I use MXC_UART_INSTANCES here...
+                ... but initializing the default value is problematic then.
+*/
+
+int MXC_UART_SetPinMapping(mxc_uart_regs_t *uart, sys_map_t pin_mapping)
+{
+    if (MXC_UART_GET_IDX(uart) < 0) {
+        return E_BAD_PARAM;
+    }
+
+    uart_pin_mapping[MXC_UART_GET_IDX(uart)] = pin_mapping;
+    return E_NO_ERROR;
+}
+
+inline sys_map_t MXC_UART_GetPinMapping(mxc_uart_regs_t *uart)
+{
+    if (MXC_UART_GET_IDX(uart) < 0) {
+        return E_BAD_PARAM;
+    }
+
+    return uart_pin_mapping[MXC_UART_GET_IDX(uart)];
+}
+
 void MXC_UART_DMACallback(int ch, int error)
 {
     MXC_UART_RevB_DMACallback(ch, error);
@@ -58,6 +82,7 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int retval;
+    sys_map_t current_pin_mapping = MXC_UART_GetPinMapping(uart);
 
     retval = MXC_UART_Shutdown(uart);
 
@@ -96,22 +121,38 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clo
 
     switch (MXC_UART_GET_IDX(uart)) {
     case 0:
-        MXC_GPIO_Config(&gpio_cfg_uart0);
+        if (current_pin_mapping == MAP_A) {
+            MXC_GPIO_Config(&gpio_cfg_uart0);
+        } else if (current_pin_mapping == MAP_B) {
+            MXC_GPIO_Config(&gpio_cfg_uart0b);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART0);
         break;
 
     case 1:
-        MXC_GPIO_Config(&gpio_cfg_uart1);
+        if (current_pin_mapping == MAP_A) {
+            MXC_GPIO_Config(&gpio_cfg_uart1);
+        } else if (current_pin_mapping == MAP_B) {
+            MXC_GPIO_Config(&gpio_cfg_uart1b);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART1);
         break;
 
     case 2:
-        MXC_GPIO_Config(&gpio_cfg_uart2);
+        if (current_pin_mapping == MAP_A) {
+            MXC_GPIO_Config(&gpio_cfg_uart2);
+        } else if (current_pin_mapping == MAP_B) {
+            MXC_GPIO_Config(&gpio_cfg_uart2b);
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART2);
         break;
 
     case 3:
-        MXC_GPIO_Config(&gpio_cfg_uart3);
+        if (current_pin_mapping == MAP_A) {
+            MXC_GPIO_Config(&gpio_cfg_uart3);
+        } else if (current_pin_mapping == MAP_B) {
+            return E_BAD_PARAM; // UART 3 (LPUART0) does not have a map B
+        }
         MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_UART3);
         MXC_MCR->lppioctrl |= (MXC_F_MCR_LPPIOCTRL_LPUART0_RX | MXC_F_MCR_LPPIOCTRL_LPUART0_TX);
         break;


### PR DESCRIPTION
### Description

Closes #733 

Adds `MXC_UART_SetPinMapping` and `MXC_UART_GetPinMapping` for the MAX32672, and pin definitions to pins_me21.c.

Setter should be called _before_ UART_Init...

```C
MXC_UART_SetPinMapping(MXC_UART0, MAP_B);
MXC_UART_Init(MXC_UART0, ...);
// ...
```

Also fixed UART2A mapping being incorrect.  It was pointing to UART2B...

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
