### PR TITLE
feat(PeriphDrivers): Allow Skipping Clock and GPIO Initialization on Additional Peripherals

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32570/owm.h
+++ b/Libraries/PeriphDrivers/Include/MAX32570/owm.h
@@ -92,7 +92,8 @@ typedef struct {
 /**
  * @brief   Initialize and enable OWM module.
  * @param   cfg         Pointer to OWM configuration.
- * @param   map         MAP_A, MAP_B or MAP_C onewire pins select
+ * @param   map         MAP_A, MAP_B or MAP_C onewire pins select. Has no effect 
+ *                      incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  #E_NO_ERROR if everything is successful
  * @return  #E_NULL_PTR if parameter is a null pointer

--- a/Libraries/PeriphDrivers/Include/MAX32660/uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/uart.h
@@ -176,7 +176,8 @@ struct _mxc_uart_req_t {
  * @param   uart            Pointer to UART registers (selects the UART block used.)
  * @param   baud            The requested clock frequency. The actual clock frequency
  *                          will be returned by the function if successful.
- * @param   map             Selects which pin map to use.
+ * @param   map             Selects which pin map to use. Has no effect incase of 
+ *                          MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  If successful, the actual clock frequency is returned. Otherwise, see
  *          \ref MXC_Error_Codes for a list of return codes.

--- a/Libraries/PeriphDrivers/Include/MAX32665/owm.h
+++ b/Libraries/PeriphDrivers/Include/MAX32665/owm.h
@@ -111,7 +111,8 @@ typedef struct {
 /**
  * @brief   Initialize and enable OWM module.
  * @param   cfg         Pointer to OWM configuration.
- * @param   map         MAP_A, MAP_B or MAP_C onewire pins select
+ * @param   map         MAP_A, MAP_B or MAP_C onewire pins select. Has no effect 
+ *                      incase of MSDK_NO_GPIO_CLK_INIT has been defined.
  *
  * @return  #E_NO_ERROR if everything is successful
  * @return  #E_NULL_PTR if parameter is a null pointer

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me10.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me10.c
@@ -62,8 +62,10 @@
 // ********************************************************************************
 int MXC_ADC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_Reset_Periph(MXC_SYS_RESET_ADC);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ADC);
+#endif
 
     return MXC_ADC_RevA_Init((mxc_adc_reva_regs_t *)MXC_ADC);
 }

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
@@ -114,8 +114,10 @@ static void initGPIOForTrigSrc(mxc_adc_trig_sel_t hwTrig)
 
 int MXC_ADC_Init(mxc_adc_req_t *req)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_Reset_Periph(MXC_SYS_RESET0_ADC);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ADC);
+#endif
 
     MXC_ADC_ReferenceSelect(req->ref);
 

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me13.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me13.c
@@ -43,9 +43,11 @@
 
 int MXC_ADC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_Reset_Periph(MXC_SYS_RESET0_ADC);
 
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ADC);
+#endif
 
     //turn on charge pump enable (chip specific)
     MXC_ADC->ctrl |= MXC_F_ADC_CTRL_CHGPUMP_PWR;

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me14.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me14.c
@@ -61,6 +61,7 @@
 
 int MXC_ADC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_GCR->rstr0 |= MXC_F_GCR_RSTR0_ADC;
 
     // Reset ADC block
@@ -68,6 +69,7 @@ int MXC_ADC_Init(void)
 
     // Enable ADC peripheral clock
     MXC_GCR->perckcn0 &= ~MXC_F_GCR_PERCKCN0_ADCD;
+#endif
 
     return MXC_ADC_RevA_Init((mxc_adc_reva_regs_t *)MXC_ADC);
 }

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me17.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me17.c
@@ -102,9 +102,11 @@ static void initGPIOForChannel(mxc_adc_chsel_t channel)
 
 int MXC_ADC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_Reset_Periph(MXC_SYS_RESET0_ADC);
 
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ADC);
+#endif
 
     return MXC_ADC_RevA_Init((mxc_adc_reva_regs_t *)MXC_ADC);
 }

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
@@ -133,11 +133,13 @@ static void initGPIOForTrigSrc(mxc_adc_trig_sel_t hwTrig)
 
 int MXC_ADC_Init(mxc_adc_req_t *req)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_Reset_Periph(MXC_SYS_RESET0_ADC);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ADC);
 
     /* This is required for temperature sensor only */
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif
 
     MXC_ADC_ReferenceSelect(req->ref);
 

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me21.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me21.c
@@ -166,6 +166,7 @@ static void initGPIOforHWTrig(mxc_adc_trig_sel_t hwTrig)
 
 int MXC_ADC_Init(mxc_adc_req_t *req)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     /* ADC in reset state */
     switch (req->clock) {
     case MXC_ADC_CLK_HCLK:
@@ -189,6 +190,7 @@ int MXC_ADC_Init(mxc_adc_req_t *req)
 
     /* This is required for temperature sensor only */
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO);
+#endif
 
     MXC_ADC_ReferenceSelect(req->ref);
 

--- a/Libraries/PeriphDrivers/Source/ADC/adc_me55.c
+++ b/Libraries/PeriphDrivers/Source/ADC/adc_me55.c
@@ -44,9 +44,11 @@
 
 int MXC_ADC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_Reset_Periph(MXC_SYS_RESET0_ADC);
 
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ADC);
+#endif
 
     //turn on charge pump enable (chip specific)
     MXC_ADC->ctrl |= MXC_F_ADC_CTRL_CHGPUMP_PWR;

