### PR TITLE
fix(Boards): Add default interrupt handlers for the touchscreen

### DIFF
--- a/Libraries/Boards/MAX32570/MN_EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32570/MN_EvKit_V1/Source/board.c
@@ -74,8 +74,8 @@ const mxc_gpio_cfg_t ts_busy_pin = { MXC_GPIO0, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_IN
 
 /******************************************************************************/
 /** 
- * NOTE: This weak definition is included to support Push Button interrupts in
- *       case the user does not define this interrupt handler in their application.
+ * NOTE: This weak definition is included to support Push Button/Touchscreen interrupts
+ *       in case the user does not define this interrupt handler in their application.
  **/
 __weak void GPIO0_IRQHandler(void)
 {

--- a/Libraries/Boards/MAX32570/M_EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32570/M_EvKit_V1/Source/board.c
@@ -72,8 +72,8 @@ const mxc_gpio_cfg_t ts_busy_pin = { MXC_GPIO0, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_IN
 
 /******************************************************************************/
 /** 
- * NOTE: This weak definition is included to support Push Button interrupts in
- *       case the user does not define this interrupt handler in their application.
+ * NOTE: This weak definition is included to support Push Button/Touchscreen interrupts
+ *       in case the user does not define this interrupt handler in their application.
  **/
 __weak void GPIO0_IRQHandler(void)
 {

--- a/Libraries/Boards/MAX32570/QN_EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32570/QN_EvKit_V1/Source/board.c
@@ -87,6 +87,16 @@ __weak void GPIO3_IRQHandler(void)
 }
 
 /******************************************************************************/
+/** 
+ * NOTE: This weak definition is included to support Touchscreen interrupt in
+ *       case the user does not define this interrupt handler in their application.
+ **/
+__weak void GPIO0_IRQHandler(void)
+{
+    MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO0));
+}
+
+/******************************************************************************/
 static int ext_flash_board_init(void)
 {
     int err;

--- a/Libraries/Boards/MAX32570/Q_EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32570/Q_EvKit_V1/Source/board.c
@@ -79,9 +79,19 @@ const mxc_gpio_cfg_t ts_busy_pin = { MXC_GPIO0, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_IN
  * NOTE: This weak definition is included to support Push Button interrupts in
  *       case the user does not define this interrupt handler in their application.
  **/
-__weak void GPIO0_IRQHandler(void)
+__weak void GPIO3_IRQHandler(void)
 {
     MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO3));
+}
+
+/******************************************************************************/
+/** 
+ * NOTE: This weak definition is included to support Touchscreen interrupt in
+ *       case the user does not define this interrupt handler in their application.
+ **/
+__weak void GPIO0_IRQHandler(void)
+{
+    MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO0));
 }
 
 /******************************************************************************/

--- a/Libraries/Boards/MAX32655/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX32655/EvKit_V1/Source/board.c
@@ -73,8 +73,8 @@ const unsigned int num_leds = (sizeof(led_pin) / sizeof(mxc_gpio_cfg_t));
 
 /******************************************************************************/
 /** 
- * NOTE: This weak definition is included to support Push Button interrupts in
- *       case the user does not define this interrupt handler in their application.
+ * NOTE: This weak definition is included to support Push Button/Touchscreen interrupt
+ *       in case the user does not define this interrupt handler in their application.
  **/
 __weak void GPIO0_IRQHandler(void)
 {

--- a/Libraries/Boards/MAX78000/EvKit_V1/Source/board.c
+++ b/Libraries/Boards/MAX78000/EvKit_V1/Source/board.c
@@ -102,6 +102,16 @@ __weak void GPIO2_IRQHandler(void)
     MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO2));
 }
 
+/******************************************************************************/
+/** 
+ * NOTE: This weak definition is included to support Touchscreen interrupts in
+ *       case the user does not define this interrupt handler in their application.
+ **/
+__weak void GPIO0_IRQHandler(void)
+{
+    MXC_GPIO_Handler(MXC_GPIO_GET_IDX(MXC_GPIO0));
+}
+
 #ifndef __riscv
 void TS_SPI_Init(void)
 {


### PR DESCRIPTION
A customer discovered that the MAX32570_Demo examples were hanging after the touchscreen was pressed. After doing a little digging I discovered it was stuck in an undefined GPIO IRQ handler that had previously been defined in the pb.c files. This PR adds a default touchscreen IRQ handler for each board which has a touchscreen controller. 
