### PR TITLE
fix(Build): Fix unrecognized option '--no-warn-rwx-segments' on riscv

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -308,23 +308,23 @@ LDFLAGS=-mthumb                                                                \
 
 # Add --no-warn-rwx-segments on GCC 12+
 # This is not universally supported or enabled by default, so we need to check whether the linker supports it first
-RWX_SEGMENTS_SUPPORTED ?=
-ifeq "$(RWX_SEGMENTS_SUPPORTED)" "" # -------------------------------------
+ARM_RWX_SEGMENTS_SUPPORTED ?=
+ifeq "$(ARM_RWX_SEGMENTS_SUPPORTED)" "" # -------------------------------------
 # Print the linker's help string and parse it for --no-warn-rwx-segments
 # Note we invoke the linker through the compiler "-Xlinker" because ld may not
 # be on the path, and that's how we invoke the linker for our implicit rules
 LINKER_OPTIONS := $(shell $(CC) -Xlinker --help)
 ifneq "$(findstring --no-warn-rwx-segments,$(LINKER_OPTIONS))" ""
-RWX_SEGMENTS_SUPPORTED := 1
+ARM_RWX_SEGMENTS_SUPPORTED := 1
 else
-RWX_SEGMENTS_SUPPORTED := 0
+ARM_RWX_SEGMENTS_SUPPORTED := 0
 endif
 
 # export the variable for sub-make calls, so we don't need to interact with the shell again (it's slow).
-export RWX_SEGMENTS_SUPPORTED
+export ARM_RWX_SEGMENTS_SUPPORTED
 endif # ------------------------------------------------------------------
 
-ifeq "$(RWX_SEGMENTS_SUPPORTED)" "1"
+ifeq "$(ARM_RWX_SEGMENTS_SUPPORTED)" "1"
 LDFLAGS += -Xlinker --no-warn-rwx-segments
 endif
 

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -317,23 +317,24 @@ LDFLAGS+=-Xlinker --gc-sections       \
 
 # Add --no-warn-rwx-segments on GCC 12+
 # This is not universally supported or enabled by default, so we need to check whether the linker supports it first
-RWX_SEGMENTS_SUPPORTED ?=
-ifeq "$(RWX_SEGMENTS_SUPPORTED)" "" # -------------------------------------
+RISCV_RWX_SEGMENTS_SUPPORTED ?=
+ifeq "$(RISCV_RWX_SEGMENTS_SUPPORTED)" "" # -------------------------------------
 # Print the linker's help string and parse it for --no-warn-rwx-segments
 # Note we invoke the linker through the compiler "-Xlinker" because ld may not
 # be on the path, and that's how we invoke the linker for our implicit rules
 LINKER_OPTIONS := $(shell $(CC) -Xlinker --help)
 ifneq "$(findstring --no-warn-rwx-segments,$(LINKER_OPTIONS))" ""
-RWX_SEGMENTS_SUPPORTED := 1
+$(error test)
+RISCV_RWX_SEGMENTS_SUPPORTED := 1
 else
-RWX_SEGMENTS_SUPPORTED := 0
+RISCV_RWX_SEGMENTS_SUPPORTED := 0
 endif
 
 # export the variable for sub-make calls, so we don't need to interact with the shell again (it's slow).
-export RWX_SEGMENTS_SUPPORTED
+export RISCV_RWX_SEGMENTS_SUPPORTED
 endif # ------------------------------------------------------------------
 
-ifeq "$(RWX_SEGMENTS_SUPPORTED)" "1"
+ifeq "$(RISCV_RWX_SEGMENTS_SUPPORTED)" "1"
 LDFLAGS += -Xlinker --no-warn-rwx-segments
 endif
 


### PR DESCRIPTION
### Description

For some dual-core builds on GCC 12+, the `--no-warn-rwx-segments` would get added to the RISC-V linker flags when the compiler doesn't support it.  This PR prevents this from happening by renaming the variables to avoid namespace conflict.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.