--- a/Libraries/PeriphDrivers/Source/AES/aes_ai87.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_ai87.c
@@ -68,8 +68,10 @@
 
 int MXC_AES_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_AES);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_AES->ctrl = 0x00;
     // Start with a randomly generated key.

--- a/Libraries/PeriphDrivers/Source/AES/aes_me12.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me12.c
@@ -67,8 +67,10 @@
 
 int MXC_AES_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_AES);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return MXC_AES_RevB_Init((mxc_aes_revb_regs_t *)MXC_AES);
 }

--- a/Libraries/PeriphDrivers/Source/AES/aes_me15.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me15.c
@@ -85,8 +85,10 @@ static void reverse_key(const void *key, uint8_t *keyr, int len)
 
 int MXC_AES_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_AES);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_AES->ctrl = 0x00;
     // Start with a randomly generated key.

--- a/Libraries/PeriphDrivers/Source/AES/aes_me17.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me17.c
@@ -68,8 +68,10 @@
 
 int MXC_AES_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_AES);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return MXC_AES_RevB_Init((mxc_aes_revb_regs_t *)MXC_AES);
 }

--- a/Libraries/PeriphDrivers/Source/AES/aes_me18.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me18.c
@@ -67,8 +67,10 @@
 
 int MXC_AES_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_AES);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return MXC_AES_RevB_Init((mxc_aes_revb_regs_t *)MXC_AES);
 }

--- a/Libraries/PeriphDrivers/Source/AES/aes_me21.c
+++ b/Libraries/PeriphDrivers/Source/AES/aes_me21.c
@@ -66,8 +66,10 @@
 
 int MXC_AES_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_AES);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_AES_RevB_Init((mxc_aes_revb_regs_t *)MXC_AES);
 

--- a/Libraries/PeriphDrivers/Source/CRC/crc_ai87.c
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_ai87.c
@@ -63,7 +63,9 @@
 
 int MXC_CRC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CRC);
+#endif
 
     MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC);
 

--- a/Libraries/PeriphDrivers/Source/CRC/crc_me15.c
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_me15.c
@@ -63,7 +63,9 @@
 
 int MXC_CRC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CRC);
+#endif
 
     MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC);
 

--- a/Libraries/PeriphDrivers/Source/CRC/crc_me16.c
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_me16.c
@@ -63,7 +63,9 @@
 
 int MXC_CRC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CRC);
+#endif
 
     MXC_CRC_RevA_Init();
 

--- a/Libraries/PeriphDrivers/Source/CRC/crc_me17.c
+++ b/Libraries/PeriphDrivers/Source/CRC/crc_me17.c
@@ -63,7 +63,9 @@
 
 int MXC_CRC_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_CRC);
