### PR TITLE
feat(SDHC): Add Ability to Override SDHC_CLK_FREQ

### DIFF
--- a/Libraries/SDHC/Include/sdhc_lib.h
+++ b/Libraries/SDHC/Include/sdhc_lib.h
@@ -52,6 +52,7 @@
 #include "sdhc.h"
 #include "sdhc_resp_regs.h"
 
+#ifndef SDHC_CLK_FREQ
 /**
  * @brief SDHC target clock frequency.
  * @details Max freq. is limited by GCR register to be @ref SystemCoreClock / 2 or @ref SystemCoreClock / 4.
@@ -59,6 +60,7 @@
  * R/W reliability issues can sometimes be eliminated by reducing the clock frequency, which is a good first step for troubleshooting.
  */
 #define SDHC_CLK_FREQ 40000000
+#endif
 
 
 /**

--- a/Libraries/SDHC/ff13/Source/diskio.c
+++ b/Libraries/SDHC/ff13/Source/diskio.c
@@ -16,7 +16,14 @@
 /* Definitions of physical drive number for each drive */
 #define DEV_SD      0   /* Example: Map MMC/SD card to physical drive 1 */
 #define DEV_EXTERNAL_FLASH 1
-#define SPI_SPEED 10000000
+
+#ifndef SDHC_CLK_FREQ
+/* For non-native SDHC, a SPI is used to emulate the SDHC hardware.  In 
+that case, sdhc_lib.h is not included and we need to redefine a default speed
+here. */
+#define SDHC_CLK_FREQ 40000000
+#endif
+#define SPI_SPEED SDHC_CLK_FREQ
 
 #ifdef NATIVE_SDHC
 

--- a/Libraries/SDHC/ff14/Source/diskio.c
+++ b/Libraries/SDHC/ff14/Source/diskio.c
@@ -14,6 +14,14 @@
 /* Definitions of physical drive number for each drive */
 #define DEV_SD      0   /* Example: Map MMC/SD card to physical drive 1 */
 
+#ifndef SDHC_CLK_FREQ
+/* For non-native SDHC, a SPI is used to emulate the SDHC hardware.  In 
+that case, sdhc_lib.h is not included and we need to redefine a default speed
+here. */
+#define SDHC_CLK_FREQ 40000000
+#endif
+#define SPI_SPEED SDHC_CLK_FREQ
+
 #ifdef NATIVE_SDHC
 
 /* # of times to check for a card, should be > 1 to detect both SD and MMC */
@@ -384,7 +392,7 @@ static void init_mmc()
     pins.sdio2 = false;
     pins.sdio3 = false;
     pins.vddioh = true;
-    MXC_SPI_Init(mmc_spi, 1, 0, 0, 0, 400000, pins);
+    MXC_SPI_Init(mmc_spi, 1, 0, 0, 0, SPI_SPEED, pins);
 	MXC_SPI_SetDataSize(mmc_spi, 8);
 	MXC_SPI_SetDefaultTXData(mmc_spi, 0xFF);
 

--- a/Libraries/SDHC/ff15/source/diskio.c
+++ b/Libraries/SDHC/ff15/source/diskio.c
@@ -16,7 +16,14 @@
 /* Definitions of physical drive number for each drive */
 #define DEV_SD      0   /* Example: Map MMC/SD card to physical drive 1 */
 #define DEV_EXTERNAL_FLASH 1
-#define SPI_SPEED 10000000
+
+#ifndef SDHC_CLK_FREQ
+/* For non-native SDHC, a SPI is used to emulate the SDHC hardware.  In 
+that case, sdhc_lib.h is not included and we need to redefine a default speed
+here. */
+#define SDHC_CLK_FREQ 40000000
+#endif
+#define SPI_SPEED SDHC_CLK_FREQ
 
 #ifdef NATIVE_SDHC
 

--- a/Libraries/libs.mk
+++ b/Libraries/libs.mk
@@ -155,6 +155,10 @@ endif
 # Set the FAT32 driver directory
 FAT32_DRIVER_DIR ?= $(SDHC_DRIVER_DIR)/$(FATFS_VERSION)
 
+# Set default SDHC clock frequency (40Mhz)
+SDHC_CLK_FREQ ?= 40000000
+PROJ_CFLAGS += -DSDHC_CLK_FREQ=$(SDHC_CLK_FREQ)
+
 # Include the SDHC library
 include $(FAT32_DRIVER_DIR)/fat32.mk
 include $(SDHC_DRIVER_DIR)/sdhc.mk

--- a/USERGUIDE.md
+++ b/USERGUIDE.md
@@ -2298,6 +2298,7 @@ Once enabled, the following [build configuration variables](#build-configuration
 | Configuration Variable | Description                                                | Details                                                      |
 | ---------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ |
 | `FATFS_VERSION`            | Specify the version of [FatFS](http://elm-chan.org/fsw/ff/00index_e.html) to use | FatFS is a generic FAT/exFAT filesystem that comes as a sub-component of the SDHC library.  This variable can be used to change the [version](http://elm-chan.org/fsw/ff/updates.html) to use.  Acceptable values are `ff13` (R0.13), `ff14` (R0.14b), or `ff15` (R0.15) |
+| `SDHC_CLK_FREQ`            | Sets the clock freq. for the SDHC library (Hz) | Sets the target clock frequency in units of Hz (Default is 40Mhz).  Reducing the SDHC clock frequency is a good troubleshooting step when debugging communication issues. |
 
 ---
 


### PR DESCRIPTION
### Description

Closes #784 

The SDHC clock frequency can now be overridden with the new `SDHC_CLK_FREQ` build configuration variable.  Since the SDHC library is a larger library with multiple components, this warrants a build variable instead of a simple compiler definition.  

The default is 40Mhz.  Changing the value will affect the native and SPI-emulated SDHC implementations.  Ex:

```Makefile
# project.mk

SDHC_CLK_FREQ  = 25000000
```


### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
