### PR TITLE
fix(BLE): Cordio HCI now has implementation in HCI for RSSI and Phy Enable/Disable

### DIFF
--- a/Libraries/Cordio/controller/sources/ble/lhci/lhci_cmd_vs.c
+++ b/Libraries/Cordio/controller/sources/ble/lhci/lhci_cmd_vs.c
@@ -271,7 +271,7 @@ bool_t lhciCommonVsStdDecodeCmdPkt(LhciHdr_t *pHdr, uint8_t *pBuf)
             /*
                 TODO: Needs feature in PHY
             */
-            pBuf[0] = 0;
+            pBuf[0] = -10;
             break;
         }
 

--- a/Libraries/Cordio/controller/sources/ble/lhci/lhci_cmd_vs.c
+++ b/Libraries/Cordio/controller/sources/ble/lhci/lhci_cmd_vs.c
@@ -82,6 +82,7 @@ bool_t lhciCommonVsStdDecodeCmdPkt(LhciHdr_t *pHdr, uint8_t *pBuf)
     uint8_t status = HCI_SUCCESS;
     uint8_t evtParamLen = 1; /* default is status field only */
     uint32_t regReadAddr = 0;
+    uint32_t channel = 0;
     
 
     /* Decode and consume command packet. */
@@ -211,6 +212,25 @@ bool_t lhciCommonVsStdDecodeCmdPkt(LhciHdr_t *pHdr, uint8_t *pBuf)
         status = LlEnhancedRxTest(pBuf[0], pBuf[1], pBuf[2], numPackets);
         break;
     }
+    case LHCI_OPCODE_VS_GET_RSSI:
+    {
+        status = LL_SUCCESS;
+        channel = pBuf[0];
+        evtParamLen += sizeof(int8_t);
+        break;
+    }
+    case LHCI_OPCODE_VS_PHY_EN:
+    {
+        status = LL_SUCCESS;
+        PalBbEnable();
+        break;
+    }
+    case LHCI_OPCODE_VS_PHY_DIS:
+    {
+        status = LL_SUCCESS;
+        PalBbDisable();
+        break;
+    }
 
     /* --- default --- */
     default:
@@ -236,12 +256,22 @@ bool_t lhciCommonVsStdDecodeCmdPkt(LhciHdr_t *pHdr, uint8_t *pBuf)
         case LHCI_OPCODE_VS_REG_WRITE:
         case LHCI_OPCODE_VS_RX_TEST:
         case LHCI_OPCODE_VS_TX_TEST:
+        case LHCI_OPCODE_VS_PHY_EN:
+        case LHCI_OPCODE_VS_PHY_DIS:
+
 
             /* no action */
             break;
 
         case LHCI_OPCODE_VS_RESET_TEST_STATS: {
             BbBleResetTestStats();
+            break;
+        }
+        case LHCI_OPCODE_VS_GET_RSSI:{
+            /*
+                TODO: Needs feature in PHY
+            */
+            pBuf[0] = 0;
             break;
         }
 

--- a/Libraries/Cordio/controller/sources/ble/lhci/lhci_cmd_vs_adv_master_ae.c
+++ b/Libraries/Cordio/controller/sources/ble/lhci/lhci_cmd_vs_adv_master_ae.c
@@ -58,7 +58,9 @@ bool_t lhciMstExtScanVsStdDecodeCmdPkt(LhciHdr_t *pHdr, uint8_t *pBuf)
     case LHCI_OPCODE_VS_GET_AUX_SCAN_STATS:
       evtParamLen += sizeof(BbBleAuxScanPktStats_t);
       break;
-
+    case LHCI_OPCODE_VS_GET_PER_SCAN_STATS:
+      evtParamLen += sizeof(BbBlePerScanPktStats_t);
+      break;
     /* --- default --- */
 
     default:

--- a/Libraries/Cordio/controller/sources/ble/lhci/lhci_int.h
+++ b/Libraries/Cordio/controller/sources/ble/lhci/lhci_int.h
@@ -366,6 +366,15 @@ extern "C" {
 #define LHCI_OPCODE_VS_RX_TEST     \
     HCI_OPCODE(HCI_OGF_VENDOR_SPEC, \
                0x305) /*!<Vendor specific RX Test*/
+#define LHCI_OPCODE_VS_GET_RSSI     \
+    HCI_OPCODE(HCI_OGF_VENDOR_SPEC, \
+               0x306) /*!<Vendor specific Get RSSI*/
+#define LHCI_OPCODE_VS_PHY_EN     \
+    HCI_OPCODE(HCI_OGF_VENDOR_SPEC, \
+               0x307) /*!<Vendor specific Get RSSI*/
+#define LHCI_OPCODE_VS_PHY_DIS     \
+    HCI_OPCODE(HCI_OGF_VENDOR_SPEC, \
+               0x308) /*!<Vendor specific Get RSSI*/
 /* Vendor specific event masks. */
 #define LHCI_VS_EVT_MASK_SCAN_REPORT_EVT 0x01 /*!< (Byte 0) VS event bit, scan report. */
 #define LHCI_VS_EVT_MASK_DIAG_TRACE_EVT 0x02 /*!< (Byte 0) VS event bit, diagnostic tracing. */


### PR DESCRIPTION

### Description

Added HCI commands to enable/disable PHY as well as capture an RSSI sample. 
The RSSI sample returns a static value now as it requires a feature in the PHY not yet present in the MSDK. This will be updated upon the next PHY update. 