+#endif
 
     MXC_CRC_RevA_Init((mxc_crc_reva_regs_t *)MXC_CRC);
 

--- a/Libraries/PeriphDrivers/Source/HTMR/htmr_me13.c
+++ b/Libraries/PeriphDrivers/Source/HTMR/htmr_me13.c
@@ -50,6 +50,7 @@ int MXC_HTMR_Init(mxc_htmr_regs_t *htmr, uint32_t longInterval, uint8_t shortInt
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO) != E_NO_ERROR) {
         return E_TIME_OUT;
     }
@@ -61,6 +62,7 @@ int MXC_HTMR_Init(mxc_htmr_regs_t *htmr, uint32_t longInterval, uint8_t shortInt
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     return MXC_HTMR_RevA_Init((mxc_htmr_reva_regs_t *)htmr, longInterval, shortInterval);
 }

--- a/Libraries/PeriphDrivers/Source/HTMR/htmr_me14.c
+++ b/Libraries/PeriphDrivers/Source/HTMR/htmr_me14.c
@@ -68,6 +68,7 @@ int MXC_HTMR_Init(mxc_htmr_regs_t *htmr, uint32_t longInterval, uint8_t shortInt
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_HIRC8) != E_NO_ERROR) {
         return E_TIME_OUT;
     }
@@ -79,6 +80,7 @@ int MXC_HTMR_Init(mxc_htmr_regs_t *htmr, uint32_t longInterval, uint8_t shortInt
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     return MXC_HTMR_RevA_Init((mxc_htmr_reva_regs_t *)htmr, longInterval, shortInterval);
 }

--- a/Libraries/PeriphDrivers/Source/HTMR/htmr_me55.c
+++ b/Libraries/PeriphDrivers/Source/HTMR/htmr_me55.c
@@ -50,6 +50,7 @@ int MXC_HTMR_Init(mxc_htmr_regs_t *htmr, uint32_t longInterval, uint8_t shortInt
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_IBRO) != E_NO_ERROR) {
         return E_TIME_OUT;
     }
@@ -61,6 +62,7 @@ int MXC_HTMR_Init(mxc_htmr_regs_t *htmr, uint32_t longInterval, uint8_t shortInt
     } else {
         return E_BAD_PARAM;
     }
+#endif
 
     return MXC_HTMR_RevA_Init((mxc_htmr_reva_regs_t *)htmr, longInterval, shortInterval);
 }

--- a/Libraries/PeriphDrivers/Source/OWM/owm_ai87.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_ai87.c
@@ -69,6 +69,7 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Set system level configurations
     mxc_gpio_regs_t *gpio = gpio_cfg_owm.port;
 
@@ -78,6 +79,7 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
     if ((err = MXC_GPIO_Config(&gpio_cfg_owm)) != E_NO_ERROR) {
         return err;
     }
+#endif
 
     // Configure clk divisor to get 1MHz OWM clk
     mxc_owm_clk = PeripheralClock;

--- a/Libraries/PeriphDrivers/Source/OWM/owm_me10.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_me10.c
@@ -74,9 +74,11 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Set system level configurations
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_OWIRE);
     MXC_GPIO_Config(&gpio_cfg_owm);
+#endif
 
     // Configure clk divisor to get 1MHz OWM clk
     mxc_owm_clk = PeripheralClock;

--- a/Libraries/PeriphDrivers/Source/OWM/owm_me13.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_me13.c
@@ -54,6 +54,7 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg, sys_map_t map)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Set system level configurations
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_OWIRE);
 
@@ -73,6 +74,9 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg, sys_map_t map)
     if ((err = MXC_GPIO_Config(gpio)) != E_NO_ERROR) {
         return err;
     }
+#else
+    (void)map;
+#endif
 
     // Configure clk divisor to get 1MHz OWM clk
     mxc_owm_clk = PeripheralClock;

