### PR TITLE
fix(PeriphDrivers): Fix MAX32655 WDT clock source order

### DIFF
--- a/Libraries/PeriphDrivers/Source/OWM/owm_me14.c
+++ b/Libraries/PeriphDrivers/Source/OWM/owm_me14.c
@@ -124,7 +124,9 @@ int MXC_OWM_Init(const mxc_owm_cfg_t *cfg, sys_map_t map)
         return E_NOT_SUPPORTED;
     }
 
-    return MXC_OWM_RevA_Init((mxc_owm_reva_regs_t *)MXC_OWM, cfg);
+    err = MXC_OWM_RevA_Init((mxc_owm_reva_regs_t *)MXC_OWM, cfg);
+
+    return err;
 }
 
 void MXC_OWM_Shutdown(void)

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_me17.c
@@ -163,7 +163,7 @@ int MXC_WDT_SetClockSource(mxc_wdt_regs_t *wdt, mxc_wdt_clock_t clock_source)
 #if TARGET_NUM == 32655 || TARGET_NUM == 78000
     mxc_wdt_clock_t clock_sources[2][8] = {
         { MXC_WDT_PCLK, MXC_WDT_IBRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
-        { MXC_WDT_IBRO_CLK, MXC_WDT_ERTCO_CLK, MXC_WDT_INRO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
+        { MXC_WDT_IBRO_CLK, MXC_WDT_INRO_CLK, MXC_WDT_ERTCO_CLK, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
     };
 #elif TARGET_NUM == 32680
     mxc_wdt_clock_t clock_sources[2][8] = {

--- a/Libraries/PeriphDrivers/Source/WDT/wdt_revb.c
+++ b/Libraries/PeriphDrivers/Source/WDT/wdt_revb.c
@@ -158,6 +158,7 @@ void MXC_WDT_RevB_ClearIntFlag(mxc_wdt_revb_regs_t *wdt)
 void MXC_WDT_RevB_SetClockSource(mxc_wdt_revb_regs_t *wdt, int clock_source)
 {
     const uint8_t clock_source_num = 8; // Max number of clock sources for Rev B WDT
+    (void)clock_source_num;
 
     MXC_ASSERT((clock_source < clock_source_num) && (clock_source >= 0));
     MXC_SETFIELD(wdt->clksel, MXC_F_WDT_REVB_CLKSEL_SOURCE,


### PR DESCRIPTION
## Pull Request Template

### Description

WDT1(LPWDT0) clock sources order of MAX32655 is wrong in user guide.

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/94184469/db6a748b-e914-4f1b-a516-6d57d71590aa)

To test clock source selection feature on MAX32655 for LPWDT0, selected ERTCO(CLK1) as clock source and disabled it but WDT continued to work. Switched selected clock source to CLK2 which is INRO clock's slot according to the user guide and disabled ERTCO clock, then WDT stopped working. Given clock source order in user guide is wrong. Updated clock sources order for WDT1.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.