### PR TITLE
fix(workflow): Run shallow clone for workflows running from BTM-CI

### DIFF
--- a/.github/workflows/Generate_Register_Files.yml
+++ b/.github/workflows/Generate_Register_Files.yml
@@ -77,7 +77,7 @@ jobs:
             git pull
             cd ..
           else
-            git clone git@github.com:Analog-Devices-MSDK/msdk-internal.git
+            git clone --depth 1 git@github.com:Analog-Devices-MSDK/msdk-internal.git
           fi
 
       - name: Generating register files.

--- a/.github/workflows/Verify_Register_SVD.yml
+++ b/.github/workflows/Verify_Register_SVD.yml
@@ -82,7 +82,7 @@ jobs:
             pwd
           else
             pwd
-            git clone git@github.com:Analog-Devices-MSDK/msdk-internal.git
+            git clone --depth 1 git@github.com:Analog-Devices-MSDK/msdk-internal.git
             ls
           fi
           

--- a/.github/workflows/scripts/test_launcher.sh
+++ b/.github/workflows/scripts/test_launcher.sh
@@ -596,7 +596,7 @@ change_advertising_names
 # Temporary fix until RF Closed is merged into RF Phy
 # Build a specific RF-PHY-closed branch
 cd $MSDK_DIR/Libraries
-git clone git@github.com:Analog-Devices-MSDK/RF-PHY-closed.git
+git clone --depth 1 git@github.com:Analog-Devices-MSDK/RF-PHY-closed.git
 cd $MSDK_DIR/Libraries/RF-PHY-closed
 git checkout ME17B1-new
 cd MAX32655/build/gcc


### PR DESCRIPTION
### Description

Update all the workflows, that use runners from the BTM-CI, to run a shallow clone to conserve storage space.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.