--- a/Libraries/PeriphDrivers/Source/OWM/owm_me14.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_me14.c
@@ -69,6 +69,7 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg, sys_map_t map)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     // Set system level configurations
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_OWIRE);
 
@@ -91,6 +92,9 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg, sys_map_t map)
     if ((err = MXC_GPIO_Config(gpio)) != E_NO_ERROR) {
         return err;
     }
+#else
+    (void)map;
+#endif
 
     // Configure clk divisor to get 1MHz OWM clk
     mxc_owm_clk = PeripheralClock;

--- a/Libraries/PeriphDrivers/Source/OWM/owm_me17.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_me17.c
@@ -69,11 +69,13 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_OWIRE);
 
     if ((err = MXC_GPIO_Config(&gpio_cfg_owm)) != E_NO_ERROR) {
         return err;
     }
+#endif
 
     // Configure clk divisor to get 1MHz OWM clk
     mxc_owm_clk = PeripheralClock;

--- a/Libraries/PeriphDrivers/Source/OWM/owm_me18.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_me18.c
@@ -69,11 +69,13 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
         return E_NULL_PTR;
     }
 
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_OWIRE);
 
     if ((err = MXC_GPIO_Config(&gpio_cfg_owm)) != E_NO_ERROR) {
         return err;
     }
+#endif
 
     // Configure clk divisor to get 1MHz OWM clk
     mxc_owm_clk = PeripheralClock;

--- a/Libraries/PeriphDrivers/Source/SPIMSS/i2s_me10.c
+++ b/Libraries/PeriphDrivers/Source/SPIMSS/i2s_me10.c
@@ -67,8 +67,10 @@ mxc_i2s_direction_t dir;
 /* ************************************************************************* */
 int MXC_I2S_Init(const mxc_i2s_config_t *cfg, void (*dma_ctz_cb)(int, int))
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_I2S);
     MXC_GPIO_Config(&gpio_cfg_i2s);
+#endif
 
     return MXC_I2S_RevA_Init((mxc_spimss_reva_regs_t *)MXC_SPIMSS, cfg, dma_ctz_cb);
 }

--- a/Libraries/PeriphDrivers/Source/SPIMSS/i2s_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPIMSS/i2s_me11.c
@@ -74,6 +74,7 @@ int dma_channel = -1;
 
 int MXC_I2S_Init(const mxc_i2s_config_t *config, void (*dma_ctz_cb)(int, int))
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     if (config->map == I2S_MAP_A) {
         MXC_GPIO_Config(&gpio_cfg_spi1a); // SPIMSS: I2S and SPI share pins
     } else if (config->map == I2S_MAP_B) {
@@ -83,6 +84,7 @@ int MXC_I2S_Init(const mxc_i2s_config_t *config, void (*dma_ctz_cb)(int, int))
     }
 
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPI1); // SPI1 clock used for SPIMSS
+#endif
 
     return MXC_I2S_RevA_Init((mxc_spimss_reva_regs_t *)MXC_SPIMSS, config, dma_ctz_cb);
 }

--- a/Libraries/PeriphDrivers/Source/SPIXF/spixf_me10.c
+++ b/Libraries/PeriphDrivers/Source/SPIXF/spixf_me10.c
@@ -65,10 +65,12 @@
 /* ************************************************************************** */
 int MXC_SPIXF_Init(uint32_t cmdval, uint32_t frequency)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXIPF);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXIPM);
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ICACHEXIP);
     MXC_GPIO_Config(&gpio_cfg_spixfc);
+#endif
 
     MXC_SPIXF_RevA_Init((mxc_spixfc_reva_regs_t *)MXC_SPIXFC, (mxc_spixfm_reva_regs_t *)MXC_SPIXF,
                         cmdval, frequency);

--- a/Libraries/PeriphDrivers/Source/SPIXF/spixf_me13.c
+++ b/Libraries/PeriphDrivers/Source/SPIXF/spixf_me13.c
@@ -45,10 +45,12 @@
 
 int MXC_SPIXF_Init(uint32_t cmdval, uint32_t frequency)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXIP); // SPIX
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXFC); // SPIXFC
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ICACHEXIP); // XIP ICACHE
     MXC_GPIO_Config(&gpio_cfg_spixf);
