### PR TITLE
fix(BLE): Connection-Parameter-Update

### DIFF
--- a/Libraries/Cordio/ble-profiles/sources/af/app_slave.c
+++ b/Libraries/Cordio/ble-profiles/sources/af/app_slave.c
@@ -527,7 +527,7 @@ static void appSlaveConnUpdate(dmEvt_t *pMsg, appConnCb_t *pCb)
                                       pMsg->connUpdate.connInterval <= pAppUpdateCfg->connIntervalMax;
     
     /* if successful and we got an update using one of our requested values*/
-    if ((pMsg->hdr.status == HCI_SUCCESS && intervalInBetween ) || pCb->attempts >= pAppUpdateCfg->maxAttempts)
+    if ((pMsg->hdr.status == HCI_SUCCESS && intervalInBetween ))
     {
       pCb->attempts = 0;
       /* stop connection update timer */

--- a/Libraries/Cordio/ble-profiles/sources/af/app_slave.c
+++ b/Libraries/Cordio/ble-profiles/sources/af/app_slave.c
@@ -527,7 +527,7 @@ static void appSlaveConnUpdate(dmEvt_t *pMsg, appConnCb_t *pCb)
                                       pMsg->connUpdate.connInterval <= pAppUpdateCfg->connIntervalMax;
     
     /* if successful and we got an update using one of our requested values*/
-    if ((pMsg->hdr.status == HCI_SUCCESS && intervalInBetween ))
+    if (pMsg->hdr.status == HCI_SUCCESS && intervalInBetween)
     {
       pCb->attempts = 0;
       /* stop connection update timer */

--- a/Libraries/Cordio/ble-profiles/sources/af/app_slave.c
+++ b/Libraries/Cordio/ble-profiles/sources/af/app_slave.c
@@ -523,9 +523,13 @@ static void appSlaveConnUpdate(dmEvt_t *pMsg, appConnCb_t *pCb)
 {
   if (pAppUpdateCfg->idlePeriod != 0)
   {
-    /* if successful */
-    if (pMsg->hdr.status == HCI_SUCCESS)
+    const bool_t intervalInBetween =  pAppUpdateCfg->connIntervalMin <= pMsg->connUpdate.connInterval && 
+                                      pMsg->connUpdate.connInterval <= pAppUpdateCfg->connIntervalMax;
+    
+    /* if successful and we got an update using one of our requested values*/
+    if ((pMsg->hdr.status == HCI_SUCCESS && intervalInBetween ) || pCb->attempts >= pAppUpdateCfg->maxAttempts)
     {
+      pCb->attempts = 0;
       /* stop connection update timer */
       appConnUpdateTimerStop(pCb);
     }
@@ -970,7 +974,9 @@ static void appSlaveConnUpdateTimeout(wsfMsgHdr_t *pMsg, appConnCb_t *pCb)
     connSpec.minCeLen = 0;
     connSpec.maxCeLen = 0xffff;
 
-    DmConnUpdate(pCb->connId, &connSpec);
+    
+      DmConnUpdate(pCb->connId, &connSpec);
+    
   }
   else
   {


### PR DESCRIPTION
## Pull Request Template

### Description
Cordio now will only cancel connection parameter update requests upon max attempts or connection interval agreement.


At the app layer, when requesting a connection update, a request goes through periodically until the update is successful or the max attempts have been reached. However, the stack does not differentiate between Master and Slave requests. So if the Master requests a connection update, the slaves request will be cancelled. Therefore, the parameters the application wants are never obtained. This change will stop trying for updates once the connection interval is accepted based on the range given by the user, or max attempts have been reached. 
