### PR TITLE
fix(PeriphDrivers): Fix TMR Shutdown Bug, Stop Timer Before Clearing CTRL0

### DIFF
--- a/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+++ b/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
@@ -234,6 +234,8 @@ void MXC_TMR_RevB_Shutdown(mxc_tmr_revb_regs_t *tmr)
     (void)tmr_id;
     MXC_ASSERT(tmr_id >= 0);
 
+    // Stop timer before disable it.
+    MXC_TMR_RevB_Stop(tmr);
     // Disable timer and clear settings
     tmr->ctrl0 = 0;
     while (tmr->ctrl1 & MXC_F_TMR_REVB_CTRL1_CLKRDY_A) {}


### PR DESCRIPTION
## Pull Request Template

### Description

- In shutdown function, ctrl0 register set as 0. This causes problem because it disables timer clock before the timer. Thats why cnt register starts counting in next timer initialization when clk_en_x field is enabled even en_x field read as 0. To fix this problem, called stop function before setting ctrl0 register to 0.

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/94184469/28a91709-7779-4f1c-b95f-6042548d0f30)

For these 2 programs, timer shutdown and reinitialize for each configuration. Output 1 is current revB driver's output and output 2 is updated version's output. 

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