+#endif
 
     return MXC_SPIXF_RevA_Init((mxc_spixfc_reva_regs_t *)MXC_SPIXFC,
                                (mxc_spixfm_reva_regs_t *)MXC_SPIXFM, cmdval, frequency);

--- a/Libraries/PeriphDrivers/Source/SPIXF/spixf_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPIXF/spixf_me14.c
@@ -63,10 +63,12 @@
 
 int MXC_SPIXF_Init(uint32_t cmdval, uint32_t frequency)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXIP); // SPIX
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXFC); // SPIXFC
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ICACHEXIP); // XIP ICACHE
     MXC_GPIO_Config(&gpio_cfg_spixfc);
+#endif
 
     return MXC_SPIXF_RevA_Init((mxc_spixfc_reva_regs_t *)MXC_SPIXFC,
                                (mxc_spixfm_reva_regs_t *)MXC_SPIXFM, cmdval, frequency);

--- a/Libraries/PeriphDrivers/Source/SPIXF/spixf_me18.c
+++ b/Libraries/PeriphDrivers/Source/SPIXF/spixf_me18.c
@@ -63,8 +63,10 @@
 
 int MXC_SPIXF_Init(uint32_t cmdval, uint32_t frequency)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXIP); // SPIX
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXIPC); // SPIXFC
+#endif
 
     return MXC_SPIXF_RevA_Init((mxc_spixfc_reva_regs_t *)MXC_SPIXFC,
                                (mxc_spixfm_reva_regs_t *)MXC_SPIXFM, cmdval, frequency);

--- a/Libraries/PeriphDrivers/Source/SPIXF/spixf_me55.c
+++ b/Libraries/PeriphDrivers/Source/SPIXF/spixf_me55.c
@@ -45,10 +45,12 @@
 
 int MXC_SPIXF_Init(uint32_t cmdval, uint32_t frequency)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXIP); // SPIX
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SPIXFC); // SPIXFC
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_ICACHEXIP); // XIP ICACHE
     MXC_GPIO_Config(&gpio_cfg_spixf);
+#endif
 
     return MXC_SPIXF_RevA_Init((mxc_spixfc_reva_regs_t *)MXC_SPIXFC,
                                (mxc_spixfm_reva_regs_t *)MXC_SPIXFM, cmdval, frequency);

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_ai85.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_ai85.c
@@ -69,7 +69,9 @@
 
 int MXC_TRNG_Init()
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_ai87.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_ai87.c
@@ -69,7 +69,9 @@
 
 int MXC_TRNG_Init()
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me10.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me10.c
@@ -67,7 +67,9 @@
 // *********************************************************************
 int MXC_TRNG_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     return MXC_TRNG_RevA_Init();
 }

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me12.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me12.c
@@ -69,7 +69,9 @@
 
 int MXC_TRNG_Init()
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me14.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me14.c
@@ -69,7 +69,9 @@
 
 int MXC_TRNG_Init()
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me15.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me15.c
@@ -64,7 +64,9 @@
 
 int MXC_TRNG_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me16.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me16.c
@@ -64,7 +64,9 @@
 
 int MXC_TRNG_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me17.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me17.c
@@ -69,7 +69,9 @@
 
 int MXC_TRNG_Init()
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me18.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me18.c
@@ -69,7 +69,9 @@
 
 int MXC_TRNG_Init()
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me20.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me20.c
@@ -69,7 +69,9 @@
 
 int MXC_TRNG_Init()
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/TRNG/trng_me21.c
+++ b/Libraries/PeriphDrivers/Source/TRNG/trng_me21.c
@@ -64,7 +64,9 @@
 
 int MXC_TRNG_Init(void)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_TRNG);
+#endif
 
     MXC_TRNG_RevB_Init();
 

--- a/Libraries/PeriphDrivers/Source/UART/uart_es17.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_es17.c
@@ -74,6 +74,7 @@ int MXC_UART_AsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
@@ -92,6 +93,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud)
         return E_BAD_PARAM;
         break;
     }
