### PR TITLE
fix(PeriphDrivers): Fix MAX32672 `MXC_TMR_GetPeriod` for 16-32Mhz Clock

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
@@ -304,7 +304,8 @@ uint32_t MXC_TMR_GetPeriod(mxc_tmr_regs_t *tmr, mxc_tmr_clock_t clock, uint32_t 
             break;
 
         case MXC_TMR_32M_CLK:
-            clockFrequency = 16000000; // Clock Frequency 16 MHz
+            clockFrequency = ERFO_FREQ; // Note: Could vary between 16-32Mhz.  ERFO_FREQ should be
+                                        // overridden for custom designs.
             break;
 
         default:

--- a/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
@@ -305,7 +305,7 @@ uint32_t MXC_TMR_GetPeriod(mxc_tmr_regs_t *tmr, mxc_tmr_clock_t clock, uint32_t 
 
         case MXC_TMR_32M_CLK:
             clockFrequency = ERFO_FREQ; // Note: Could vary between 16-32Mhz.  ERFO_FREQ should be
-                                        // overridden for custom designs.
+                // overridden for custom designs.
             break;
 
         default:


### PR DESCRIPTION
### Description

Closes #810 

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
