### PR TITLE
fix(CMSIS): Vector table address now properly set

### DIFF
--- a/Libraries/CMSIS/5.9.0/Core/Include/core_rv32.h
+++ b/Libraries/CMSIS/5.9.0/Core/Include/core_rv32.h
@@ -484,7 +484,13 @@ __STATIC_INLINE uint32_t NVIC_GetPendingIRQ(IRQn_Type IRQn)
  */
 __STATIC_INLINE void NVIC_SetPendingIRQ(IRQn_Type IRQn)
 {
-    //NVIC->ISPR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* set interrupt pending */
+    if (IRQn < 32) {
+        MXC_INTR->irq0_set_pending |= (1 << IRQn);
+        MXC_EVENT->event0_set_pending |= (1 << IRQn);
+    } else {
+        MXC_INTR->irq1_set_pending |= (1 << (IRQn - 32));
+        MXC_EVENT->event1_set_pending |= (1 << (IRQn - 32));
+    }
 }
 
 /** \brief  Clear Pending Interrupt

--- a/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/startup_riscv_max32655.S
+++ b/Libraries/CMSIS/Device/Maxim/MAX32655/Source/GCC/startup_riscv_max32655.S
@@ -165,8 +165,9 @@ __isr_vector:
 Reset_Handler:
 
   /* set 0 in mtvec (base for IVT) */
-  csrrw x0, mtvec, x0
-
+  la t0, (__isr_vector + 1)
+  csrrw x0, mtvec, t0
+  
   /* Initialize Stack Pointer */
   la    sp, __StackTop
 

--- a/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/startup_riscv_max78000.S
+++ b/Libraries/CMSIS/Device/Maxim/MAX78000/Source/GCC/startup_riscv_max78000.S
@@ -126,9 +126,9 @@ __isr_vector:
     .globl   Reset_Handler
     .type    Reset_Handler, %function
 Reset_Handler:
-
-  /* set 0 in mtvec (base for IVT) */
-  csrrw x0, mtvec, x0
+  /* Load interrupt vector table */
+  la t0, (__isr_vector + 1)
+  csrrw x0, mtvec, t0
 
   /* Initialize Stack Pointer */
   la    sp, __StackTop


### PR DESCRIPTION

### Description
Inside the startup script for the RISCV MAX32655, the vector table was being set to 0, instead of the the ISR vector table so interrupts were not working correctly.