+#endif
 
     return MXC_UART_RevC_Init((mxc_uart_revc_regs_t *)uart, baud);
 }

--- a/Libraries/PeriphDrivers/Source/UART/uart_me10.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me10.c
@@ -99,6 +99,7 @@ static mxc_uart_req_t *tx_states[MXC_UART_INSTANCES];
 /* ************************************************************************* */
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int err;
 
     if ((err = MXC_UART_Shutdown(uart)) != E_NO_ERROR) {
@@ -122,6 +123,7 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud)
     default:
         return E_BAD_PARAM;
     }
+#endif
 
     // Clear pending requests
     rx_states[MXC_UART_GET_IDX(uart)] = NULL;

--- a/Libraries/PeriphDrivers/Source/UART/uart_me11.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me11.c
@@ -94,6 +94,7 @@ int MXC_UART_RxAsyncStop(mxc_uart_regs_t *uart)
 
 int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, sys_map_t map)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     int retval;
 
     retval = MXC_UART_Shutdown(uart);
@@ -127,6 +128,9 @@ int MXC_UART_Init(mxc_uart_regs_t *uart, unsigned int baud, sys_map_t map)
         return E_BAD_PARAM;
         break;
     }
+#else
+    (void)map;
+#endif
 
     return MXC_UART_RevA_Init(((mxc_uart_reva_regs_t *)uart), baud);
 }

--- a/Libraries/PeriphDrivers/Source/WUT/wut_ai85.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_ai85.c
@@ -82,7 +82,9 @@ static mxc_wut_complete_cb_t cb_async;
 /* ************************************************************************** */
 void MXC_WUT_Init(mxc_wut_pres_t pres)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif
     MXC_WUT_RevA_Init((mxc_wut_reva_regs_t *)MXC_WUT, pres);
 }
 

--- a/Libraries/PeriphDrivers/Source/WUT/wut_ai87.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_ai87.c
@@ -66,7 +66,9 @@
 /* ************************************************************************** */
 void MXC_WUT_Init(mxc_wut_pres_t pres)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif
     MXC_WUT_RevA_Init((mxc_wut_reva_regs_t *)MXC_WUT, pres);
 }
 

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me14.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me14.c
@@ -82,7 +82,9 @@ static mxc_wut_complete_cb_t cb_async;
 /* ************************************************************************** */
 void MXC_WUT_Init(mxc_wut_pres_t pres)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_XTAL32K);
+#endif
     MXC_WUT_RevA_Init((mxc_wut_reva_regs_t *)MXC_WUT, pres);
 }
 

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me17.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me17.c
@@ -82,7 +82,9 @@ static mxc_wut_complete_cb_t cb_async;
 /* ************************************************************************** */
 void MXC_WUT_Init(mxc_wut_regs_t *wut, mxc_wut_pres_t pres)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif
     MXC_WUT_RevA_Init((mxc_wut_reva_regs_t *)wut, pres);
 }
 

--- a/Libraries/PeriphDrivers/Source/WUT/wut_me18.c
+++ b/Libraries/PeriphDrivers/Source/WUT/wut_me18.c
@@ -82,7 +82,9 @@ static mxc_wut_complete_cb_t cb_async;
 /* ************************************************************************** */
 void MXC_WUT_Init(mxc_wut_pres_t pres)
 {
+#ifndef MSDK_NO_GPIO_CLK_INIT
     MXC_SYS_ClockSourceEnable(MXC_SYS_CLOCK_ERTCO);
+#endif
     MXC_WUT_RevA_Init((mxc_wut_reva_regs_t *)MXC_WUT, pres);
 }
 


### PR DESCRIPTION
## Pull Request Template

### Description

Propagate changes in this https://github.com/Analog-Devices-MSDK/msdk/pull/730 to other peripherals.
The purpose of this change is to provide a way to the use pass clock & gpio initialization. Changes applied to below peripherals.
- ADC
- OWM
- UART
- AES/CRC/TRNG
- HTMR
- WUT
- SPIXF/ SPIMSS

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
