### PR TITLE
fix(PeriphDrivers): Fix MAX32675, MAX32680 A5 Silicon AFE Init, and Speedups

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32675/hart_uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/hart_uart.h
@@ -75,6 +75,7 @@ extern "C" {
 #define NORMAL_HART_TRANSCEIVE_MODE 0
 #define HART_TEST_MODE_TX_1200 1
 #define HART_TEST_MODE_TX_2200 2
+#define HART_TEST_MODE_EXTERNAL 3
 
 /** TPDLL Communications Errors, based on Command Summary Specification
     HCF-Spec099 Section 7.3.1 Table 10 Communication Status. */

--- a/Libraries/PeriphDrivers/Include/MAX32680/hart_uart.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/hart_uart.h
@@ -75,6 +75,7 @@ extern "C" {
 #define NORMAL_HART_TRANSCEIVE_MODE 0
 #define HART_TEST_MODE_TX_1200 1
 #define HART_TEST_MODE_TX_2200 2
+#define HART_TEST_MODE_EXTERNAL 3
 
 /** TPDLL Communications Errors, based on Command Summary Specification
     HCF-Spec099 Section 7.3.1 Table 10 Communication Status. */

--- a/Libraries/PeriphDrivers/Source/AFE/afe.c
+++ b/Libraries/PeriphDrivers/Source/AFE/afe.c
@@ -86,7 +86,7 @@
 #define AFE_SPI_PORT MXC_SPI1
 #endif
 
-#define AFE_SPI_BAUD 100000 // Can only run up to PCLK speed
+#define AFE_SPI_BAUD 1000000 // Can only run up to PCLK speed
 #define AFE_SPI_BIT_WIDTH 8
 #define AFE_SPI_SSEL_PIN 1
 #define AFE_SPI_ADDRESS_LEN 1
@@ -95,21 +95,32 @@
 //#define DUMP_TRIM_DATA
 
 //
+// Enabling this will use the afe timer to timeout polling of the AFE.
+//  This avoid any chance of the blocking function afe_spi_transceive from never returning.
+//  However, as this low level function can be called several times for even a single
+//  AFE register read, it decreases throughput to and from the AFE.
+//  When running at lower system clock frequencies this can be more of a concern.
+//
+//#define AFE_SPI_TRANSCEIVE_SAFE_BUT_SLOWER
+
+#ifdef AFE_SPI_TRANSCEIVE_SAFE_BUT_SLOWER
+//
 // This timeout prevents infinite loop if AFE is not responsive via SPI
 //
 //  Each read from AFE is 8 bits, unless CRC is enabled.
 //  maximum of 4 reads.
 //      1/AFE_SPI_BAUD * 4 * 8 should be a reasonable timeout for this.
-//      1/100000 = 10us * 4 * 8 = 320us
+//      1/1000000 = 1us * 4 * 8 = 32us
 //
-//  Since this is just for catastrophic lockup, lets round it up to 1000
+//  Since this is just for catastrophic lockup, lets round it up to 100
 //      this will also be a even multiple for MXC_AFE_SPI_RESET_TIMEOUT_ITERATES
 //
-#if (AFE_SPI_BAUD != 100000)
+#if (AFE_SPI_BAUD != 1000000)
 #warning "Recalculate MXC_AFE_SPI_READ_TIMEOUT, since baud rate was modified.\n"
 #endif
+#endif // End of AFE_SPI_TRANSCEIVE_SAFE_BUT_SLOWER
 
-#define MXC_AFE_SPI_READ_TIMEOUT USEC(1000)
+#define MXC_AFE_SPI_READ_TIMEOUT USEC(100)
 
 //
 // Initial AFE RESET time, up to 10 milliseconds
@@ -419,7 +430,12 @@ static int afe_spi_setup(void)
     return E_NO_ERROR;
 }
 
-// This function block until transceive is completed, or times out
+#ifdef AFE_SPI_TRANSCEIVE_SAFE_BUT_SLOWER
+//
+// This function blocks until transceive is completed, or times out
+//  To avoid possibility of getting stuck in a infinite loop, it uses the afe timer
+//  to timeout polling.
+//
 static int afe_spi_transceive(uint8_t *data, int byte_length)
 {
     int status = E_NO_ERROR;
@@ -536,6 +552,86 @@ static int afe_spi_transceive(uint8_t *data, int byte_length)
     // Got all bytes, and we did NOT timeout
     return E_NO_ERROR;
 }
+#else // Not AFE_SPI_TRANSCEIVE_SAFE_BUT_SLOWER
+
+//
+// This function blocks until transceive is completed, or times out
+//  This version does not use the afe timer to interrupt potential infinite polling.
+//
+static int afe_spi_transceive(uint8_t *data, int byte_length)
+{
+    int i = 0;
+
+    if (byte_length > AFE_SPI_MAX_DATA_LEN) {
+        return E_OVERFLOW;
+    }
+
+    //
+    // Ensure transmit FIFO is finished
+    // NOTE: if the AFE was reset during transaction this may not finish, so using a timeout
+    //
+    while ((pSPIm->dma & MXC_F_SPI_DMA_TX_LVL) != 0) {}
+
+    //
+    // If a transaction has been started, verify it completed before continuing
+    //
+    if (check_done) {
+        while (!(pSPIm->intfl & MXC_F_SPI_INTFL_MST_DONE)) {}
+    }
+
+    check_done = 1;
+
+    pSPIm->intfl = pSPIm->intfl;
+    pSPIm->dma |= (MXC_F_SPI_DMA_TX_FLUSH | MXC_F_SPI_DMA_RX_FLUSH);
+
+    while (pSPIm->dma & (MXC_F_SPI_DMA_TX_FLUSH | MXC_F_SPI_DMA_RX_FLUSH)) {}
+
+    pSPIm->ctrl1 = ((((byte_length) << MXC_F_SPI_CTRL1_TX_NUM_CHAR_POS)) |
+                    (byte_length << MXC_F_SPI_CTRL1_RX_NUM_CHAR_POS));
+
+    if (device_version < MXC_AFE_VERSION_POST_RESET) {
+        //
+        // Legacy: Disable pull down on MISO while transmitting.
+        //
+        AFE_SPI_MISO_GPIO_PORT->padctrl0 |= AFE_SPI_MISO_GPIO_PIN;
+    }
+
+    pSPIm->ctrl0 |= MXC_F_SPI_CTRL0_START;
+
+    // NOTE: At most we will read 32 bits before returning to processing, no streaming data
+
+    //
+    // Transmit the data
+    //
+    for (i = 0; i < byte_length; i++) {
+        pSPIm->fifo8[0] = data[i];
+    }
+
+    //
+    // Receive the data
+    //
+
+    // Reset byte counter
+    i = 0;
+
+    do {
+        if ((pSPIm->dma & MXC_F_SPI_DMA_RX_LVL)) {
+            data[i] = pSPIm->fifo8[0];
+            i++;
+        }
+    } while (i < byte_length);
+
+    if (device_version < MXC_AFE_VERSION_POST_RESET) {
+        //
+        // Legacy: Enable pull down on MISO while idle.
+        //
+        AFE_SPI_MISO_GPIO_PORT->padctrl0 |= AFE_SPI_MISO_GPIO_PIN;
+    }
+
+    // Got all bytes, and we did NOT timeout
+    return E_NO_ERROR;
+}
+#endif // End of else not AFE_SPI_TRANSCEIVE_SAFE_BUT_SLOWER
 
 static int afe_spi_poll_for_ready_post_reset_change(uint32_t *true_por)
 {

--- a/Libraries/PeriphDrivers/Source/AFE/afe.c
+++ b/Libraries/PeriphDrivers/Source/AFE/afe.c
@@ -764,7 +764,7 @@ static int afe_setup_non_por(void)
     // mask all bits but st_dis, or hart_en bits.
     read_val &= (MXC_F_AFE_ADC_ZERO_SYS_CTRL_HART_EN | MXC_F_AFE_ADC_ZERO_SYS_CTRL_ST_DIS);
 
-    if (device_version >= MXC_MAX32675_REV_B4) {
+    if (device_version >= MXC_AFE_VERSION_POST_RESET) {
         // ST_DIS MUST be set, and HART_EN MAY be set
         if ((read_val !=
              (MXC_F_AFE_ADC_ZERO_SYS_CTRL_HART_EN | MXC_F_AFE_ADC_ZERO_SYS_CTRL_ST_DIS)) &&
@@ -810,7 +810,7 @@ int afe_setup(mxc_tmr_regs_t *tmr)
     // NEW on ME16-0D, ensure reset is released for the AFE via GRC
     //  Reset could be active due to SW error recovery.
     //
-    if (device_version >= MXC_MAX32675_REV_B4) {
+    if (device_version >= MXC_AFE_VERSION_POST_RESET) {
         MXC_GCR->rst1 &= ~MXC_F_GCR_RST1_AFE;
     }
 

--- a/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
+++ b/Libraries/PeriphDrivers/Source/AFE/hart_uart.c
@@ -503,7 +503,6 @@ static int hart_uart_pins_idle_mode(void)
     return retval;
 }
 
-
 static int hart_uart_pins_external_test_mode_state(void)
 {
     int retval = 0;
@@ -512,7 +511,7 @@ static int hart_uart_pins_external_test_mode_state(void)
     // RTS Input to AFE, LOW is transmit mode, so Pulling Up
     hart_pin.port = HART_RTS_GPIO_PORT;
     hart_pin.mask = HART_RTS_GPIO_PIN;
-    hart_pin.pad  = MXC_GPIO_PAD_PULL_UP;
+    hart_pin.pad = MXC_GPIO_PAD_PULL_UP;
     hart_pin.func = MXC_GPIO_FUNC_IN;
 
     retval = MXC_AFE_GPIO_Config(&hart_pin);
@@ -523,7 +522,7 @@ static int hart_uart_pins_external_test_mode_state(void)
     // CD output from AFE, Tristate
     hart_pin.port = HART_CD_GPIO_PORT;
     hart_pin.mask = HART_CD_GPIO_PIN;
-    hart_pin.pad  = MXC_GPIO_PAD_NONE;
+    hart_pin.pad = MXC_GPIO_PAD_NONE;
 
     retval = MXC_AFE_GPIO_Config(&hart_pin);
     if (retval != E_NO_ERROR) {
@@ -533,7 +532,7 @@ static int hart_uart_pins_external_test_mode_state(void)
     // IN input to AFE, pulling Up
     hart_pin.port = HART_IN_GPIO_PORT;
     hart_pin.mask = HART_IN_GPIO_PIN;
-    hart_pin.pad  = MXC_GPIO_PAD_PULL_UP;
+    hart_pin.pad = MXC_GPIO_PAD_PULL_UP;
 
     retval = MXC_AFE_GPIO_Config(&hart_pin);
     if (retval != E_NO_ERROR) {
@@ -543,7 +542,7 @@ static int hart_uart_pins_external_test_mode_state(void)
     // IN output from AFE, Tristate
     hart_pin.port = HART_OUT_GPIO_PORT;
     hart_pin.mask = HART_OUT_GPIO_PIN;
-    hart_pin.pad  = MXC_GPIO_PAD_NONE;
+    hart_pin.pad = MXC_GPIO_PAD_NONE;
 
     retval = MXC_AFE_GPIO_Config(&hart_pin);
     if (retval != E_NO_ERROR) {
@@ -552,7 +551,6 @@ static int hart_uart_pins_external_test_mode_state(void)
 
     return retval;
 }
-
 
 void hart_rts_transmit_mode(void)
 {
@@ -595,13 +593,14 @@ int hart_reset_check_and_handle(void)
     }
 
     // MASK off all status bits but HART_EN and ST_DIS
-    masked_read_val = read_val & (MXC_F_AFE_ADC_ZERO_SYS_CTRL_HART_EN | MXC_F_AFE_ADC_ZERO_SYS_CTRL_ST_DIS);
+    masked_read_val = read_val &
+                      (MXC_F_AFE_ADC_ZERO_SYS_CTRL_HART_EN | MXC_F_AFE_ADC_ZERO_SYS_CTRL_ST_DIS);
 
     // If BOTH HART_EN and ST_DIS are set, then a NON-POR reset has occurred.
     //  in this case we need to clear ST_DIS to allow the HART state machine to proceed
     //  normally.
-    if (masked_read_val == (MXC_F_AFE_ADC_ZERO_SYS_CTRL_HART_EN | MXC_F_AFE_ADC_ZERO_SYS_CTRL_ST_DIS)) {
-
+    if (masked_read_val ==
+        (MXC_F_AFE_ADC_ZERO_SYS_CTRL_HART_EN | MXC_F_AFE_ADC_ZERO_SYS_CTRL_ST_DIS)) {
         // Both HART_EN and ST_DIS are set. (NON POR reset indicated)
 
         // Clear State Machine Disable
@@ -611,13 +610,11 @@ int hart_reset_check_and_handle(void)
         if (retval != E_NO_ERROR) {
             return retval;
         }
-    }
-    else {
+    } else {
         // HART_EN or ST_DIS are clear. (Normal, POR behavior)
     }
 
     return E_SUCCESS;
-
 }
 
 // TODO(ADI): Consider adding some parameters to this function to specify


### PR DESCRIPTION
## Pull Request Template

### Description

Corrects AFE initialization issue on latest MAX32675 silicon.

Changes to AFE driver to speed up communications.  Increased SPI clock rate from 100KHz, to 1Mhz, and added define AFE_SPI_TRANSCEIVE_SAFE_BUT_SLOWER to allow compile time choice between timer based infinite loop protection, as was previously used, and the faster version without timeouts used by default now.

Adds HART_TEST_MODE_EXTERNAL this "Tristates" the HART Uart pins to allows them to be driven from off board PC.  This mode is required during HART registration testing as a Modem (Secondary Master). 

Validated working on MAX32675.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
