### PR TITLE
feat(MiscDrivers): Add Ability to Override TS_MAX_BUTTONS for TSC2046

### DIFF
--- a/Libraries/MiscDrivers/Touchscreen/tsc2046.h
+++ b/Libraries/MiscDrivers/Touchscreen/tsc2046.h
@@ -43,7 +43,9 @@
 #include <gpio.h>
 
 /************************************************************************************/
+#ifndef TS_MAX_BUTTONS
 #define TS_MAX_BUTTONS 16
+#endif
 #define TS_INVALID_KEY_CODE -1
 
 typedef enum {


### PR DESCRIPTION
### Description

Closes #785 

`TS_MAX_BUTTONS` can now be defined per-project.  Ex:

```Makefile
# project.mk

PROJ_CFLAGS += -DTS_MAX_BUTTONS=30
```

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
