### PR TITLE
feat(PeriphDrivers): Add clock selection feature to WDT

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32655/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/wdt.h
@@ -121,6 +121,16 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum {
+    MXC_WDT_PCLK = 0,
+    MXC_WDT_IBRO_CLK,
+    MXC_WDT_INRO_CLK,
+    MXC_WDT_ERTCO_CLK
+} mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -233,6 +243,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Include/MAX32662/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/wdt.h
@@ -121,6 +121,19 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum {
+    MXC_WDT_PCLK = 0,
+    MXC_WDT_IPO_CLK,
+    MXC_WDT_IBRO_CLK,
+    MXC_WDT_NANO_CLK,
+    MXC_WDT_ERTCO_CLK,
+    MXC_WDT_EXT_CLK,
+    MXC_WDT_ERFO_CLK
+} mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -233,6 +246,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Include/MAX32670/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/wdt.h
@@ -121,6 +121,19 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum {
+    MXC_WDT_PCLK = 0,
+    MXC_WDT_IPO_CLK,
+    MXC_WDT_IBRO_CLK,
+    MXC_WDT_INRO_CLK,
+    MXC_WDT_ERTCO_CLK,
+    MXC_WDT_EXT_CLK,
+    MXC_WDT_ERFO_CLK
+} mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -233,6 +246,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Include/MAX32672/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/wdt.h
@@ -121,6 +121,19 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum {
+    MXC_WDT_PCLK = 0,
+    MXC_WDT_IPO_CLK,
+    MXC_WDT_IBRO_CLK,
+    MXC_WDT_INRO_CLK,
+    MXC_WDT_ERTCO_CLK,
+    MXC_WDT_EXT_CLK,
+    MXC_WDT_ERFO_CLK
+} mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -233,6 +246,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Include/MAX32675/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/wdt.h
@@ -125,6 +125,16 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum {
+    MXC_WDT_PCLK = 0,
+    MXC_WDT_IPO_CLK,
+    MXC_WDT_IBRO_CLK,
+    MXC_WDT_INRO_CLK
+} mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -237,6 +247,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Include/MAX32680/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/wdt.h
@@ -121,6 +121,11 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum { MXC_WDT_PCLK = 0, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK } mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -233,6 +238,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Include/MAX32690/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/wdt.h
@@ -121,6 +121,16 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum {
+    MXC_WDT_PCLK = 0,
+    MXC_WDT_IBRO_CLK,
+    MXC_WDT_INRO_CLK,
+    MXC_WDT_ERTCO_CLK
+} mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -233,6 +243,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Include/MAX78000/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/wdt.h
@@ -121,6 +121,16 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum {
+    MXC_WDT_PCLK = 0,
+    MXC_WDT_IBRO_CLK,
+    MXC_WDT_INRO_CLK,
+    MXC_WDT_ERTCO_CLK
+} mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -233,6 +243,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Include/MAX78002/wdt.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/wdt.h
@@ -121,6 +121,19 @@ typedef enum {
 } mxc_wdt_mode_t;
 
 /**
+ * @brief Peripheral Clock settings 
+ */
+typedef enum {
+    MXC_WDT_PCLK = 0,
+    MXC_WDT_IPO_CLK,
+    MXC_WDT_IBRO_CLK,
+    MXC_WDT_INRO_CLK,
+    MXC_WDT_ERTCO_CLK,
+    MXC_WDT_EXT_CLK,
+    MXC_WDT_ERFO_CLK
+} mxc_wdt_clock_t;
+
+/**
  * @brief Timer Configuration
  */
 typedef struct {
@@ -233,6 +246,13 @@ int MXC_WDT_GetIntFlag(mxc_wdt_regs_t *wdt);
  * @param       wdt     Pointer to watchdog registers.
  */
 void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt);
+
+/**
+ * @brief       Sets clock source.
+ * @param       wdt             Pointer to watchdog registers.
+ * @param       clock_source    Clock source.
+ */
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source);
 
 /**@} end of group wdt */
 

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_ai87.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_ai87.c
@@ -157,3 +157,38 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 {
     MXC_WDT_RevB_ClearIntFlag((mxc_wdt_revb_regs_t *)wdt);
 }
