### PR TITLE
fix(CMSIS): Update OWM_STAT.presence_detect field position [7] for MAX32690

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/max32690.svd
@@ -10968,7 +10968,7 @@ memory.
       <field>
        <name>presence_detect</name>
        <description>Presence Pulse Detected.</description>
-       <bitRange>[5:5]</bitRange>
+       <bitRange>[7:7]</bitRange>
        <access>read-only</access>
       </field>
      </fields>

--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Include/owm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Include/owm_regs.h
@@ -191,7 +191,7 @@ typedef struct {
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS           4 /**< CTRL_STAT_OD_SPEC_MODE Position */
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE               ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS)) /**< CTRL_STAT_OD_SPEC_MODE Mask */
 
-#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        5 /**< CTRL_STAT_PRESENCE_DETECT Position */
+#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        7 /**< CTRL_STAT_PRESENCE_DETECT Position */
 #define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT            ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS)) /**< CTRL_STAT_PRESENCE_DETECT Mask */
 
 /**@} end of group OWM_CTRL_STAT_Register */

--- a/Libraries/PeriphDrivers/Source/OWM/owm_reva_me18.svd
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_reva_me18.svd
@@ -128,7 +128,7 @@
           <field>
             <name>presence_detect</name>
             <description>Presence Pulse Detected.</description>
-            <bitRange>[5:5]</bitRange>
+            <bitRange>[7:7]</bitRange>
             <access>read-only</access>
           </field>
         </fields>


### PR DESCRIPTION
### Description

OWM_STAT.presense_detect field should be at bit position 7 for MAX32690.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
