### PR TITLE
fix(PeriphDrivers): Fix OWM Presence Detect Bit and GPIO Alternate Functions, Use VDDIOH by Default

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Include/max32650.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Include/max32650.svd
@@ -6091,7 +6091,7 @@
       <field>
        <name>presence_detect</name>
        <description>Presence Pulse Detected.</description>
-       <bitRange>[5:5]</bitRange>
+       <bitRange>[7:7]</bitRange>
        <access>read-only</access>
       </field>
      </fields>

--- a/Libraries/CMSIS/Device/Maxim/MAX32650/Include/owm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32650/Include/owm_regs.h
@@ -192,7 +192,7 @@ typedef struct {
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS           4 /**< CTRL_STAT_OD_SPEC_MODE Position */
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE               ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS)) /**< CTRL_STAT_OD_SPEC_MODE Mask */
 
-#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        5 /**< CTRL_STAT_PRESENCE_DETECT Position */
+#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        7 /**< CTRL_STAT_PRESENCE_DETECT Position */
 #define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT            ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS)) /**< CTRL_STAT_PRESENCE_DETECT Mask */
 
 /**@} end of group OWM_CTRL_STAT_Register */

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/max32655.svd
@@ -7216,7 +7216,7 @@
       <field>
        <name>presence_detect</name>
        <description>Presence Pulse Detected.</description>
-       <bitRange>[5:5]</bitRange>
+       <bitRange>[7:7]</bitRange>
        <access>read-only</access>
       </field>
      </fields>

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Include/owm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Include/owm_regs.h
@@ -192,7 +192,7 @@ typedef struct {
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS           4 /**< CTRL_STAT_OD_SPEC_MODE Position */
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE               ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS)) /**< CTRL_STAT_OD_SPEC_MODE Mask */
 
-#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        5 /**< CTRL_STAT_PRESENCE_DETECT Position */
+#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        7 /**< CTRL_STAT_PRESENCE_DETECT Position */
 #define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT            ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS)) /**< CTRL_STAT_PRESENCE_DETECT Mask */
 
 /**@} end of group OWM_CTRL_STAT_Register */

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Include/max32680.svd
@@ -7152,7 +7152,7 @@
       <field>
        <name>presence_detect</name>
        <description>Presence Pulse Detected.</description>
-       <bitRange>[5:5]</bitRange>
+       <bitRange>[7:7]</bitRange>
        <access>read-only</access>
       </field>
      </fields>

--- a/Libraries/CMSIS/Device/Maxim/MAX32680/Include/owm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32680/Include/owm_regs.h
@@ -192,7 +192,7 @@ typedef struct {
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS           4 /**< CTRL_STAT_OD_SPEC_MODE Position */
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE               ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS)) /**< CTRL_STAT_OD_SPEC_MODE Mask */
 
-#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        5 /**< CTRL_STAT_PRESENCE_DETECT Position */
+#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        7 /**< CTRL_STAT_PRESENCE_DETECT Position */
 #define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT            ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS)) /**< CTRL_STAT_PRESENCE_DETECT Mask */
 
 /**@} end of group OWM_CTRL_STAT_Register */

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Include/max78000.svd
@@ -7262,7 +7262,7 @@
       <field>
        <name>presence_detect</name>
        <description>Presence Pulse Detected.</description>
-       <bitRange>[5:5]</bitRange>
+       <bitRange>[7:7]</bitRange>
        <access>read-only</access>
       </field>
      </fields>

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Include/owm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Include/owm_regs.h
@@ -192,7 +192,7 @@ typedef struct {
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS           4 /**< CTRL_STAT_OD_SPEC_MODE Position */
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE               ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS)) /**< CTRL_STAT_OD_SPEC_MODE Mask */
 
-#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        5 /**< CTRL_STAT_PRESENCE_DETECT Position */
+#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        7 /**< CTRL_STAT_PRESENCE_DETECT Position */
 #define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT            ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS)) /**< CTRL_STAT_PRESENCE_DETECT Mask */
 
 /**@} end of group OWM_CTRL_STAT_Register */

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/max78002.svd
@@ -11112,7 +11112,7 @@
       <field>
        <name>presence_detect</name>
        <description>Presence Pulse Detected.</description>