+
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
+{
+    const uint8_t clock_source_num = 8;
+    uint8_t idx = 0;
+    uint8_t instance = 0;
+    mxc_wdt_clock_t clock_sources[2][8] = {
+        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
+          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF },
+        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
+          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF }
+    };
+
+    if (wdt == MXC_WDT0) {
+        instance = 0;
+    } else if (wdt == MXC_WDT1) {
+        instance = 1;
+    } else {
+        return E_BAD_PARAM;
+    }
+
+    for (idx = 0; idx < clock_source_num; idx++) {
+        if (clock_sources[instance][idx] == clock_source) {
+            break;
+        }
+    }
+
+    if (idx == clock_source_num) {
+        return E_BAD_PARAM;
+    }
+
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+
+    return E_NO_ERROR;
+}

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_ai87.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_ai87.c
@@ -160,12 +160,6 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
-    const uint8_t last_clock_source = MXC_WDT_ERFO_CLK;
-
-    if ((clock_source < 0) || (clock_source > last_clock_source)) {
-        return E_BAD_PARAM;
-    }
-
     MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, (int)clock_source);
 
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_ai87.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_ai87.c
@@ -160,35 +160,13 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
-    const uint8_t clock_source_num = 8;
-    uint8_t idx = 0;
-    uint8_t instance = 0;
-    mxc_wdt_clock_t clock_sources[2][8] = {
-        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
-          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF },
-        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
-          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF }
-    };
+    const uint8_t last_clock_source = MXC_WDT_ERFO_CLK;
 
-    if (wdt == MXC_WDT0) {
-        instance = 0;
-    } else if (wdt == MXC_WDT1) {
-        instance = 1;
-    } else {
+    if ((clock_source < 0) || (clock_source > last_clock_source)) {
         return E_BAD_PARAM;
     }
 
-    for (idx = 0; idx < clock_source_num; idx++) {
-        if (clock_sources[instance][idx] == clock_source) {
-            break;
-        }
-    }
-
-    if (idx == clock_source_num) {
-        return E_BAD_PARAM;
-    }
-
-    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, (int)clock_source);
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me12.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me12.c
@@ -166,27 +166,13 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
-    const uint8_t clock_source_num = 8;
-    uint8_t idx = 0;
-    mxc_wdt_clock_t clock_sources[1][8] = { { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK,
-                                              MXC_WDT_NANO_CLK, MXC_WDT_ERTCO_CLK, MXC_WDT_EXT_CLK,
-                                              MXC_WDT_ERFO_CLK, 0xFF } };
+    const uint8_t last_clock_source = MXC_WDT_ERFO_CLK;
 
-    if (wdt != MXC_WDT0) {
+    if ((clock_source < 0) || (clock_source > last_clock_source)) {
         return E_BAD_PARAM;
     }
 
-    for (idx = 0; idx < clock_source_num; idx++) {
-        if (clock_sources[0][idx] == clock_source) {
-            break;
-        }
-    }
-
-    if (idx == clock_source_num) {
-        return E_BAD_PARAM;
-    }
-
-    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, (int)clock_source);
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me12.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me12.c
@@ -163,3 +163,30 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 {
     MXC_WDT_RevB_ClearIntFlag((mxc_wdt_revb_regs_t *)wdt);
 }
+
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
+{
+    const uint8_t clock_source_num = 8;
+    uint8_t idx = 0;
+    mxc_wdt_clock_t clock_sources[1][8] = { { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK,
+                                              MXC_WDT_NANO_CLK, MXC_WDT_ERTCO_CLK, MXC_WDT_EXT_CLK,
+                                              MXC_WDT_ERFO_CLK, 0xFF } };
+
+    if (wdt != MXC_WDT0) {
+        return E_BAD_PARAM;
+    }
+
+    for (idx = 0; idx < clock_source_num; idx++) {
+        if (clock_sources[0][idx] == clock_source) {
+            break;
+        }
+    }
+
+    if (idx == clock_source_num) {
+        return E_BAD_PARAM;
+    }
+
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+
+    return E_NO_ERROR;
+}

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me12.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me12.c
@@ -166,12 +166,6 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
-    const uint8_t last_clock_source = MXC_WDT_ERFO_CLK;
-
-    if ((clock_source < 0) || (clock_source > last_clock_source)) {
-        return E_BAD_PARAM;
-    }
-
     MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, (int)clock_source);
 
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me15.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me15.c
@@ -156,18 +156,6 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
-#if TARGET_NUM == 32670
-    const uint8_t last_clock_source = MXC_WDT_ERFO_CLK;
-#elif TARGET_NUM == 32675
-    const uint8_t last_clock_source = MXC_WDT_INRO_CLK;
-#else
-#error ME15 WDT driver does not support given target number.
-#endif
-
-    if ((clock_source < 0) || (clock_source > last_clock_source)) {
-        return E_BAD_PARAM;
-    }
-
     MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, (int)clock_source);
 
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me15.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me15.c
@@ -156,46 +156,19 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
-    const uint8_t clock_source_num = 8;
-    uint8_t idx = 0;
-    uint8_t instance = 0;
-
 #if TARGET_NUM == 32670
-    mxc_wdt_clock_t clock_sources[2][8] = {
-        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
-          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF },
-        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
-          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF }
-    };
+    const uint8_t last_clock_source = MXC_WDT_ERFO_CLK;
 #elif TARGET_NUM == 32675
-    mxc_wdt_clock_t clock_sources[2][8] = { { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK,
-                                              MXC_WDT_INRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF },
-                                            { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK,
-                                              MXC_WDT_INRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF } };
+    const uint8_t last_clock_source = MXC_WDT_INRO_CLK;
 #else
-    mxc_wdt_clock_t clock_sources[2][8] = { { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
-                                            { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } };
+#error ME15 WDT driver does not support given target number.
 #endif
 
-    if (wdt == MXC_WDT0) {
-        instance = 0;
-    } else if (wdt == MXC_WDT1) {
-        instance = 1;
-    } else {
+    if ((clock_source < 0) || (clock_source > last_clock_source)) {
         return E_BAD_PARAM;
     }
 
-    for (idx = 0; idx < clock_source_num; idx++) {
-        if (clock_sources[instance][idx] == clock_source) {
-            break;
-        }
-    }
-
-    if (idx == clock_source_num) {
-        return E_BAD_PARAM;
-    }
-
-    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, (int)clock_source);
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me15.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me15.c
@@ -153,3 +153,49 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 {
     MXC_WDT_RevB_ClearIntFlag((mxc_wdt_revb_regs_t *)wdt);
 }
+
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
+{
+    const uint8_t clock_source_num = 8;
+    uint8_t idx = 0;
+    uint8_t instance = 0;
+
+#if TARGET_NUM == 32670
+    mxc_wdt_clock_t clock_sources[2][8] = {
+        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
+          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF },
+        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
+          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF }
+    };
+#elif TARGET_NUM == 32675
+    mxc_wdt_clock_t clock_sources[2][8] = { { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK,
+                                              MXC_WDT_INRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF },
+                                            { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK,
+                                              MXC_WDT_INRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF } };
+#else
+    mxc_wdt_clock_t clock_sources[2][8] = { { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+                                            { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } };
+#endif
+
+    if (wdt == MXC_WDT0) {
+        instance = 0;
+    } else if (wdt == MXC_WDT1) {
+        instance = 1;
+    } else {
+        return E_BAD_PARAM;
+    }
+
+    for (idx = 0; idx < clock_source_num; idx++) {
+        if (clock_sources[instance][idx] == clock_source) {
+            break;
+        }
+    }
+
+    if (idx == clock_source_num) {
+        return E_BAD_PARAM;
+    }
+
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+
+    return E_NO_ERROR;
+}

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
@@ -171,8 +171,7 @@ int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
         { MXC_WDT_IBRO_CLK, 0xFF, MXC_WDT_INRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
     };
 #else
-    mxc_wdt_clock_t clock_sources[2][8] = { { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
-                                            { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } };
+#error ME17 WDT driver does not support given target number.
 #endif
 
     if (wdt == MXC_WDT0) {

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
@@ -188,10 +188,6 @@ int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
         }
     }
 