-       <bitRange>[5:5]</bitRange>
+       <bitRange>[7:7]</bitRange>
        <access>read-only</access>
       </field>
      </fields>

--- a/Libraries/CMSIS/Device/Maxim/MAX78002/Include/owm_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX78002/Include/owm_regs.h
@@ -192,7 +192,7 @@ typedef struct {
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS           4 /**< CTRL_STAT_OD_SPEC_MODE Position */
 #define MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE               ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_OD_SPEC_MODE_POS)) /**< CTRL_STAT_OD_SPEC_MODE Mask */
 
-#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        5 /**< CTRL_STAT_PRESENCE_DETECT Position */
+#define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS        7 /**< CTRL_STAT_PRESENCE_DETECT Position */
 #define MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT            ((uint32_t)(0x1UL << MXC_F_OWM_CTRL_STAT_PRESENCE_DETECT_POS)) /**< CTRL_STAT_PRESENCE_DETECT Mask */
 
 /**@} end of group OWM_CTRL_STAT_Register */

--- a/Libraries/PeriphDrivers/Source/OWM/owm_me17.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_me17.c
@@ -69,11 +69,7 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
         return E_NULL_PTR;
     }
 
-    // Set system level configurations
-    mxc_gpio_regs_t *gpio = gpio_cfg_owm.port;
-
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_OWIRE);
-    gpio->vssel |= gpio_cfg_owm.mask; // 1-Wire pins need to be at 3.3V.
 
     if ((err = MXC_GPIO_Config(&gpio_cfg_owm)) != E_NO_ERROR) {
         return err;

--- a/Libraries/PeriphDrivers/Source/OWM/owm_me18.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_me18.c
@@ -69,11 +69,7 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg)
         return E_NULL_PTR;
     }
 
-    // Set system level configurations
-    mxc_gpio_regs_t *gpio = gpio_cfg_owm.port;
-
     MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_OWIRE);