-    if (idx == clock_source_num) {
-        return E_BAD_PARAM;
-    }
-
     MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
 
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
@@ -153,3 +153,47 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 {
     MXC_WDT_RevB_ClearIntFlag((mxc_wdt_revb_regs_t *)wdt);
 }
+
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
+{
+    const uint8_t clock_source_num = 8;
+    uint8_t idx = 0;
+    uint8_t instance = 0;
+
+#if TARGET_NUM == 32655 || TARGET_NUM == 78000
+    mxc_wdt_clock_t clock_sources[2][8] = {
+        { MXC_WDT_PCLK, MXC_WDT_IBRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+        { MXC_WDT_IBRO_CLK, MXC_WDT_ERTCO_CLK, MXC_WDT_INRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
+    };
+#elif TARGET_NUM == 32680
+    mxc_wdt_clock_t clock_sources[2][8] = {
+        { MXC_WDT_PCLK, MXC_WDT_IBRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+        { MXC_WDT_IBRO_CLK, 0xFF, MXC_WDT_INRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
+    };
+#else
+    mxc_wdt_clock_t clock_sources[2][8] = { { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+                                            { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } };
+#endif
+
+    if (wdt == MXC_WDT0) {
+        instance = 0;
+    } else if (wdt == MXC_WDT1) {
+        instance = 1;
+    } else {
+        return E_BAD_PARAM;
+    }
+
+    for (idx = 0; idx < clock_source_num; idx++) {
+        if (clock_sources[instance][idx] == clock_source) {
+            break;
+        }
+    }
+
+    if (idx == clock_source_num) {
+        return E_BAD_PARAM;
+    }
+
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+
+    return E_NO_ERROR;
+}

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
@@ -178,10 +178,6 @@ int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
         }
     }
 
-    if (idx == clock_source_num) {
-        return E_BAD_PARAM;
-    }
-
     MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
 
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me18.c
@@ -153,3 +153,36 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 {
     MXC_WDT_RevB_ClearIntFlag((mxc_wdt_revb_regs_t *)wdt);
 }
+
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
+{
+    const uint8_t clock_source_num = 8;
+    uint8_t idx = 0;
+    uint8_t instance = 0;
+    mxc_wdt_clock_t clock_sources[2][8] = {
+        { MXC_WDT_PCLK, MXC_WDT_IBRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+        { MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
+    };
+
+    if (wdt == MXC_WDT0) {
+        instance = 0;
+    } else if (wdt == MXC_WDT1) {
+        instance = 1;
+    } else {
+        return E_BAD_PARAM;
+    }
+
+    for (idx = 0; idx < clock_source_num; idx++) {
+        if (clock_sources[instance][idx] == clock_source) {
+            break;
+        }
+    }
+
+    if (idx == clock_source_num) {
+        return E_BAD_PARAM;
+    }
+
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+
+    return E_NO_ERROR;
+}

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me21.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me21.c
@@ -156,35 +156,13 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
-    const uint8_t clock_source_num = 8;
-    uint8_t idx = 0;
-    uint8_t instance = 0;
-    mxc_wdt_clock_t clock_sources[2][8] = {
-        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
-          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF },
-        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
-          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF }
-    };
+    const uint8_t last_clock_source = MXC_WDT_ERFO_CLK;
 
-    if (wdt == MXC_WDT0) {
-        instance = 0;
-    } else if (wdt == MXC_WDT1) {
-        instance = 1;
-    } else {
+    if ((clock_source < 0) || (clock_source > last_clock_source)) {
         return E_BAD_PARAM;
     }
 
-    for (idx = 0; idx < clock_source_num; idx++) {
-        if (clock_sources[instance][idx] == clock_source) {
-            break;
-        }
-    }
-
-    if (idx == clock_source_num) {
-        return E_BAD_PARAM;
-    }
-
-    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, (int)clock_source);
 
     return E_NO_ERROR;
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me21.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me21.c
@@ -153,3 +153,38 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 {
     MXC_WDT_RevB_ClearIntFlag((mxc_wdt_revb_regs_t *)wdt);
 }
+
+int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
+{
+    const uint8_t clock_source_num = 8;
+    uint8_t idx = 0;
+    uint8_t instance = 0;
+    mxc_wdt_clock_t clock_sources[2][8] = {
+        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
+          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF },
+        { MXC_WDT_PCLK, MXC_WDT_IPO_CLK, MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK,
+          MXC_WDT_EXT_CLK, MXC_WDT_ERFO_CLK, 0xFF }
+    };
+
+    if (wdt == MXC_WDT0) {
+        instance = 0;
+    } else if (wdt == MXC_WDT1) {
+        instance = 1;
+    } else {
+        return E_BAD_PARAM;
+    }
+
+    for (idx = 0; idx < clock_source_num; idx++) {
+        if (clock_sources[instance][idx] == clock_source) {
+            break;
+        }
+    }
+
+    if (idx == clock_source_num) {
+        return E_BAD_PARAM;
+    }
+
+    MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, idx);
+
+    return E_NO_ERROR;
+}

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me21.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me21.c
@@ -156,12 +156,6 @@ void MXC_WDT_ClearIntFlag(mxc_wdt_regs_t *wdt)
 
 int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 {
-    const uint8_t last_clock_source = MXC_WDT_ERFO_CLK;
-
-    if ((clock_source < 0) || (clock_source > last_clock_source)) {
-        return E_BAD_PARAM;
-    }
-
     MXC_WDT_RevB_SetClockSource((mxc_wdt_revb_regs_t *)wdt, (int)clock_source);
 
     return E_NO_ERROR;

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_revb.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_revb.c
@@ -154,3 +154,9 @@ void MXC_WDT_RevB_ClearIntFlag(mxc_wdt_revb_regs_t *wdt)
 {
     wdt->ctrl &= ~(MXC_F_WDT_REVB_CTRL_INT_LATE | MXC_F_WDT_REVB_CTRL_INT_EARLY);
 }
+
+void MXC_WDT_RevB_SetClockSource(mxc_wdt_revb_regs_t *wdt, int clock_source)
+{
+    MXC_SETFIELD(wdt->clksel, MXC_F_WDT_REVB_CLKSEL_SOURCE,
+                 (clock_source << MXC_F_WDT_REVB_CLKSEL_SOURCE_POS));
+}

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_revb.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_revb.c
@@ -157,6 +157,9 @@ void MXC_WDT_RevB_ClearIntFlag(mxc_wdt_revb_regs_t *wdt)
 
 void MXC_WDT_RevB_SetClockSource(mxc_wdt_revb_regs_t *wdt, int clock_source)
 {
+    const uint8_t clock_source_num = 8; // Max number of clock sources for Rev B WDT
+
+    MXC_ASSERT((clock_source < clock_source_num) && (clock_source >= 0));
     MXC_SETFIELD(wdt->clksel, MXC_F_WDT_REVB_CLKSEL_SOURCE,
                  (clock_source << MXC_F_WDT_REVB_CLKSEL_SOURCE_POS));
 }

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_revb.h
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_revb.h
@@ -110,5 +110,6 @@ int MXC_WDT_RevB_GetResetFlag(mxc_wdt_revb_regs_t *wdt);
 void MXC_WDT_RevB_ClearResetFlag(mxc_wdt_revb_regs_t *wdt);
 int MXC_WDT_RevB_GetIntFlag(mxc_wdt_revb_regs_t *wdt);
 void MXC_WDT_RevB_ClearIntFlag(mxc_wdt_revb_regs_t *wdt);
+void MXC_WDT_RevB_SetClockSource(mxc_wdt_revb_regs_t *wdt, int clock_source);
 
 #endif // LIBRARIES_PERIPHDRIVERS_SOURCE_WDT_WDT_REVB_H_


### PR DESCRIPTION
## Pull Request Template

### Description

WDT peripheral of MAX32655, MAX32662, MAX32670, MAX32672, MAX32675, MAX32680, MAX32690, MAX78000 and MAX78002 supports selecting different clock sources which are given in user guide. 
Added a new function to set clksel register on revB WDT driver.
Added a new function to select supported clock sources for these part numbers.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.