-    gpio->vssel |= gpio_cfg_owm.mask; // 1-Wire pins need to be at 3.3V.
 
     if ((err = MXC_GPIO_Config(&gpio_cfg_owm)) != E_NO_ERROR) {
         return err;

--- a/Libraries/PeriphDrivers/Source/OWM/owm_reva_ai87.svd
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_reva_ai87.svd
@@ -128,7 +128,7 @@
           <field>
             <name>presence_detect</name>
             <description>Presence Pulse Detected.</description>
-            <bitRange>[5:5]</bitRange>
+            <bitRange>[7:7]</bitRange>
             <access>read-only</access>
           </field>
         </fields>

--- a/Libraries/PeriphDrivers/Source/OWM/owm_reva_me10.svd
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_reva_me10.svd
@@ -128,7 +128,7 @@
           <field>
             <name>presence_detect</name>
             <description>Presence Pulse Detected.</description>
-            <bitRange>[5:5]</bitRange>
+            <bitRange>[7:7]</bitRange>
             <access>read-only</access>
           </field>
         </fields>

--- a/Libraries/PeriphDrivers/Source/OWM/owm_reva_me17.svd
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_reva_me17.svd
@@ -128,7 +128,7 @@
           <field>
             <name>presence_detect</name>
             <description>Presence Pulse Detected.</description>
-            <bitRange>[5:5]</bitRange>
+            <bitRange>[7:7]</bitRange>
             <access>read-only</access>
           </field>
         </fields>

--- a/Libraries/PeriphDrivers/Source/SYS/pins_ai87.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_ai87.c
@@ -116,10 +116,11 @@ const mxc_gpio_cfg_t gpio_cfg_i2s0 = { MXC_GPIO1, (MXC_GPIO_PIN_2 | MXC_GPIO_PIN
 const mxc_gpio_cfg_t gpio_cfg_i2s0_extclk = { MXC_GPIO0, (MXC_GPIO_PIN_14), MXC_GPIO_FUNC_ALT2,
                                               MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
+// 1-Wire pins need to be at 3.3V so that MXC_GPIO_VSSEL_VDDIOH is selected.
 const mxc_gpio_cfg_t gpio_cfg_owm = { MXC_GPIO0, (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7), MXC_GPIO_FUNC_ALT2,
-                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_owmb = { MXC_GPIO0, (MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19), MXC_GPIO_FUNC_ALT2,
-                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
 
 const mxc_gpio_cfg_t gpio_cfg_rtcsqw = { MXC_GPIO3, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_ALT1,
                                          MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me10.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me10.c
@@ -214,6 +214,7 @@ const mxc_gpio_cfg_t gpio_cfg_sdhc_1 = { MXC_GPIO1, (MXC_GPIO_PIN_0 | MXC_GPIO_P
                                          MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5 | MXC_GPIO_PIN_6), MXC_GPIO_FUNC_ALT1,
                                          MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
+// 1-Wire pins need to be at 3.3V so that MXC_GPIO_VSSEL_VDDIOH is selected.
 const mxc_gpio_cfg_t gpio_cfg_owm = { MXC_GPIO1, (MXC_GPIO_PIN_30 | MXC_GPIO_PIN_31), MXC_GPIO_FUNC_ALT1,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
 

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me17.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me17.c
@@ -136,8 +136,11 @@ const mxc_gpio_cfg_t gpio_cfg_pt2 = { MXC_GPIO0, MXC_GPIO_PIN_16, MXC_GPIO_FUNC_
 const mxc_gpio_cfg_t gpio_cfg_pt3 = { MXC_GPIO0, MXC_GPIO_PIN_17, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
-const mxc_gpio_cfg_t gpio_cfg_owm = { MXC_GPIO0, (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7), MXC_GPIO_FUNC_ALT1,
-                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+// 1-Wire pins need to be at 3.3V so that MXC_GPIO_VSSEL_VDDIOH is selected.
+const mxc_gpio_cfg_t gpio_cfg_owm = { MXC_GPIO0, (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7), MXC_GPIO_FUNC_ALT2,
+                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_owmb = { MXC_GPIO0, (MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19), MXC_GPIO_FUNC_ALT2,
+                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
 
 const mxc_gpio_cfg_t gpio_cfg_adc_ain0 = { MXC_GPIO2, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT1,
                                            MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me18.c
@@ -234,8 +234,11 @@ const mxc_gpio_cfg_t gpio_cfg_pt14 = { MXC_GPIO2, MXC_GPIO_PIN_28, MXC_GPIO_FUNC
 const mxc_gpio_cfg_t gpio_cfg_pt15 = { MXC_GPIO2, MXC_GPIO_PIN_12, MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
+// 1-Wire pins need to be at 3.3V so that MXC_GPIO_VSSEL_VDDIOH is selected.
 const mxc_gpio_cfg_t gpio_cfg_owm = { MXC_GPIO0, (MXC_GPIO_PIN_7 | MXC_GPIO_PIN_8), MXC_GPIO_FUNC_ALT1,
-                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_owmb = { MXC_GPIO1, (MXC_GPIO_PIN_30 | MXC_GPIO_PIN_31), MXC_GPIO_FUNC_ALT1,
+                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
 
 const mxc_gpio_cfg_t gpio_cfg_adc_ain0 = { MXC_GPIO3, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT1,
                                            MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };


### PR DESCRIPTION
## Pull Request Template

### Description

- MAX32655/ MAX78000/ MAX78002 presence detect bit is 7 not 5
- MAX32655 OWM GPIO alternate function 2 not 1
- MAX32655/MAX32690 OWM GPIO mapping B pins defined
- Unneeded code which set voltage source deleted from drivers
- Voltage source selected as VDDIOH to provide 3.3V.

Test output on MAX32655 with MAX31825 target
ROM ID read succeeded.
![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/34129e59-6b8a-4b29-ba53-bb2f94b46821)


### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [X] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.


PS: It will be nice to update init function to it take map parameters to select related gpio mapping but I am not sure whether API should be changed now or not. Changing API will break existing customer build system but i am not sure whether is there any one customer to use OWM API or not.
See [MAX32570 OWM init function](https://github.com/Analog-Devices-MSDK/msdk/blob/main/Libraries/PeriphDrivers/Include/MAX32570/owm.h#L104)