### PR TITLE
feat(Examples,PeriphDrivers): Add SPIMSS_DMA example and SPIMSS Master Trans DMA APIs

### DIFF
--- a/Examples/MAX32660/SPIMSS_DMA/.cproject
+++ b/Examples/MAX32660/SPIMSS_DMA/.cproject
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" moduleId="org.eclipse.cdt.core.settings" name="Default">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default" optionalBuildProperties="org.eclipse.cdt.docker.launcher.containerbuild.property.selectedvolumes=,org.eclipse.cdt.docker.launcher.containerbuild.property.volumes=" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.312149002" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.1979514558" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.1205189276" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.1826884923" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.1004080608" incrementalBuildTarget="-r -j 8 --output-sync=target --no-print-directory" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross">
+								<outputEntries>
+									<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="outputPath" name=""/>
+								</outputEntries>
+							</builder>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.65797671" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.1897731433" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/PeriphDrivers/Include/${TARGET}/&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${MAXIM_PATH}/Libraries/Boards/${TARGET}/${BOARD}/Include&quot;"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1784350960" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" valueType="definedSymbols"/>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.154347489" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.2041852460" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.1753899980" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.c.linker.input.832209989" superClass="cdt.managedbuild.tool.gnu.c.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.90214721" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.615963853" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.1258173083" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.both.asm.option.include.paths.1648846468" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.372767062" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry flags="VALUE_WORKSPACE_PATH" kind="sourcePath" name=""/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+			<storageModule moduleId="ilg.gnumcueclipse.managedbuild.packs"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="SPIMSS.null.923778415" name="SPIMSS"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Default">
+			<resource resourceType="PROJECT" workspacePath="/SPIMSS"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.cross.base.1028364529;cdt.managedbuild.toolchain.gnu.cross.base.1028364529.1135114284;cdt.managedbuild.tool.gnu.cross.c.compiler.65797671;cdt.managedbuild.tool.gnu.c.compiler.input.154347489">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+</cproject>

--- a/Examples/MAX32660/SPIMSS_DMA/.project
+++ b/Examples/MAX32660/SPIMSS_DMA/.project
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>SPIMSS</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Examples/MAX32660/SPIMSS_DMA/.settings/language.settings.xml
+++ b/Examples/MAX32660/SPIMSS_DMA/.settings/language.settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.cross.base.1028364529" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="${PREFIX}(g?cc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
+			<provider class="org.eclipse.cdt.internal.build.crossgcc.CrossGCCBuiltinSpecsDetector" console="true" env-hash="-99955491804503126" id="org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT Cross GCC Built-in Compiler Settings" parameter="${GCC_PREFIX}gcc ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;  -DMXC_ASSERT_ENABLE -DARM_MATH_CM4 " prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>

--- a/Examples/MAX32660/SPIMSS_DMA/.settings/org.eclipse.cdt.codan.core.prefs
+++ b/Examples/MAX32660/SPIMSS_DMA/.settings/org.eclipse.cdt.codan.core.prefs
@@ -1,0 +1,93 @@
+eclipse.preferences.version=1
+org.eclipse.cdt.codan.checkers.errnoreturn=Warning
+org.eclipse.cdt.codan.checkers.errnoreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return\\")",implicit\=>false}
+org.eclipse.cdt.codan.checkers.errreturnvalue=Error
+org.eclipse.cdt.codan.checkers.errreturnvalue.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused return value\\")"}
+org.eclipse.cdt.codan.checkers.nocommentinside=-Error
+org.eclipse.cdt.codan.checkers.nocommentinside.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Nesting comments\\")"}
+org.eclipse.cdt.codan.checkers.nolinecomment=-Error
+org.eclipse.cdt.codan.checkers.nolinecomment.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Line comments\\")"}
+org.eclipse.cdt.codan.checkers.noreturn=Error
+org.eclipse.cdt.codan.checkers.noreturn.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No return value\\")",implicit\=>false}
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation=Error
+org.eclipse.cdt.codan.internal.checkers.AbstractClassCreation.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Abstract class cannot be instantiated\\")"}
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AmbiguousProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Ambiguous problem\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.AssignmentInConditionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment in condition\\")"}
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem=Error
+org.eclipse.cdt.codan.internal.checkers.AssignmentToItselfProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Assignment to itself\\")"}
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CStyleCastProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"C-Style cast instead of C++ cast\\")"}
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.CaseBreakProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"No break at end of case\\")",no_break_comment\=>"no break",last_case_param\=>false,empty_case_param\=>false,enable_fallthrough_quickfix_param\=>false}
+org.eclipse.cdt.codan.internal.checkers.CatchByReference=Warning
+org.eclipse.cdt.codan.internal.checkers.CatchByReference.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Catching by reference is recommended\\")",unknown\=>false,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem=Error
+org.eclipse.cdt.codan.internal.checkers.CircularReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Circular inheritance\\")"}
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization=Warning
+org.eclipse.cdt.codan.internal.checkers.ClassMembersInitialization.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class members should be properly initialized\\")",skip\=>true}
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.CopyrightProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Lack of copyright information\\")",regex\=>".*Copyright.*"}
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem=Error
+org.eclipse.cdt.codan.internal.checkers.DecltypeAutoProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid 'decltype(auto)' specifier\\")"}
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FieldResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Field cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.FunctionResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Function cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.GotoStatementProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Goto statement used\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidArguments.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid arguments\\")"}
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem=Error
+org.eclipse.cdt.codan.internal.checkers.InvalidTemplateArgumentsProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid template argument\\")"}
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.LabelStatementNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Label statement not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MemberDeclarationNotFoundProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Member declaration not found\\")"}
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.MethodResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Method cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissCaseProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing cases in switch\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissDefaultProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing default in switch\\")",defaultWithAllEnums\=>false}
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissReferenceProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing reference return value in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.MissSelfCheckProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Missing self check in assignment operator\\")"}
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker=-Info
+org.eclipse.cdt.codan.internal.checkers.NamingConventionFunctionChecker.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Name convention for function\\")",pattern\=>"^[a-z]",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.NonVirtualDestructorProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Class has a virtual method and non-virtual destructor\\")"}
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem=Error
+org.eclipse.cdt.codan.internal.checkers.OverloadProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid overload\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redeclaration\\")"}
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.RedefinitionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Invalid redefinition\\")"}
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ReturnStyleProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Return with parenthesis\\")"}
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.ScanfFormatStringSecurityProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Format String Vulnerability\\")"}
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.StatementHasNoEffectProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Statement has no effect\\")",macro\=>true,exceptions\=>()}
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuggestedParenthesisProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suggested parenthesis around expression\\")",paramNot\=>false}
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.SuspiciousSemicolonProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Suspicious semicolon\\")",else\=>false,afterelse\=>false}
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.TypeResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Type cannot be resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedFunctionDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused function declaration\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedStaticFunctionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused static function\\")",macro\=>true}
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem=Warning
+org.eclipse.cdt.codan.internal.checkers.UnusedVariableDeclarationProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Unused variable declaration in file scope\\")",macro\=>true,exceptions\=>("@(\#)","$Id")}
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem=-Warning
+org.eclipse.cdt.codan.internal.checkers.UsingInHeaderProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Using directive in header\\")"}
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem=Error
+org.eclipse.cdt.codan.internal.checkers.VariableResolutionProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Symbol is not resolved\\")"}
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem=-Error
+org.eclipse.cdt.codan.internal.checkers.VirtualMethodCallProblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>true,RUN_ON_INC_BUILD\=>true,RUN_ON_FILE_OPEN\=>false,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>"@suppress(\\"Virtual method call in constructor/destructor\\")"}
+org.eclipse.cdt.qt.core.qtproblem=Warning
+org.eclipse.cdt.qt.core.qtproblem.params={launchModes\=>{RUN_ON_FULL_BUILD\=>false,RUN_ON_INC_BUILD\=>false,RUN_ON_FILE_OPEN\=>true,RUN_ON_FILE_SAVE\=>false,RUN_AS_YOU_TYPE\=>true,RUN_ON_DEMAND\=>true},suppression_comment\=>null}

--- a/Examples/MAX32660/SPIMSS_DMA/.settings/org.eclipse.cdt.core.prefs
+++ b/Examples/MAX32660/SPIMSS_DMA/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,15 @@
+eclipse.preferences.version=1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/BOARD/value=EvKit_V1
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/operation=replace
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/GCC_PREFIX/value=arm-none-eabi-
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/PROJECT/value=SPIMSS
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/delimiter=;
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/operation=append
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/TARGET/value=MAX32660
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/append=true
+environment/project/cdt.managedbuild.toolchain.gnu.cross.base.1028364529/appendContributed=true

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/README.md
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/README.md
@@ -1,0 +1,420 @@
+# VSCode-Maxim
+
+_(If you're viewing this document from within Visual Studio Code you can press `CTRL+SHIFT+V` to open a Markdown preview window.)_
+
+## Quick Links
+
+* [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+  * If it's not in the README, check the UG.
+  * If it's not in the UG, open a ticket!
+* [VSCode-Maxim Github](https://github.com/Analog-Devices-MSDK/VSCode-Maxim)
+
+## Introduction
+
+VSCode-Maxim is a set of [Visual Studio Code](https://code.visualstudio.com/) project configurations and utilities for enabling embedded development for [Analog Device's MSDK](https://github.com/Analog-Devices-MSDK/msdk) and the [MAX32xxx/MAX78xxx microcontrollers](https://www.analog.com/en/product-category/microcontrollers.html).
+
+The following features are supported:
+
+* Code editing with intellisense down to the register level
+* Code compilation with the ability to easily re-target a project for different microcontrollers and boards
+* Flashing programs
+* GUI and command-line debugging
+
+## Dependencies
+
+* [Visual Studio Code](https://code.visualstudio.com/)
+  * [C/C++ VSCode Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
+  * [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
+* [Analog Devices MSDK](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
+
+## Installation
+
+The steps below are also available in video form in "Understanding Artificial Intelligence Episode 8.5 - Visual Studio Code" [here](https://www.analog.com/en/education/education-library/videos/6313212752112.html).
+
+1. Download and install the Analog Devices MSDK for your OS from the links below.  For more detailed instructions on installing the MSDK, see the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)
+    * [Windows](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0010820A)
+    * [Linux (Ubuntu)](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018720A)
+    * [MacOS](https://www.analog.com/en/design-center/evaluation-hardware-and-software/software/software-download?swpart=SFW0018610A)
+
+2. Run the installer executable, and ensure that "Visual Studio Code Support" is enabled for your installation.
+
+    ![Selected Components](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/installer_components.JPG)
+
+3. Finish the MSDK installation, taking note of where the MSDK was installed.
+
+4. Download & install Visual Studio Code for your OS [here](https://code.visualstudio.com/Download).
+
+5. Launch Visual Studio Code.
+
+6. Install the Microsoft [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).
+
+7. Install the [Cortex-Debug Extension](https://marketplace.visualstudio.com/items?itemName=marus25.cortex-debug)
+
+8. Use `CTRL + SHIFT + P` (or `COMMAND + SHIFT + P` on MacOS) to open the developer prompt.
+
+9. Type "open settings json" and select the "Preferences: Open Settings (JSON)" option (_not_ the "Preferences: Open _Default_ Settings (JSON)").  This will open your user settings.json file in VS Code's editor.
+
+    ![Open Settings JSON Command](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/open_settings_json.jpg)
+
+10. Add the entries below into your user settings.json file.
+
+    ```json
+    {
+        // There may be other settings up here...
+        "MAXIM_PATH":"C:/MaximSDK", // Set this to the installed location of the Analog Devices MSDK. Only use forward slashes '/' when setting this path!
+        "update.mode": "manual",
+        "extensions.autoUpdate": false,
+        // There may be other settings down here...
+    }
+    ```
+
+11. Save your changes to the file with `CTRL + S` and restart VS Code.
+
+12. That's it! You're ready to start using Visual Studio Code to develop with Analog Devices MAX-series Microcontrollers. The MSDK examples come pre-populated with .vscode project folders, and the `Tools/VSCode-Maxim` folder of the MSDK contains documentation and templates.  See [Usage](#usage) below for more details.
+
+## Usage
+
+This section covers basic usage of the VSCode-Maxim project files.  For documentation on Visual Studio Code itself, please refer to the official docs [here](https://code.visualstudio.com/Docs).
+
+### Opening Projects
+
+Visual Studio Code is built around a "working directory" paradigm.  The editor is always rooted in a working directory, and the main mechanism for changing that directory is `File -> Open Folder...`.
+
+![File -> Open Folder](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/file_openfolder.JPG)
+
+As a result, you'll notice that there is no "New Project" mechanism.  A "project" in VS Code is simply a folder.  It will look inside of the opened folder for a `.vscode` _sub_-folder to load project-specific settings from.
+
+A project that is configured for VS Code will have, at minimum, a .vscode sub-folder and a Makefile in its directory _(Note: You may need to enable viewing of hidden items in your file explorer to see the .vscode sub-folder)_.  
+
+Ex:
+
+![Example Directory Contents](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/opening_projects_2.jpg)
+
+### Where to Find Projects
+
+The [Examples](https://github.com/Analog-Devices-MSDK/msdk/tree/main/Examples) in the MSDK come with with pre-configured .vscode project folders.  These projects can be opened "out of the box", but it's good practice to copy example folders _outside_ of the MSDK so that the original copies are kept as clean references.  The examples can be freely moved to any location _without a space in its path_.
+
+Additionally, empty project templates and a drag-and-drop folder for "injecting" a VSCode-Maxim project can be found under `Tools/VSCode-Maxim` in the MSDK installation.
+
+### Build Tasks
+
+Once a project is opened 4 available build tasks will become available via `Terminal > Run Build task...` or the shortcut `Ctrl+Shift+B`.  These tasks are configured by the `.vscode/task.json` file.
+
+![Build Tasks Image](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/buildtasks.JPG)
+
+#### Build
+
+* Compiles the code with a `make all` command.
+* Additional options are passed into Make on the command-line based on the project's settings.json file.
+* The `./build` directory will be created and will contain the output binary, as well as all intermediary object files.
+
+#### Clean
+
+* Cleans the build output, removing the `./build` directory and all of its contents.
+
+#### Clean-Periph
+
+* This task is the same as 'clean', but it also removes the build output for the MSDK's peripheral drivers.
+* Use this if you would like to recompile the peripheral drivers from source on the next build.
+
+#### Flash
+
+* Launching this task automatically runs the `Build` task first.  Then, it flashes the output binary to the microcontroller.
+* It uses the GDB `load` and `compare-sections` commands, and handles launching an OpenOCD internally via a pipe connection.
+* The flashed program will be halted until the microcontroller is reset, power cycled, or a debugger is connected.
+* A debugger must be connected correctly to use this task.  Refer to the datasheet of your microcontroller's evaluation board for instructions.
+
+#### Flash & Run
+
+* This is the same as the `Flash` task, but it also will launch execution of the program once flashing is complete.
+
+#### Erase Flash
+
+* Completely erases all of the application code in the flash memory bank.
+* Once complete, the target microcontroller will be effectively "blank".
+* This can be useful for recovering from Low-Power (LP) lockouts, bad firmware, etc.
+
+### Debugging
+
+![Debug Window](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/debugger.JPG)
+
+Debugging is enabled by Visual Studio Code's integrated debugger.  Launch configurations can be found in the `.vscode/launch.json` file.
+
+* Note: **Flashing does not happen automatically when launching the debugger.**  Run the "Flash" [build task](#build-tasks) for your program _before_ debugging.
+
+#### Debugger Limitations
+
+In general, the MAX-series microcontrollers have the following debugger limitations at the hardware level:
+
+* The debugger can not be connected _while_ the device is in reset.
+
+* The device can not be debugged while the device is in Sleep, Low Power Mode, Micro Power Mode, Standby, Backup, or Shutdown mode.  These modes shut down the SWD clock.
+
+* These limitations can sometimes make the device difficult or impossible to connect to if firmware has locked out the debugger.  In such cases, the ["Erase Flash"](#erase-flash) task can be used to recover the part.
+
+#### Launching the Debugger
+
+1. Attach your debugger to the SWD port on the target microcontroller.  (Refer to the datasheet of your evaluation board for instructions on connecting a debugger)
+
+2. Flash the program to the microcontroller with the "Flash" [Build Task](#build-tasks).  **Flashing does not happen automatically when launching the debugger.**
+
+3. Launch the debugger with `Run > Start Debugging`, with the shortcut `F5`, or via the `Run and Debug` window (Ctrl + Shift + D) and the green "launch" arrow.  
+
+    ![Debug Tab](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/debugger_window.JPG)
+
+4. The debugger will launch a GDB client & OpenOCD server, reset the microcontroller, and should break on entry into `main`.
+
+    ![Debugger Break on Main](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/debugger_breakmain.JPG)
+
+#### Using the Debugger
+
+* For full usage details, please refer to the [official VS Code debugger documentation](https://code.visualstudio.com/docs/editor/debugging).
+
+The main interface for the debugger is the debugger control bar:
+
+![Debugger Control Bar Image](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/debugger_bar.JPG)
+
+`Continue | Step Over | Step Into | Step Out | Restart | Stop`
+
+Breakpoints can be set by clicking in the space next to the line number in a source code file.  A red dot indicates a line to break on.  Breakpoints can be removed by clicking on them again.  Ex:
+
+![Breakpoint](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/breakpoint.JPG)
+
+## Project Configuration
+
+### Project Settings
+
+`.vscode/settings.json` is the main project configuration file.  Values set here are parsed into the other .json config files.  
+
+**When a change is made to this file, VS Code should be reloaded with CTRL+SHIFT+P -> Reload Window (or alternatively restarted completely) to force a re-parse.**
+
+![Reload Window](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/reload_window.JPG)
+
+The default project configuration should work for most use cases as long as `"target"` and `"board"` are set correctly.
+
+Any field from `settings.json` can be referenced from any other config file (including itself) with `"${config:[fieldname]}"`
+
+The following configuration options are available:
+
+### Basic Config Options
+
+#### `"target"`
+
+* This sets the target microcontroller for the project.
+* It sets the `TARGET` [Build Configuration](#build-configuration) variable.
+* Supported values:
+  * `"MAX32520"`
+  * `"MAX32570"`
+  * `"MAX32650"`
+  * `"MAX32655"`
+  * `"MAX32660"`
+  * `"MAX32662"`
+  * `"MAX32665"` (for MAX32665-MAX32668)
+  * `"MAX32670"`
+  * `"MAX32672"`
+  * `"MAX32675"`
+  * `"MAX32680"`
+  * `"MAX32690"`
+  * `"MAX78000"`
+  * `"MAX78002"`
+
+#### `"board"`
+
+* This sets the target board for the project (ie. Evaluation Kit, Feather board, etc.)
+* Supported values:
+  * ... can be found in the `Libraries/Boards` folder of the MSDK
+  * For example, the supported options for the MAX78000 are `"EvKit_V1"`, `"FTHR_RevA"`, and `"MAXREFDES178"`.
+
+  ![MAX78000 Boards](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/main/img/78000_boards.JPG)
+
+### Advanced Config Options
+
+#### `"MAXIM_PATH"`
+
+* This option must point to the root installation directory of the MSDK.
+* It should be placed in the _global_ user settings.json file during first-time VSCode-Maxim setup.  See [Installation](#installation).
+
+#### `"terminal.integrated.env.[platform]:Path"`
+
+* This prepends the location of the MSDK toolchain binaries to the system `Path` used by VSCode's integrated terminal.
+* The Path is not sanitized by default, which means that the terminal inherits the system path.
+* Don't touch unless you know what you're doing :)
+
+#### `"project_name"`
+
+* Sets the name of project.  This is used in other config options such as `program_file`.
+* Default value: `"${workspaceFolderBasename}"`
+
+#### `"program_file"`
+
+* Sets the name of the file to flash and debug.  This is provided in case it's needed, but for most use cases should be left at its default.  
+* File extension must be included.
+* Default value: `"${config:project_name}.elf"`
+
+#### `"symbol_file"`
+
+* Sets the name of the file that GDB will load debug symbols from.
+* File extension must be included.
+* Default value: `"${config:program_file}"`
+
+#### `"M4_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the Arm M4 core.  This should match the debugger being used for the M4 core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"cmsis-dap.cfg"`
+
+#### `"M4_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the Arm M4 core.  This should match the target microcontroller.
+* `.cfg` file extension must be included.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* Default value: `"${config:target}.cfg"`
+
+#### `"RV_OCD_interface_file"`
+
+* Sets the OpenOCD interface file to use to connect to the RISC-V core.  This should match the debugger being used for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/interface` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"ftdi/olimex-arm-usb-ocd-h.cfg"`
+
+#### `"RV_OCD_target_file"`
+
+* Sets the OpenOCD target file to use for the RISC-V core.
+* The `MaximSDK/Tools/OpenOCD/scripts/target` folder is searched for the file specified by this setting.
+* `.cfg` file extension must be included.
+* Default value: `"${config:target}_riscv.cfg"`
+
+#### `"v_Arm_GCC"`
+
+* Sets the version of the Arm Embedded GCC to use, including toolchain binaries and the standard library version.
+* This gets parsed into `ARM_GCC_path`.
+* Default value:  `"10.3"`
+
+#### `"v_xPack_GCC"`
+
+* Sets the version of the xPack RISC-V GCC to use.
+* This gets parsed into `xPack_GCC_path`.
+* Default value: `"10.2.0-1.2"`
+
+#### `"OCD_path"`
+
+* Where to find the OpenOCD.
+* Default value: `"${config:MAXIM_PATH}/Tools/OpenOCD"`
+
+#### `"ARM_GCC_path"`
+
+* Where to find the Arm Embedded GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}"`
+
+#### `"xPack_GCC_path"`
+
+* Where to find the RISC-V GCC Toolchain.
+* Default value: `"${config:MAXIM_PATH}/Tools/xPack/riscv-none-embed-gcc/${config:v_xPack_GCC}"`
+
+#### `"Make_path"`
+
+* Where to find Make binaries (only used on Windows)
+* Default value: `"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin"`
+
+#### `"C_Cpp.default.includePath"`
+
+* Which paths to search to find header (.h) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.browse.path"`
+
+* Which paths to search to find source (.c) files.
+* Does not recursively search by default.  To recursively search, use `/**`.
+
+#### `"C_Cpp.default.defines"`
+
+* Sets the compiler definitions to use for the intellisense engine.
+* Most definitions should be defined in header files, but if a definition is missing it can be entered here to get the intellisense engine to recognize it.
+
+### Setting Search Paths for Intellisense
+
+VS Code's intellisense engine must be told where to find the header files for your source code.  By default, the MSDK's peripheral drivers, the C standard libraries, and all of the sub-directories of the workspace will be searched for header files to use with Intellisense.  If VS Code throws an error on an `#include` statement (and the file exists), then a search path is most likely missing.
+
+To add additional search paths :
+
+1. Open the `.vscode/settings.json` file.
+
+2. Add the include path(s) to the `C_Cpp.default.includePath` list.  The paths set here should contain header files, and will be searched by the Intellisense engine and when using "Go to Declaration" in the editor.
+
+3. Add the path(s) to any relevant implementation files to the `C_Cpp.default.browse.path` list.  This list contains the paths that will be searched when using "Go to Definition".
+
+## Build Configuration
+
+A project's build system is managed by two files found in the project's root directory.  These files are used alongside the [GNU Make](https://www.gnu.org/software/make/) program (which is a part of the MSDK toolchain) to locate and build a project's source code for the correct microcontroller.
+
+* `Makefile`
+* `project.mk`
+
+![Files are located in the root directory](https://raw.githubusercontent.com/Analog-Devices-MSDK/VSCode-Maxim/65af7c61800c7039956f3c1971ffd7915008668d/img/projectmk.JPG)
+
+When the command...
+
+```shell
+make
+```
+
+... is run, the program `make` will load settings from these two files.  Then, it will use them to build the project's source code.  VSCode-Maxim is a "wrapper" around this Makefile system.
+
+**See the [MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system) for full documentation on how to configure the build system.**
+
+## Project Creation
+
+### Option 1.  Copying a Pre-Made Project
+
+Copying a pre-made example project is a great way to get rolling quickly, and is currently the recommended method for creating new projects.
+
+The release package for this project (Located at Tools/VSCode-Maxim in the Analog Devices MSDK) contains a `New_Project` folder designed for such purposes. Additionally, any of the VS Code-enabled Example projects can be copied from the MSDK.
+
+1. Copy the existing project folder to an accessible location.  This will be the location of your new project.
+
+2. (Optional) Rename the folder.  For example, I might rename the folder to `MyProject`.
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller and board correctly.  See [Basic Config Options](#basic-config-options)
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. That's it!  The existing project is ready to build, debug, and modify.
+
+### Option 2 - Injecting
+
+VSCode-Maxim releases provide the `Inject` folder for "injecting" into an existing folder.  If you want to start from scratch or use the project files with existing source code, take this option.
+
+1. Create your project folder if necessary.  For example, I might create a new project in a workspace folder with the path: `C:\Users\Jake.Carter\workspace\MyNewProject`.
+
+2. Copy the **contents** of the `Inject` folder into the project folder from step 1.  The contents to copy include a `.vscode` folder, a `Makefile`, and a `project.mk` file.  For this example, the contents of the 'MyProject' folder would be the following:
+
+    ```shell
+    C:\Users\Jake.Carter\workspace\MyNewProject
+    |- .vscode
+    |- Makefile
+    |- project.mk
+    ```
+
+3. Open the project in VS Code (`File -> Open Folder...`)
+
+4. Set your target microcontroller correctly.  See [Basic Config Options](#basic-config-options).
+
+5. `CTRL+SHIFT+P -> Reload Window` to re-parse the project settings.
+
+6. Configure the [build system](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system) for use with any pre-existing source code.
+
+7. That's it!  Your new empty project can now be opened with `File > Open Folder` from within VS Code.
+
+## Issue Tracker
+
+Bug reports, feature requests, and contributions are welcome via the [issues](https://github.com/Analog-Devices-MSDK/VSCode-Maxim/issues) tracker on Github.
+
+New issues should contain _at minimum_ the following information:
+
+* Visual Studio Code version #s (see `Help -> About`)
+* C/C++ Extension version #
+* Target microcontroller and evaluation platform
+* The projects `.vscode` folder and `Makefile` (where applicable).  Standard compression formats such as `.zip`, `.rar`, `.tar.gz`, etc. are all acceptable.

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/c_cpp_properties.json
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/c_cpp_properties.json
@@ -1,0 +1,53 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc.exe",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "${default}"
+            ],
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gcc",
+            "browse": {
+                "path": [
+                    "${default}"
+                ]
+            }
+        }
+    ],
+    "version": 4
+}

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/flash.gdb
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/flash.gdb
@@ -1,0 +1,15 @@
+define flash_m4
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor reset halt
+end
+
+define flash_m4_run
+    set architecture armv7e-m
+    target remote | openocd -c "gdb_port pipe;log_output flash.log" -s $arg0/scripts -f interface/$arg1 -f target/$arg2 -c "init; reset halt"
+    load
+    compare-sections
+    monitor resume
+end

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/launch.json
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/launch.json
@@ -1,0 +1,133 @@
+{
+    "configurations": [
+        {
+            "name": "Debug Arm (Cortex-debug)",
+            "cwd":"${workspaceRoot}",
+            "executable": "${workspaceFolder}/build/${config:program_file}",
+            "loadFiles": ["${workspaceFolder}/build/${config:program_file}"],
+            "symbolFiles": [{
+                "file": "${workspaceFolder}/build/${config:symbol_file}"
+            }],
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            "linux": {
+                "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "serverpath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "serverpath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "gdbPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "serverpath": "${config:OCD_path}/openocd",
+            },
+            "searchDir": ["${config:OCD_path}/scripts"],
+            "configFiles": ["interface/${config:M4_OCD_interface_file}", "target/${config:M4_OCD_target_file}"],
+            "interface": "swd",
+            "runToEntryPoint": "main",
+            "svdFile": "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include/${config:target}.svd"
+        },
+        {
+            "name": "GDB (Arm M4)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/${config:program_file}",
+            "args": [],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:ARM_GCC_path}/bin/arm-none-eabi-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3333",
+            "debugServerArgs": "-s ${config:OCD_path}/scripts -f interface/${config:M4_OCD_interface_file} -f target/${config:M4_OCD_target_file} -c \"init; reset halt\"",
+            "serverStarted": "Info : Listening on port 3333 for gdb connections",
+            "filterStderr": true,
+            "targetArchitecture": "arm",
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-arm.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text":"exec-file build/${config:program_file}" },
+                { "text":"symbol-file build/${config:symbol_file}" },
+                { "text":"target remote localhost:3333" },
+                { "text":"monitor reset halt" },
+                { "text":"set $pc=Reset_Handler"},
+                { "text":"b main" }
+            ]
+        },
+        {
+            "name": "GDB (RISC-V)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/buildrv/${config:program_file}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "linux": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/openocd",
+            },
+            "windows": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb.exe",
+                "debugServerPath": "${config:OCD_path}/openocd.exe",
+            },
+            "osx": {
+                "miDebuggerPath": "${config:xPack_GCC_path}/bin/riscv-none-embed-gdb",
+                "debugServerPath": "${config:OCD_path}/bin/openocd",
+            },
+            "logging": {
+                "exceptions": true,
+                "trace": false,
+                "traceResponse": false,
+                "engineLogging": false
+            },
+            "miDebuggerServerAddress": "localhost:3334",
+            "debugServerArgs": "-c \"gdb_port 3334\" -s ${config:OCD_path}/scripts -f interface/${config:RV_OCD_interface_file} -f target/${config:RV_OCD_target_file}",
+            "serverStarted": "Info : Listening on port 3334 for gdb connections",
+            "filterStderr": true,
+            "customLaunchSetupCommands": [
+                {"text":"-list-features"}
+            ],
+            "targetArchitecture": "arm",
+            "setupCommands": [
+                { "text":"set logging overwrite on"},
+                { "text":"set logging file debug-riscv.log"},
+                { "text":"set logging on"},
+                { "text":"cd ${workspaceFolder}" },
+                { "text": "set architecture riscv:rv32", "ignoreFailures": false },
+                { "text":"exec-file build/${config:program_file}", "ignoreFailures": false },
+                { "text":"symbol-file buildrv/${config:symbol_file}", "ignoreFailures": false },
+                { "text":"target remote localhost:3334" },
+                { "text":"b main" },
+                { "text": "set $pc=Reset_Handler","ignoreFailures": false }
+            ]
+        }
+    ]
+}

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/settings.json
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/settings.json
@@ -1,0 +1,92 @@
+{
+    "terminal.integrated.env.windows": {
+        "Path":"${config:OCD_path};${config:ARM_GCC_path}/bin;${config:xPack_GCC_path}/bin;${config:Make_path};${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.defaultProfile.windows": "Command Prompt",
+
+    "terminal.integrated.env.linux": {
+        "PATH":"${config:OCD_path}:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+    "terminal.integrated.env.osx": {
+        "PATH":"${config:OCD_path}/bin:${config:ARM_GCC_path}/bin:${config:xPack_GCC_path}/bin:${env:PATH}",
+        "MAXIM_PATH":"${config:MAXIM_PATH}"
+    },
+
+    "target":"MAX32660",
+    "board":"EvKit_V1",
+
+    "project_name":"${workspaceFolderBasename}",
+
+    "program_file":"${config:project_name}.elf",
+    "symbol_file":"${config:program_file}",
+
+    "M4_OCD_interface_file":"cmsis-dap.cfg",
+    "M4_OCD_target_file":"max32660.cfg",
+    "RV_OCD_interface_file":"ftdi/olimex-arm-usb-ocd-h.cfg",
+    "RV_OCD_target_file":"${config:target}_riscv.cfg",
+
+    "v_Arm_GCC":"10.3",
+    "v_xPack_GCC":"12.2.0-3.1",
+
+    "OCD_path":"${config:MAXIM_PATH}/Tools/OpenOCD",
+    "ARM_GCC_path":"${config:MAXIM_PATH}/Tools/GNUTools/${config:v_Arm_GCC}",
+    "xPack_GCC_path":"${config:MAXIM_PATH}/Tools/xPack/riscv-none-elf-gcc/${config:v_xPack_GCC}",
+    "Make_path":"${config:MAXIM_PATH}/Tools/MSYS2/usr/bin",
+
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}",
+        "${workspaceFolder}/**",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/${config:target}/Include",
+        "${config:MAXIM_PATH}/Libraries/CMSIS/Include",
+        "${config:ARM_GCC_path}/arm-none-eabi/include",
+        "${config:ARM_GCC_path}/lib/gcc/arm-none-eabi/${config:v_Arm_GCC}/include",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Include/${config:target}",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/ExtMemory",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen"
+    ],
+    "C_Cpp.default.browse.path": [
+        "${workspaceFolder}",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/Source",
+        "${config:MAXIM_PATH}/Libraries/Boards/${config:target}/${config:board}/Source",
+        "${config:MAXIM_PATH}/Libraries/PeriphDrivers/Source",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Camera",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Display",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/LED",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PMIC",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/PushButton",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers/Touchscreen",
+        "${config:MAXIM_PATH}/Libraries/MiscDrivers"
+    ],
+    "C_Cpp.default.defines": [
+
+    ],
+    "C_Cpp.default.forcedInclude": [
+        "${workspaceFolder}/build/project_defines.h"
+    ],
+    "files.associations": {
+        "spimss.h": "c",
+        "nvic_table.h": "c",
+        "spimss_regs.h": "c",
+        "mxc_delay.h": "c",
+        "mxc_sys.h": "c",
+        "dma.h": "c",
+        "spimss_reva.h": "c",
+        "uart.h": "c",
+        "mxc_lock.h": "c",
+        "dma_regs.h": "c",
+        "spi.h": "c",
+        "led.h": "c",
+        "mxc_pins.h": "c",
+        "mxc_device.h": "c"
+    }
+}
+

--- a/Examples/MAX32660/SPIMSS_DMA/.vscode/tasks.json
+++ b/Examples/MAX32660/SPIMSS_DMA/.vscode/tasks.json
@@ -1,0 +1,115 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make -r -j 8 --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "osx":{
+                "command": "source ~/.zshrc && make -r -j 8 --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}"
+            },
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean",
+            "type": "shell",
+            "command": "make -j 8 clean --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "osx":{
+                "command": "source ~/.zshrc && make -j 8 clean --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}"
+            },
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "clean-periph",
+            "type": "shell",
+            "command": "make -j 8 distclean --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}",
+            "osx":{
+                "command": "source ~/.zshrc && make -j 8 distclean --output-sync=target --no-print-directory TARGET=${config:target} BOARD=${config:board} MAXIM_PATH=${config:MAXIM_PATH} MAKE=make PROJECT=${config:project_name}"
+            },
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
+            "label": "flash",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4 ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "flash & run",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--cd=\"${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "-x=\"${workspaceFolder}/.vscode/flash.gdb\"",
+                "--ex=\"flash_m4_run ${config:OCD_path} ${config:M4_OCD_interface_file} ${config:M4_OCD_target_file}\"",
+                "--batch"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "dependsOn":["build"]
+        },
+        {
+            "label": "erase flash",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s", "${config:OCD_path}/scripts",
+                "-f", "interface/${config:M4_OCD_interface_file}",
+                "-f", "target/${config:M4_OCD_target_file}",
+                "-c", "\"init; reset halt; max32xxx mass_erase 0;\"",
+                "-c", "exit"
+            ],
+            "group":"build",
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "openocd (m4)",
+            "type": "shell",
+            "command": "openocd",
+            "args": [
+                "-s",
+                "${config:OCD_path}/scripts",
+                "-f",
+                "interface/${config:M4_OCD_interface_file}",
+                "-f",
+                "target/${config:M4_OCD_target_file}",
+                "-c",
+                "\"init; reset halt\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+        {
+            "label": "gdb (m4)",
+            "type": "shell",
+            "command": "arm-none-eabi-gdb",
+            "args": [
+                "--ex=\"cd ${workspaceFolder}\"",
+                "--se=\"build/${config:program_file}\"",
+                "--symbols=build/${config:symbol_file}",
+                "--ex=\"target remote localhost:3333\"",
+                "--ex=\"monitor reset halt\"",
+                "--ex=\"b main\"",
+                "--ex=\"c\""
+            ],
+            "problemMatcher": [],
+            "dependsOn":[]
+        },
+    ]
+}

--- a/Examples/MAX32660/SPIMSS_DMA/Makefile
+++ b/Examples/MAX32660/SPIMSS_DMA/Makefile
@@ -1,0 +1,395 @@
+################################################################################
+ # Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a
+ # copy of this software and associated documentation files (the "Software"),
+ # to deal in the Software without restriction, including without limitation
+ # the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ # and/or sell copies of the Software, and to permit persons to whom the
+ # Software is furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included
+ # in all copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ # OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ # IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ # OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ #
+ # Except as contained in this notice, the name of Maxim Integrated
+ # Products, Inc. shall not be used except as stated in the Maxim Integrated
+ # Products, Inc. Branding Policy.
+ #
+ # The mere transfer of this software does not imply any licenses
+ # of trade secrets, proprietary technology, copyrights, patents,
+ # trademarks, maskwork rights, or any other form of intellectual
+ # property whatsoever. Maxim Integrated Products, Inc. retains all
+ # ownership rights.
+ #
+###############################################################################
+
+# ** Readme! **
+# Don't edit this file! This is the core Makefile for a MaximSDK
+# project. The available configuration options can be overridden
+# in "project.mk", on the command-line, or with system environment
+# variables.
+
+# See https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+# for more detailed instructions on how to use this system.
+
+# The detailed instructions mentioned above are easier to read than
+# this file, but the comments found in this file also outline the
+# available configuration variables. This file is organized into
+# sub-sections, some of which expose config variables.
+
+
+# *******************************************************************************
+# Set the target microcontroller and board to compile for.
+
+# Every TARGET microcontroller has some Board Support Packages (BSPs) that are
+# available for it under the MaximSDK/Libraries/Boards/TARGET folder.  The BSP
+# that gets selected is MaximSDK/Libraries/Boards/TARGET/BOARD.
+
+# Configuration Variables:
+# - TARGET : Override the default target microcontroller.  Ex: TARGET=MAX78000
+# - BOARD : Override the default BSP (case sensitive).  Ex: BOARD=EvKit_V1, BOARD=FTHR_RevA
+
+
+ifeq "$(TARGET)" ""
+# Default target microcontroller
+TARGET := MAX32660
+TARGET_UC := MAX32660
+TARGET_LC := max32660
+else
+# "TARGET" has been overridden in the environment or on the command-line.
+# We need to calculate an upper and lowercase version of the part number,
+# because paths on Linux and MacOS are case-sensitive.
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+endif
+
+# Default board.
+BOARD ?= EvKit_V1
+
+# *******************************************************************************
+# Locate the MaximSDK
+
+# This Makefile needs to know where to find the MaximSDK, and the MAXIM_PATH variable 
+# should point to the root directory of the MaximSDK installation.  Setting this manually
+# is usually only required if you're working on the command-line.
+
+# If MAXIM_PATH is not specified, we assume the project still lives inside of the MaximSDK
+# and move up from this project's original location.
+
+# Configuration Variables:
+# - MAXIM_PATH : Tell this Makefile where to find the MaximSDK.  Ex:  MAXIM_PATH=C:/MaximSDK
+
+
+ifneq "$(MAXIM_PATH)" ""
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+# Locate some other useful paths...
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+endif
+
+# *******************************************************************************
+# Include project Makefile.  We do this after formulating TARGET, BOARD, and MAXIM_PATH
+# in case project.mk needs to reference those values.  However, we also include
+# this as early as possible in the Makefile so that it can append to or override
+# the variables below.
+
+
+PROJECTMK ?= $(abspath ./project.mk)
+include $(PROJECTMK)
+$(info Loaded project.mk)
+# PROJECTMK is also used by implicit rules and other libraries to add project.mk as a watch file
+
+# *******************************************************************************
+# Final path sanitization and re-calculation.  No options here.
+
+ifeq "$(MAXIM_PATH)" ""
+# MAXIM_PATH is still not defined...
+DEPTH := ../../../
+MAXIM_PATH := $(abspath $(DEPTH))
+$(warning Warning:  MAXIM_PATH is not set!  Set MAXIM_PATH in your environment or in project.mk to clear this warning.)
+$(warning Warning:  Attempting to use $(MAXIM_PATH) calculated from relative path)
+else
+# Sanitize MAXIM_PATH for backslashes
+MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
+endif
+
+# Final recalculation of LIBS_DIR/CMSIS_ROOT
+LIBS_DIR := $(abspath $(MAXIM_PATH)/Libraries)
+CMSIS_ROOT := $(LIBS_DIR)/CMSIS
+
+# One final UC/LC check in case user set TARGET in project.mk
+TARGET_UC := $(subst m,M,$(subst a,A,$(subst x,X,$(TARGET))))
+TARGET_LC := $(subst M,m,$(subst A,a,$(subst X,x,$(TARGET))))
+
+export TARGET
+export TARGET_UC
+export TARGET_LC
+export CMSIS_ROOT
+# TODO: Remove dependency on exports for these variables.
+
+# *******************************************************************************
+# Set up search paths, and auto-detect all source code on those paths.
+
+# The following paths are searched by default, where "./" is the project directory.
+# ./
+# |- *.h
+# |- *.c
+# |-include (optional)
+#   |- *.h
+# |-src (optional)
+#   |- *.c
+
+# Configuration Variables:
+# - VPATH : Tell this Makefile to search additional locations for source (.c) files.
+# 			You should use the "+=" operator with this option.
+#			Ex:  VPATH += your/new/path
+# - IPATH : Tell this Makefile to search additional locations for header (.h) files.
+# 			You should use the "+=" operator with this option.
+#			Ex:  VPATH += your/new/path
+# - SRCS : Tell this Makefile to explicitly add a source (.c) file to the build.
+# 			This is really only useful if you want to add a source file that isn't
+#			on any VPATH, in which case you can add the full path to the file here.
+#			You should use the "+=" operator with this option.
+#			Ex:  SRCS += your/specific/source/file.c
+# - AUTOSEARCH : Set whether this Makefile should automatically detect .c files on
+#				VPATH and add them to the build.  This is enabled by default.  Set
+#				to 0 to disable.  If autosearch is disabled, source files must be
+#				manually added to SRCS.
+#				Ex:  AUTOSEARCH = 0
+
+
+# Where to find source files for this project.
+VPATH += .
+VPATH += src
+VPATH := $(VPATH)
+
+# Where to find header files for this project
+IPATH += .
+IPATH += include
+IPATH := $(IPATH)
+
+AUTOSEARCH ?= 1
+ifeq ($(AUTOSEARCH), 1)
+# Auto-detect all C/C++ source files on VPATH
+SRCS += $(wildcard $(addsuffix /*.c, $(VPATH)))
+SRCS += $(wildcard $(addsuffix /*.cpp, $(VPATH)))
+endif
+
+# Collapse SRCS before passing them on to the next stage
+SRCS := $(SRCS)
+
+# *******************************************************************************
+# Set the output filename
+
+# Configuration Variables:
+# - PROJECT : Override the default output filename.  Ex: PROJECT=MyProject
+
+
+# The default value creates a file named after the target micro.  Ex: MAX78000.elf
+PROJECT ?= $(TARGET_LC)
+
+# *******************************************************************************
+# Compiler options
+
+# Configuration Variables:
+# - DEBUG : Set DEBUG=1 to build explicitly for debugging.  This adds some additional
+#			symbols and sets -Og as the default optimization level.
+# - MXC_OPTIMIZE_CFLAGS : Override the default compiler optimization level.
+#			Ex: MXC_OPTIMIZE_CFLAGS = -O2
+# - PROJ_CFLAGS : Add additional compiler flags to the build.
+#			You should use the "+=" operator with this option.
+#			Ex:  PROJ_CFLAGS += -Wextra
+# - MFLOAT_ABI : Set the floating point acceleration level.
+#			The only options are "hard", "soft", or "softfp".
+#			Ex: MFLOAT_ABI = hard
+# - LINKERFILE : Override the default linkerfile.
+#			Ex: LINKERFILE = customlinkerfile.ld
+# - LINKERPATH : Override the default search location for $(LINKERFILE)
+#			The default search location is $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/GCC
+#			If $(LINKERFILE) cannot be found at this path, then the root project
+#			directory will be used as a fallback.
+
+# Select 'GCC' or 'IAR' compiler
+ifeq "$(COMPILER)" ""
+COMPILER := GCC
+endif
+
+# Set default compiler optimization levels
+ifeq "$(MAKECMDGOALS)" "release"
+# Default optimization level for "release" builds (make release)
+MXC_OPTIMIZE_CFLAGS ?= -O2
+DEBUG = 0
+endif
+
+ifeq ($(DEBUG),1)
+# Optimizes for debugging as recommended
+# by GNU for code-edit-debug cycles
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#Optimize-Options
+MXC_OPTIMIZE_CFLAGS := -Og
+endif
+
+# Default level if not building for release or explicitly for debug
+MXC_OPTIMIZE_CFLAGS ?= -Og
+
+# Set compiler flags
+PROJ_CFLAGS += -Wall # Enable warnings
+PROJ_CFLAGS += -DMXC_ASSERT_ENABLE
+
+# Set hardware floating point acceleration.
+# Options are:
+# - hard
+# - soft
+# - softfp (default if MFLOAT_ABI is not set)
+MFLOAT_ABI ?= softfp
+# MFLOAT_ABI must be exported to other Makefiles
+export MFLOAT_ABI
+
+# This path contains system-level intialization files for the target micro.  Add to the build.
+VPATH += $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source
+
+# *******************************************************************************
+# Secure Boot Tools (SBT)
+
+# This section integrates the Secure Boot Tools.  It's intended for use with
+# microcontrollers that have a secure bootloader.
+
+# Enabling SBT integration will add some special rules, such as "make sla", "make scpa", etc.
+
+# Configuration variables:
+#	SBT : 	Toggle SBT integration.  Set to 1 to enable, or 0
+# 			to disable
+#	MAXIM_SBT_DIR : Specify the location of the SBT tool binaries.  This defaults to
+#					Tools/SBT in the MaximSDK.  The standalone SBT installer will override
+#					this via an environment variable.
+#	TARGET_SEC : 	Specify the part number to be passed into the SBT.  This should match
+#					the secure variant part #.  The default value will depend on TARGET.
+#					For example, TARGET=MAX32650 will result in TARGET_SEC=MAX32651, and
+#					the default selection happens in Tools/SBT/SBT-config.
+#					However, if there are multiple secure part #s for the target
+#					microcontroller this variable may need to be changed.
+
+SBT ?= 0
+ifeq ($(SBT), 1)
+MAXIM_SBT_DIR ?= $(MAXIM_PATH)/Tools/SBT
+MAXIM_SBT_DIR := $(subst \,/,$(MAXIM_SBT_DIR))
+# ^ Must sanitize path for \ on Windows, since this may come from an environment
+# variable.
+
+export MAXIM_SBT_DIR # SBTs must have this environment variable defined to work
+
+# SBT-config.mk and SBT-rules.mk are included further down this Makefile.
+
+endif # SBT
+
+# *******************************************************************************
+# Default goal selection.  This section allows you to override the default goal
+# that will run if no targets are specified on the command-line.
+# (ie. just running 'make' instead of 'make all')
+
+# Configuration variables:
+#	.DEFAULT_GOAL : Set the default goal if no targets were specified on the
+#			command-line
+#			** "override" must be used with this variable. **
+#			Ex: "override .DEFAULT_GOAL = mygoal"
+
+ifeq "$(.DEFAULT_GOAL)" ""
+ifeq ($(SBT),1)
+override .DEFAULT_GOAL := sla
+else
+override .DEFAULT_GOAL := all
+endif
+endif
+
+# Developer note:  'override' is used above for legacy Makefile compatibility.
+# gcc.mk/gcc_riscv.mk need to hard-set 'all' internally, so this new system
+# uses 'override' to come in over the top without breaking old projects.
+
+# It's also necessary to explicitly set MAKECMDGOALS...
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+# Enable colors when --sync-output is used.
+# See https://www.gnu.org/software/make/manual/make.html#Terminal-Output (section 13.2)
+ifneq ($(MAKE_TERMOUT),)
+PROJ_CFLAGS += -fdiagnostics-color=always
+endif
+
+ifneq ($(FORCE_COLOR),)
+PROJ_CFLAGS += -fdiagnostics-color=always
+endif
+
+# *******************************************************************************
+# Include SBT config.  We need to do this here because it needs to know
+# the current MAKECMDGOAL.
+ifeq ($(SBT),1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-config.mk
+endif
+
+# *******************************************************************************
+# Libraries
+
+# This section offers "toggle switches" to include or exclude the libraries that
+# are available in the MaximSDK.  Set a configuration variable to 1 to include the
+# library in the build, or 0 to exclude.
+
+# Each library may also have its own library specific configuration variables.  See
+# Libraries/libs.mk for more details.
+
+# Configuration variables:
+# - LIB_BOARD : Include the Board-Support Package (BSP) library. (Enabled by default)
+# - LIB_PERIPHDRIVERS : Include the peripheral driver library.  (Enabled by default)
+# - LIB_CMSIS_DSP : Include the CMSIS-DSP library.
+# - LIB_CORDIO : Include the Cordio BLE library
+# - LIB_FCL : Include the Free Cryptographic Library (FCL)
+# - LIB_FREERTOS : Include the FreeRTOS and FreeRTOS-Plus-CLI libraries
+# - LIB_LC3 : Include the Low Complexity Communication Codec (LC3) library
+# - LIB_LITTLEFS : Include the "little file system" (littleFS) library
+# - LIB_LWIP : Include the lwIP library
+# - LIB_MAXUSB : Include the MAXUSB library
+# - LIB_SDHC : Include the SDHC library
+
+include $(LIBS_DIR)/libs.mk
+
+
+# *******************************************************************************
+# Rules
+
+# Include the rules for building for this target. All other makefiles should be
+# included before this one.
+include $(CMSIS_ROOT)/Device/Maxim/$(TARGET_UC)/Source/$(COMPILER)/$(TARGET_LC).mk
+
+# Include the rules that integrate the SBTs.  SBTs are a special case that must be
+# include after the core gcc rules to extend them.
+ifeq ($(SBT), 1)
+include $(MAXIM_PATH)/Tools/SBT/SBT-rules.mk
+endif
+
+
+# Get .DEFAULT_GOAL working.
+ifeq "$(MAKECMDGOALS)" ""
+MAKECMDGOALS:=$(.DEFAULT_GOAL)
+endif
+
+
+all:
+# 	Extend the functionality of the "all" recipe here
+	arm-none-eabi-size --format=berkeley $(BUILD_DIR)/$(PROJECT).elf
+
+libclean:
+	$(MAKE)  -f ${PERIPH_DRIVER_DIR}/periphdriver.mk clean.periph
+
+clean:
+#	Extend the functionality of the "clean" recipe here
+
+# The rule to clean out all the build products.
+distclean: clean libclean

--- a/Examples/MAX32660/SPIMSS_DMA/README.md
+++ b/Examples/MAX32660/SPIMSS_DMA/README.md
@@ -1,0 +1,35 @@
+## Description
+
+This example configures the SPIMSS to send data between the MOSI (P0.11) and
+MISO (P0.10) pins.  Connect these two pins together.
+
+## Software
+
+### Project Usage
+
+Universal instructions on building, flashing, and debugging this project can be found in the **[MSDK User Guide](https://analog-devices-msdk.github.io/msdk/USERGUIDE/)**.
+
+### Project-Specific Build Notes
+
+(None - this project builds as a standard example)
+
+## Required Connections
+
+-   Connect a USB cable between the PC and the USB connector.
+-   Open an terminal application on the PC and connect to the EV kit's console UART at 115200, 8-N-1.
+-   You must connect P0.10 (MISO) to P0.11 (MOSI).
+
+## Expected Output
+
+```
+************** SPIMSS-DMA Master Demo ****************
+This example configures the SPIMSS to send data between the MISO (P0.10) and
+MOSI (P0.11) pins over dma channels.  Connect these two pins
+together. This demo shows 1024 byte data transfer for 100 times using dma.;
+During this demo you may see junk data printed to the serial port because the
+console UART shares the same pins as the SPIMSS. One DMA channel is used as tx from
+memory to SPIMSS TX FIFO and another dma channel is used for reading data from SPIMSS
+RX FIFO to memory.
+
+Test successful!
+```

--- a/Examples/MAX32660/SPIMSS_DMA/SPIMSS.launch
+++ b/Examples/MAX32660/SPIMSS_DMA/SPIMSS.launch
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals/&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="openocd"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-s ${TOOLCHAIN_PATH}/OpenOCD/scripts -f interface/cmsis-dap.cfg -f target/max32660.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value="${MAXIM_PATH}/Libraries/CMSIS/Device/Maxim/MAX32660/Include/max32660.svd"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="build/SPIMSS.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="SPIMSS"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/SPIMSS"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/Examples/MAX32660/SPIMSS_DMA/main.c
+++ b/Examples/MAX32660/SPIMSS_DMA/main.c
@@ -1,0 +1,179 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2023-2024 Analog Devices, Inc. All Rights Reserved. This
+ * software is proprietary to Analog Devices, Inc. and its licensors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+/**
+ * @file    main.c
+ * @brief   SPI Master DMA Demo
+ * @details Shows Master DMA loopback demo for SPI1 (AKA: SPIMSS)
+ *          Read the printf() for instructions
+ */
+
+/***** Includes *****/
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include "board.h"
+#include "led.h"
+#include "mxc_pins.h"
+#include "spi.h"
+#include "spimss.h"
+#include "uart.h"
+#include "dma.h"
+#include "mxc_delay.h"
+#include "nvic_table.h"
+#include "spimss_regs.h"
+#include "mxc_device.h"
+
+// Enable this macro to enable auto dma channel selection
+// and transaction handling.
+#define SPIMSS_AUTO_DMA_HANDLING 1
+
+#define SPIMSS MXC_SPIMSS
+#define SPI_SPEED 10000000
+#define NUMBER_OF_UNIT_SIZE 512
+#define TRANSFER_UNIT_SIZE 2
+/*
+* Transfer unit size is defined according to the bit
+* count.(BitCount/8) is defined as transfer unit size.
+* tx_data and rx_data is define as uint16_t. So, unit
+* size is 16/8 = 2.
+*/
+#define DATA_VALUE 0x0102
+#define TEST_COUNT 100 // Transaction count.
+
+/**
+ * Transfer unit size is 2. So, we define tx_data and rx_data as uint16_t.
+*/
+uint16_t tx_data[NUMBER_OF_UNIT_SIZE] = { 0 };
+uint16_t rx_data[NUMBER_OF_UNIT_SIZE] = { 0 };
+mxc_spimss_req_t spimss_dma_req;
+
+static uint8_t dma_tx_completed = 0;
+static uint8_t dma_rx_completed = 0;
+
+#if !SPIMSS_AUTO_DMA_HANDLING
+int txChannel = -1;
+int rxChannel = -1;
+#endif
+
+void spimss_callback(mxc_spimss_req_t *req, int error_code)
+{
+    if (NUMBER_OF_UNIT_SIZE * TRANSFER_UNIT_SIZE == req->rx_num) {
+        dma_rx_completed = 1;
+#if !SPIMSS_AUTO_DMA_HANDLING
+        MXC_DMA_DisableInt(rxChannel);
+        MXC_DMA_SetChannelInterruptEn(rxChannel, false, false);
+        MXC_DMA_ReleaseChannel(rxChannel);
+        MXC_SPIMSS_SetRXDMAChannel(SPIMSS, -1);
+        SPIMSS->dma &= ~MXC_F_SPIMSS_DMA_RX_DMA_EN; // Disable SPIMSS RX DMA requests
+#endif
+    } else if (NUMBER_OF_UNIT_SIZE * TRANSFER_UNIT_SIZE == req->tx_num) {
+        dma_tx_completed = 1;
+#if !SPIMSS_AUTO_DMA_HANDLING
+        MXC_DMA_DisableInt(txChannel);
+        MXC_DMA_SetChannelInterruptEn(txChannel, false, false); // Disable ctz interrupt.
+        MXC_DMA_ReleaseChannel(txChannel);
+        MXC_SPIMSS_SetTXDMAChannel(SPIMSS, -1);
+        MXC_SPIMSS->dma &= ~MXC_F_SPIMSS_DMA_TX_DMA_EN; // Disable SPIMSS TX DMA requests
+
+        if (req->deass) {
+            MXC_SPIMSS->mode |= MXC_F_SPIMSS_MODE_SSV; // Set Slave Select to HIGH.
+        }
+        MXC_SPIMSS->ctrl &= ~MXC_F_SPIMSS_CTRL_ENABLE; // Disable SPIMSS transaction.
+#endif
+    }
+}
+
+int main()
+{
+    int i = 0;
+    int ret_val = 0;
+
+    printf(
+        "\n\n************** SPIMSS-DMA Master Demo **************** \nThis example configures the SPIMSS to send data between the MISO (P0.10) and \nMOSI (P0.11) pins over dma channel 0 and dma channel 1.  Connect these two pins\ntogether. This demo shows 1024 byte data transfer for 100 times using dma.\n During this demo you may see junk data printed to the serial port because the\nconsole UART shares the same pins as the SPIMSS.One DMA channel is used as tx from\nmemory to SPIMSS TX FIFO and another dma channel is used for reading data from\nSPIMSS RX FIFO to memory.\n\n");
+
+    // Preparation of the transmission data and receive data buffer.
+    for (i = 0; i < NUMBER_OF_UNIT_SIZE; i++) {
+        tx_data[i] = DATA_VALUE + i;
+        rx_data[i] = 0;
+    }
+
+    // Initialize SPIMSS with MAP_A.
+    // For MAP_A P0.10:MISO, P0.11:MOSI, P0.12:SCK, P0.13:SSEL
+    ret_val = MXC_SPIMSS_Init(SPIMSS, 0, SPI_SPEED, MAP_A);
+    if (E_NO_ERROR != ret_val) {
+        return ret_val;
+    }
+
+    // Prepare the SPIMSS data transaction request.
+    spimss_dma_req.tx_data = (void *)tx_data;
+    spimss_dma_req.rx_data = (void *)rx_data;
+    spimss_dma_req.len = NUMBER_OF_UNIT_SIZE;
+    spimss_dma_req.bits = 16; // This must be >= 8
+    spimss_dma_req.deass = 1;
+    spimss_dma_req.tx_num = 0;
+    spimss_dma_req.rx_num = 0;
+    spimss_dma_req.callback = spimss_callback;
+
+    for (i = 0; i < TEST_COUNT; i++) {
+// Setting auto dma handlers enable acquiring the tx and rx channels
+// automatically in the background.
+#if SPIMSS_AUTO_DMA_HANDLING
+        MXC_SPIMSS_SetAutoDMAHandlers((SPIMSS), true);
+#else
+        MXC_DMA_Init();
+        txChannel = MXC_DMA_AcquireChannel();
+        rxChannel = MXC_DMA_AcquireChannel();
+        if (0 > txChannel || 0 > rxChannel) {
+            break;
+        }
+        MXC_SPIMSS_SetTXDMAChannel(SPIMSS, txChannel);
+        MXC_SPIMSS_SetRXDMAChannel(SPIMSS, rxChannel);
+#endif
+
+        // Calling SPIM transaction function for communication over DMA.
+        ret_val = MXC_SPIMSS_MasterTransDMA(SPIMSS, &spimss_dma_req);
+        if (E_NO_ERROR != ret_val) {
+            printf("Test STOPPED! Err Code -> %d\r\n", ret_val);
+            return ret_val;
+        }
+
+        // Wait until we complete the transaction.
+        while (dma_rx_completed != 1 || dma_tx_completed != 1) {}
+        dma_rx_completed = 0;
+        dma_tx_completed = 0;
+        spimss_dma_req.rx_num = 0; // Setting read byte count to 0.
+        spimss_dma_req.tx_num = 0; // Setting sent byte count to 0.
+
+        // Wait for 10 ms to see the transaction on analyser clearly.
+        MXC_Delay(MXC_DELAY_MSEC(10));
+        if (0 ==
+            memcmp((void *)rx_data, (void *)tx_data, TRANSFER_UNIT_SIZE * NUMBER_OF_UNIT_SIZE)) {
+            printf("Test %d -> Successful\n\r", i);
+        } else {
+            printf("Test %d -> Failed!\n", i);
+        }
+    }
+
+    MXC_SPIMSS_Shutdown(SPIMSS);
+
+    while (1) {}
+
+    return 0;
+}

--- a/Examples/MAX32660/SPIMSS_DMA/project.mk
+++ b/Examples/MAX32660/SPIMSS_DMA/project.mk
@@ -1,0 +1,14 @@
+# This file can be used to set build configuration
+# variables.  These variables are defined in a file called
+# "Makefile" that is located next to this one.
+
+# For instructions on how to use this system, see
+# https://analog-devices-msdk.github.io/msdk/USERGUIDE/#build-system
+
+#BOARD=FTHR_RevA
+# ^ For example, you can uncomment this line to make the
+# project build for the "FTHR_RevA" board.
+
+# **********************************************************
+
+# Add your config here!

--- a/Libraries/PeriphDrivers/Include/MAX32650/spimss.h
+++ b/Libraries/PeriphDrivers/Include/MAX32650/spimss.h
@@ -34,6 +34,7 @@
 #include "mxc_pins.h"
 #include "gpio.h"
 #include "spimss_regs.h"
+#include "stdbool.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -171,6 +172,65 @@ int MXC_SPIMSS_SlaveTransAsync(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req);
  *             MXC_Error_Codes "error" if unsuccessful.
  */
 int MXC_SPIMSS_AbortAsync(mxc_spimss_req_t *req);
+
+/**
+ * @brief     Execute a master transaction over DMA.
+ * @param     spi   Pointer to spi module.
+ * @param     req   Pointer to spi request.
+ *
+ * @return  \c #E_NO_ERROR if successful, @ref
+ *             MXC_Error_Codes "error" if unsuccessful.
+ */
+int MXC_SPIMSS_MasterTransDMA(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req);
+
+/**
+ * @brief      Enable Disable auto dma handling. If set to true, dma channel for transaction
+ *             is acquired in the MXC_SPIMSS_MasterTransDMA function. Otherwise, user has to set
+ *             tx and rx channel for SPIMSS DMA transaction with MXC_SPIMSS_SetTXDMAChannel and 
+ *             MXC_SPIMSS_SetRXDMAChannel functions.
+ *
+ * @param      spi   Pointer to spi module
+ * @param      enable    Enable Disable auto handler
+ * @return  \c #E_NO_ERROR if successful, @ref
+ *             MXC_Error_Codes "error" if unsuccessful.
+*/
+int MXC_SPIMSS_SetAutoDMAHandlers(mxc_spimss_regs_t *spi, bool enable);
+
+/**
+ * @brief      Set the TX channel id for DMA to be used in SPIMSS DMA transaction.
+ *
+ * @param      spi   Pointer to spi module
+ * @param      channel    Id of the channel for TXDma Channel.
+ * @return  \c #E_NO_ERROR if successful, @ref
+ *             MXC_Error_Codes "error" if unsuccessful.
+*/
+int MXC_SPIMSS_SetTXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel);
+
+/**
+ * @brief      Returns the current TX channel id set for SPIMSS DMA transaction.
+ *
+ * @param      spi   Pointer to spi module
+ * @return  \c #TXDMA_ChannelId of the spi module.
+*/
+int MXC_SPIMSS_GetTXDMAChannel(mxc_spimss_regs_t *spi);
+
+/**
+ * @brief      Set the RX channel id for DMA to be used in SPIMSS DMA transaction.
+ *
+ * @param      spi   Pointer to spi module
+ * @param      channel    Id of the channel for RXDma Channel.
+ * @return  \c #E_NO_ERROR if successful, @ref
+ *             MXC_Error_Codes "error" if unsuccessful.
+*/
+int MXC_SPIMSS_SetRXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel);
+
+/**
+ * @brief      Returns the current RX channel id set for SPIMSS DMA transaction.
+ *
+ * @param      spi   Pointer to spi module
+ * @return  \c #RXDMA_ChannelId of the spi module.
+*/
+int MXC_SPIMSS_GetRXDMAChannel(mxc_spimss_regs_t *spi);
 
 /**@} end of group spimss */
 

--- a/Libraries/PeriphDrivers/Include/MAX32660/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/dma.h
@@ -61,19 +61,25 @@ typedef enum {
     MXC_DMA_REQUEST_MEMTOMEM =
         MXC_S_DMA_CFG_REQSEL_MEMTOMEM, ///< Memory to Memory DMA Request Selection
     MXC_DMA_REQUEST_SPI0RX = MXC_S_DMA_CFG_REQSEL_SPI0RX, ///< SPI0 Receive DMA Request Selection
-    MXC_DMA_REQUEST_SPI1RX = MXC_S_DMA_CFG_REQSEL_SPI1RX, ///< SPI1 Receive DMA Request Selection
+    MXC_DMA_REQUEST_SPIMSSRX =
+        MXC_S_DMA_CFG_REQSEL_SPI1RX, ///< SPIMSS Receive DMA Request Selection
     MXC_DMA_REQUEST_UART0RX = MXC_S_DMA_CFG_REQSEL_UART0RX, ///< UART0 Receive DMA Request Selection
     MXC_DMA_REQUEST_UART1RX = MXC_S_DMA_CFG_REQSEL_UART1RX, ///< UART1 Receive DMA Request Selection
     MXC_DMA_REQUEST_I2C0RX = MXC_S_DMA_CFG_REQSEL_I2C0RX, ///< I2C0 Receive DMA Request Selection
     MXC_DMA_REQUEST_I2C1RX = MXC_S_DMA_CFG_REQSEL_I2C1RX, ///< I2C1 Receive DMA Request Selection
     MXC_DMA_REQUEST_SPI0TX = MXC_S_DMA_CFG_REQSEL_SPI0TX, ///< SPI0 Transmit DMA Request Selection
-    MXC_DMA_REQUEST_SPI1TX = MXC_S_DMA_CFG_REQSEL_SPI1TX, ///< SPI1 Transmit DMA Request Selection
+    MXC_DMA_REQUEST_SPIMSSTX =
+        MXC_S_DMA_CFG_REQSEL_SPI1TX, ///< SPIMSS Transmit DMA Request Selection
     MXC_DMA_REQUEST_UART0TX =
         MXC_S_DMA_CFG_REQSEL_UART0TX, ///< UART0 Transmit DMA Request Selection
     MXC_DMA_REQUEST_UART1TX =
         MXC_S_DMA_CFG_REQSEL_UART1TX, ///< UART1 Transmit DMA Request Selection
     MXC_DMA_REQUEST_I2C0TX = MXC_S_DMA_CFG_REQSEL_I2C0TX, ///< I2C0 Transmit DMA Request Selection
     MXC_DMA_REQUEST_I2C1TX = MXC_S_DMA_CFG_REQSEL_I2C1TX, ///< I2C1 Transmit DMA Request Selection
+
+    // Deprecated names
+    MXC_DMA_REQUEST_SPI1RX = MXC_S_DMA_CFG_REQSEL_SPI1RX, ///< SPI1 Receive DMA Request Selection
+    MXC_DMA_REQUEST_SPI1TX = MXC_S_DMA_CFG_REQSEL_SPI1TX, ///< SPI1 Transmit DMA Request Selection
 } mxc_dma_reqsel_t;
 
 /** @brief Enumeration for the DMA prescaler */

--- a/Libraries/PeriphDrivers/Include/MAX32660/spimss.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/spimss.h
@@ -34,6 +34,7 @@
 #include "mxc_pins.h"
 #include "gpio.h"
 #include "spimss_regs.h"
+#include "stdbool.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -125,6 +126,16 @@ int MXC_SPIMSS_Shutdown(mxc_spimss_regs_t *spi);
 int MXC_SPIMSS_MasterTrans(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req);
 
 /**
+ * @brief     Execute a master transaction over DMA.
+ * @param     spi   Pointer to spi module.
+ * @param     req   Pointer to spi request.
+ *
+ * @return  \c #E_NO_ERROR if successful, @ref
+ *             MXC_Error_Codes "error" if unsuccessful.
+ */
+int MXC_SPIMSS_MasterTransDMA(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req);
+
+/**
  * @brief      Execute SPI transaction based on interrupt handler
  * @param      spi   The spi
  *
@@ -171,6 +182,55 @@ int MXC_SPIMSS_SlaveTransAsync(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req);
  *             MXC_Error_Codes "error" if unsuccessful.
  */
 int MXC_SPIMSS_AbortAsync(mxc_spimss_req_t *req);
+
+/**
+ * @brief      Enable Disable auto dma handling. If set to true, dma channel for transaction
+ *             is acquired in the MXC_SPIMSS_MasterTransDMA function. Otherwise, user has to set
+ *             tx and rx channel for SPIMSS DMA transaction with MXC_SPIMSS_SetTXDMAChannel and 
+ *             MXC_SPIMSS_SetRXDMAChannel functions.
+ * 
+ * @param      spi   Pointer to spi module
+ * @param      enable    Enable Disable auto handler
+ * @return  \c #E_NO_ERROR if successful, @ref
+ *             MXC_Error_Codes "error" if unsuccessful. 
+*/
+int MXC_SPIMSS_SetAutoDMAHandlers(mxc_spimss_regs_t *spi, bool enable);
+
+/**
+ * @brief      Set the TX channel id for DMA to be used in SPIMSS DMA transaction.
+ * 
+ * @param      spi   Pointer to spi module
+ * @param      channel    Id of the channel for TXDma Channel.
+ * @return  \c #E_NO_ERROR if successful, @ref
+ *             MXC_Error_Codes "error" if unsuccessful. 
+*/
+int MXC_SPIMSS_SetTXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel);
+
+/**
+ * @brief      Returns the current TX channel id set for SPIMSS DMA transaction.
+ * 
+ * @param      spi   Pointer to spi module
+ * @return  \c #TXDMA_ChannelId of the spi module. 
+*/
+int MXC_SPIMSS_GetTXDMAChannel(mxc_spimss_regs_t *spi);
+
+/**
+ * @brief      Set the RX channel id for DMA to be used in SPIMSS DMA transaction.
+ * 
+ * @param      spi   Pointer to spi module
+ * @param      channel    Id of the channel for RXDma Channel.
+ * @return  \c #E_NO_ERROR if successful, @ref
+ *             MXC_Error_Codes "error" if unsuccessful. 
+*/
+int MXC_SPIMSS_SetRXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel);
+
+/**
+ * @brief      Returns the current RX channel id set for SPIMSS DMA transaction.
+ * 
+ * @param      spi   Pointer to spi module
+ * @return  \c #RXDMA_ChannelId of the spi module. 
+*/
+int MXC_SPIMSS_GetRXDMAChannel(mxc_spimss_regs_t *spi);
 
 /**@} end of group spimss */
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -256,7 +256,7 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
             break;
 
         case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
+            reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
             break;
 
         default:
@@ -271,7 +271,7 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
             break;
 
         case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1RX;
+            reqselTx = MXC_DMA_REQUEST_SPIMSSRX;
             break;
 
         default:
@@ -310,7 +310,7 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
             break;
 
         case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
+            reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
             break;
 
         default:
@@ -325,7 +325,7 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
             break;
 
         case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
+            reqselRx = MXC_DMA_REQUEST_SPIMSSRX;
             break;
 
         default:

--- a/Libraries/PeriphDrivers/Source/SPIMSS/spimss_me10.c
+++ b/Libraries/PeriphDrivers/Source/SPIMSS/spimss_me10.c
@@ -93,8 +93,45 @@ int MXC_SPIMSS_SlaveTransAsync(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req)
 {
     return MXC_SPIMSS_RevA_SlaveTransAsync((mxc_spimss_reva_regs_t *)spi, (spimss_reva_req_t *)req);
 }
+
 /* ************************************************************************* */
 int MXC_SPIMSS_AbortAsync(mxc_spimss_req_t *req)
 {
     return MXC_SPIMSS_RevA_AbortAsync((spimss_reva_req_t *)req);
+}
+
+/* ************************************************************************** */
+int MXC_SPIMSS_MasterTransDMA(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req)
+{
+    return MXC_SPIMSS_RevA_MasterTransDMA((mxc_spimss_reva_regs_t *)spi, (spimss_reva_req_t *)req);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_SetAutoDMAHandlers(mxc_spimss_regs_t *spi, bool enable)
+{
+    return MXC_SPIMSS_RevA_SetAutoDMAHandlers((mxc_spimss_reva_regs_t *)spi, enable);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_SetTXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel)
+{
+    return MXC_SPIMSS_RevA_SetTXDMAChannel((mxc_spimss_reva_regs_t *)spi, channel);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_GetTXDMAChannel(mxc_spimss_regs_t *spi)
+{
+    return MXC_SPIMSS_RevA_GetTXDMAChannel((mxc_spimss_reva_regs_t *)spi);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_SetRXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel)
+{
+    return MXC_SPIMSS_RevA_SetRXDMAChannel((mxc_spimss_reva_regs_t *)spi, channel);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_GetRXDMAChannel(mxc_spimss_regs_t *spi)
+{
+    return MXC_SPIMSS_RevA_GetRXDMAChannel((mxc_spimss_reva_regs_t *)spi);
 }

--- a/Libraries/PeriphDrivers/Source/SPIMSS/spimss_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPIMSS/spimss_me11.c
@@ -95,6 +95,12 @@ int MXC_SPIMSS_MasterTrans(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req)
 }
 
 /* ************************************************************************** */
+int MXC_SPIMSS_MasterTransDMA(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req)
+{
+    return MXC_SPIMSS_RevA_MasterTransDMA((mxc_spimss_reva_regs_t *)spi, (spimss_reva_req_t *)req);
+}
+
+/* ************************************************************************** */
 int MXC_SPIMSS_SlaveTrans(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req)
 {
     return MXC_SPIMSS_RevA_SlaveTrans((mxc_spimss_reva_regs_t *)spi, (spimss_reva_req_t *)req);
@@ -112,8 +118,39 @@ int MXC_SPIMSS_SlaveTransAsync(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req)
 {
     return MXC_SPIMSS_RevA_SlaveTransAsync((mxc_spimss_reva_regs_t *)spi, (spimss_reva_req_t *)req);
 }
+
 /* ************************************************************************* */
 int MXC_SPIMSS_AbortAsync(mxc_spimss_req_t *req)
 {
     return MXC_SPIMSS_RevA_AbortAsync((spimss_reva_req_t *)req);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_SetAutoDMAHandlers(mxc_spimss_regs_t *spi, bool enable)
+{
+    return MXC_SPIMSS_RevA_SetAutoDMAHandlers((mxc_spimss_reva_regs_t *)spi, enable);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_SetTXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel)
+{
+    return MXC_SPIMSS_RevA_SetTXDMAChannel((mxc_spimss_reva_regs_t *)spi, channel);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_GetTXDMAChannel(mxc_spimss_regs_t *spi)
+{
+    return MXC_SPIMSS_RevA_GetTXDMAChannel((mxc_spimss_reva_regs_t *)spi);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_SetRXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel)
+{
+    return MXC_SPIMSS_RevA_SetRXDMAChannel((mxc_spimss_reva_regs_t *)spi, channel);
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_GetRXDMAChannel(mxc_spimss_regs_t *spi)
+{
+    return MXC_SPIMSS_RevA_GetRXDMAChannel((mxc_spimss_reva_regs_t *)spi);
 }

--- a/Libraries/PeriphDrivers/Source/SPIMSS/spimss_reva.c
+++ b/Libraries/PeriphDrivers/Source/SPIMSS/spimss_reva.c
@@ -34,6 +34,8 @@
 #include "mxc_sys.h"
 #include "spimss_reva.h"
 #include "mxc_lock.h"
+#include "dma.h"
+#include "nvic_table.h"
 
 /**
  * @ingroup spimss
@@ -45,6 +47,10 @@
 /* **** Globals **** */
 typedef struct {
     spimss_reva_req_t *req;
+    mxc_spimss_reva_regs_t *spi;
+    int channelTx;
+    int channelRx;
+    bool auto_dma_handlers;
 } spimss_reva_req_state_t;
 
 static spimss_reva_req_state_t states[MXC_SPIMSS_INSTANCES];
@@ -67,6 +73,11 @@ int MXC_SPIMSS_RevA_Init(mxc_spimss_reva_regs_t *spi, unsigned mode, unsigned fr
 
     spi_num = MXC_SPIMSS_GET_IDX((mxc_spimss_regs_t *)spi);
     states[spi_num].req = NULL;
+    states[spi_num].channelTx = -1;
+    states[spi_num].channelRx = -1;
+    states[spi_num].auto_dma_handlers = false;
+    states[spi_num].spi = spi;
+
     spi->ctrl &= ~(MXC_F_SPIMSS_REVA_CTRL_ENABLE); // Keep the SPI Disabled (This is the SPI Start)
 
     // Set the bit rate
@@ -139,7 +150,7 @@ int MXC_SPIMSS_RevA_TransSetup(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *r
     spi_num = MXC_SPIMSS_GET_IDX((mxc_spimss_regs_t *)spi);
     MXC_ASSERT(spi_num >= 0);
 
-    if (req->len == 0) {
+    if (0 == req->len) {
         return 0;
     }
 
@@ -159,11 +170,10 @@ int MXC_SPIMSS_RevA_TransSetup(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *r
     }
 
     // Setup the character size
-
     if (req->bits < 16) {
         MXC_SETFIELD(spi->mode, MXC_F_SPIMSS_REVA_MODE_NUMBITS,
                      req->bits << MXC_F_SPIMSS_REVA_MODE_NUMBITS_POS);
-
+        spi->mode |= MXC_F_SPIMSS_REVA_MODE_TX_LJ;
     } else {
         MXC_SETFIELD(spi->mode, MXC_F_SPIMSS_REVA_MODE_NUMBITS,
                      0 << MXC_F_SPIMSS_REVA_MODE_NUMBITS_POS);
@@ -228,6 +238,203 @@ int MXC_SPIMSS_RevA_MasterTrans(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *
     spi->ctrl &=
         ~(MXC_F_SPIMSS_REVA_CTRL_ENABLE); // Last of the SPIMSS value has been transmitted...
     // stop the transmission...
+    return E_NO_ERROR;
+}
+
+/* ************************************************************************** */
+void MXC_SPIMSS_RevA_DMA_Handler(int ch, int error)
+{
+    int transaction_size = 0;
+    spimss_reva_req_t *temp_req = NULL;
+
+    for (int i = 0; i < MXC_SPIMSS_INSTANCES; i++) {
+        temp_req = states[i].req;
+        transaction_size = (temp_req->bits / 8) * (temp_req->len);
+
+        if (ch == states[i].channelTx) {
+            states[i].req->tx_num = transaction_size - (MXC_DMA)->ch[ch].cnt;
+
+            if ((true == states[i].auto_dma_handlers) && (0 == (MXC_DMA)->ch[ch].cnt)) {
+                //Disable interrupts.
+                MXC_DMA_DisableInt(ch);
+                MXC_DMA_SetChannelInterruptEn(ch, false, false); // Disable ctz interrupt.
+                MXC_DMA_ReleaseChannel(ch);
+                states[i].spi->dma &=
+                    ~(MXC_F_SPIMSS_REVA_DMA_TX_DMA_EN); // Disable SPIMSS TX DMA requests
+                states[i].channelTx = -1;
+            }
+
+            if (NULL != temp_req->callback) {
+                temp_req->callback(temp_req, E_NO_ERROR);
+            }
+            break;
+        } else if (ch == states[i].channelRx) {
+            states[i].req->rx_num = transaction_size - (MXC_DMA)->ch[ch].cnt;
+
+            if ((true == states[i].auto_dma_handlers) && (0 == (MXC_DMA)->ch[ch].cnt)) {
+                //Disable interrupts.
+                MXC_DMA_DisableInt(ch);
+                MXC_DMA_SetChannelInterruptEn(ch, false, false); // Disable ctz interrupt.
+                MXC_DMA_ReleaseChannel(ch);
+
+                if (temp_req->deass) {
+                    states[i].spi->mode |= MXC_F_SPIMSS_REVA_MODE_SSV; // Set Slave Select to HIGH.
+                }
+                states[i].spi->ctrl &=
+                    ~MXC_F_SPIMSS_REVA_CTRL_ENABLE; // Disable SPIMSS transaction.
+
+                states[i].spi->dma &=
+                    ~MXC_F_SPIMSS_REVA_DMA_RX_DMA_EN; // Disable SPIMSS RX DMA requests
+
+                states[i].channelRx = -1;
+                states[i].auto_dma_handlers = false;
+                states[i].req = NULL;
+            }
+
+            MXC_FreeLock((uint32_t *)&states[i].req);
+            if (NULL != temp_req->callback) {
+                temp_req->callback(temp_req, E_NO_ERROR);
+            }
+            break;
+        }
+    }
+}
+
+static mxc_dma_config_t dma_config_tx;
+static mxc_dma_config_t dma_config_rx;
+static mxc_dma_adv_config_t dma_adv_config_tx;
+static mxc_dma_adv_config_t dma_adv_config_rx;
+static mxc_dma_srcdst_t srcdst_config_tx;
+static mxc_dma_srcdst_t srcdst_config_rx;
+/* ************************************************************************** */
+int MXC_SPIMSS_RevA_MasterTransDMA(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *req)
+{
+    // Calculating the transaction size in byte.
+    int sent_byte_len = ((req->len * (req->bits / 8)) - req->tx_num);
+    int tx_channel_id = -1;
+    int rx_channel_id = -1;
+    int spi_num = MXC_SPIMSS_GET_IDX((mxc_spimss_regs_t *)spi);
+    int ret_val = E_NO_ERROR;
+
+    //Reset static variables.
+    memset(&dma_config_tx, 0, sizeof(dma_config_tx));
+    memset(&dma_config_rx, 0, sizeof(dma_config_rx));
+    memset(&srcdst_config_tx, 0, sizeof(srcdst_config_tx));
+    memset(&srcdst_config_rx, 0, sizeof(srcdst_config_rx));
+    memset(&dma_adv_config_tx, 0, sizeof(dma_adv_config_tx));
+    memset(&dma_adv_config_rx, 0, sizeof(dma_adv_config_rx));
+
+    //We use SPIMSS master trans function to send data from
+    ret_val = MXC_SPIMSS_RevA_TransSetup(spi, req, 1);
+    if (E_NO_ERROR != ret_val) {
+        return ret_val;
+    }
+
+    //Setting dmas fifo levels for tx and rx in spimss.
+    spi->dma &= ~(MXC_F_SPIMSS_DMA_RX_FIFO_LVL);
+    spi->dma &= ~(MXC_F_SPIMSS_DMA_TX_FIFO_LVL);
+
+    //Initialization of DMA
+    if (true == states[spi_num].auto_dma_handlers) {
+        MXC_DMA_Init();
+    }
+
+    if ((true == states[spi_num].auto_dma_handlers) && (0 > states[spi_num].channelTx)) {
+        //Getting the available tx channel id.
+        tx_channel_id = MXC_DMA_AcquireChannel();
+        if (tx_channel_id < 0) {
+            return tx_channel_id;
+        }
+        MXC_SPIMSS_RevA_SetTXDMAChannel(spi, tx_channel_id);
+
+    } else {
+        tx_channel_id = MXC_SPIMSS_RevA_GetTXDMAChannel(spi);
+        if (tx_channel_id < 0) {
+            return E_BAD_STATE;
+        }
+    }
+    //Enable NVIC interrupt of the dma channel which will be used as TX channel.
+    MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(tx_channel_id), MXC_DMA_Handler);
+
+    if ((true == states[spi_num].auto_dma_handlers) && (0 > states[spi_num].channelRx)) {
+        rx_channel_id = MXC_DMA_AcquireChannel();
+        if (rx_channel_id < 0) {
+            return rx_channel_id;
+        }
+        MXC_SPIMSS_RevA_SetRXDMAChannel(spi, rx_channel_id);
+    } else {
+        rx_channel_id = MXC_SPIMSS_RevA_GetRXDMAChannel(spi);
+        if (rx_channel_id < 0) {
+            return E_BAD_STATE;
+        }
+    }
+    //Enable NVIC interrupt of the dma channel which will be used as RX channel.
+    MXC_NVIC_SetVector(MXC_DMA_CH_GET_IRQ(rx_channel_id), MXC_DMA_Handler);
+
+    states[spi_num].req = req;
+
+    // TX dma configuration settings.
+    dma_config_tx.ch = tx_channel_id;
+    dma_config_tx.reqsel = MXC_DMA_REQUEST_SPIMSSTX;
+    dma_config_tx.dstwd = MXC_DMA_WIDTH_HALFWORD;
+    dma_config_tx.srcwd = MXC_DMA_WIDTH_HALFWORD;
+    dma_config_tx.dstinc_en = 0; // Ignored since the destination is set to SPIMSS TX fifo.
+    dma_config_tx.srcinc_en = 1;
+
+    // advanced config for tx channel
+    dma_adv_config_tx.ch = tx_channel_id;
+    dma_adv_config_tx.burst_size = req->bits < 16 ? 1 : 2;
+
+    // advanced config for rx channel
+    dma_adv_config_rx.ch = rx_channel_id;
+    dma_adv_config_rx.burst_size = req->bits < 16 ? 1 : 2;
+
+    dma_config_rx.ch = rx_channel_id;
+    dma_config_rx.reqsel = MXC_DMA_REQUEST_SPIMSSRX;
+    dma_config_rx.dstwd = MXC_DMA_WIDTH_HALFWORD;
+    dma_config_rx.srcwd = MXC_DMA_WIDTH_HALFWORD;
+    dma_config_rx.dstinc_en = 1;
+    dma_config_rx.srcinc_en = 0; // Ignored since the source is set to SPIMSS RX fifo.
+
+    //Setting TX configuration values for this spi transaction.
+    srcdst_config_tx.ch = tx_channel_id;
+    srcdst_config_tx.len = sent_byte_len;
+    srcdst_config_tx.source = req->tx_data;
+    MXC_DMA_ConfigChannel(dma_config_tx, srcdst_config_tx);
+    MXC_DMA_AdvConfigChannel(dma_adv_config_tx);
+
+    // Enable TX channel CTZ interrupt to be sure that TX operation is completed
+    MXC_DMA_ChannelClearFlags(tx_channel_id,
+                              MXC_DMA_ChannelGetFlags(tx_channel_id)); // Clear interrupts.
+    MXC_DMA_EnableInt(tx_channel_id); // Enable DMA peripheral
+    //interrupt for txChannel.
+
+    MXC_DMA_SetCallback(tx_channel_id, MXC_SPIMSS_RevA_DMA_Handler);
+    MXC_DMA_SetChannelInterruptEn(tx_channel_id, false, true); // Enable ctz interrupt.
+    MXC_DMA_Start(tx_channel_id);
+
+    // rx src dst config.
+    srcdst_config_rx.ch = rx_channel_id;
+    srcdst_config_rx.len = sent_byte_len;
+    srcdst_config_rx.dest = req->rx_data;
+    MXC_DMA_ConfigChannel(dma_config_rx, srcdst_config_rx);
+    MXC_DMA_AdvConfigChannel(dma_adv_config_rx);
+
+    //Enable RX channel CTZ interrupt to be sure that RX operation is completed.
+    MXC_DMA_ChannelClearFlags(rx_channel_id,
+                              MXC_DMA_ChannelGetFlags(rx_channel_id)); // Clear interrupts.
+    MXC_DMA_EnableInt(rx_channel_id); // Enable DMA peripheral
+    //interrupt for txChannel.
+    MXC_DMA_SetCallback(rx_channel_id, MXC_SPIMSS_RevA_DMA_Handler);
+    MXC_DMA_SetChannelInterruptEn(rx_channel_id, false, true); // Enable ctz interrupt.
+    MXC_DMA_Start(rx_channel_id);
+
+    spi->dma |= MXC_F_SPIMSS_REVA_DMA_TX_DMA_EN; // Enable TX DMA requests
+    spi->dma |= MXC_F_SPIMSS_REVA_DMA_RX_DMA_EN; // Enable RX DMA requests
+
+    spi->mode &= ~(MXC_F_SPIMSS_REVA_MODE_SSV); // Set Slave Select to LOW.
+    spi->ctrl |= (MXC_F_SPIMSS_REVA_CTRL_ENABLE); // Start transaction.
+
     return E_NO_ERROR;
 }
 
@@ -483,5 +690,48 @@ int MXC_SPIMSS_RevA_AbortAsync(spimss_reva_req_t *req)
     }
 
     return E_BAD_PARAM;
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_RevA_SetAutoDMAHandlers(mxc_spimss_reva_regs_t *spi, bool enable)
+{
+    int n = MXC_SPIMSS_GET_IDX((mxc_spimss_regs_t *)spi);
+
+    states[n].auto_dma_handlers = enable;
+
+    return E_NO_ERROR;
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_RevA_SetTXDMAChannel(mxc_spimss_reva_regs_t *spi, unsigned int channel)
+{
+    int n = MXC_SPIMSS_GET_IDX((mxc_spimss_regs_t *)spi);
+
+    states[n].channelTx = channel;
+
+    return E_NO_ERROR;
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_RevA_GetTXDMAChannel(mxc_spimss_reva_regs_t *spi)
+{
+    int n = MXC_SPIMSS_GET_IDX((mxc_spimss_regs_t *)spi);
+    return states[n].channelTx;
+}
+
+/* ************************************************************************* */
+int MXC_SPIMSS_RevA_SetRXDMAChannel(mxc_spimss_reva_regs_t *spi, unsigned int channel)
+{
+    int n = MXC_SPIMSS_GET_IDX((mxc_spimss_regs_t *)spi);
+
+    states[n].channelRx = channel;
+
+    return E_NO_ERROR;
+}
+int MXC_SPIMSS_RevA_GetRXDMAChannel(mxc_spimss_reva_regs_t *spi)
+{
+    int n = MXC_SPIMSS_GET_IDX((mxc_spimss_regs_t *)spi);
+
+    return states[n].channelRx;
 }
 /**@} end of group spimss */

--- a/Libraries/PeriphDrivers/Source/SPIMSS/spimss_reva.h
+++ b/Libraries/PeriphDrivers/Source/SPIMSS/spimss_reva.h
@@ -87,9 +87,16 @@ int MXC_SPIMSS_RevA_Init(mxc_spimss_reva_regs_t *spi, unsigned mode, unsigned fr
 int MXC_SPIMSS_RevA_Shutdown(mxc_spimss_reva_regs_t *spi);
 void MXC_SPIMSS_RevA_Handler(mxc_spimss_reva_regs_t *spi);
 int MXC_SPIMSS_RevA_MasterTrans(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *req);
+int MXC_SPIMSS_RevA_MasterTransDMA(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *req);
 int MXC_SPIMSS_RevA_SlaveTrans(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *req);
 int MXC_SPIMSS_RevA_MasterTransAsync(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *req);
 int MXC_SPIMSS_RevA_SlaveTransAsync(mxc_spimss_reva_regs_t *spi, spimss_reva_req_t *req);
 int MXC_SPIMSS_RevA_AbortAsync(spimss_reva_req_t *req);
+
+int MXC_SPIMSS_RevA_SetAutoDMAHandlers(mxc_spimss_reva_regs_t *spi, bool enable);
+int MXC_SPIMSS_RevA_SetTXDMAChannel(mxc_spimss_reva_regs_t *spi, unsigned int channel);
+int MXC_SPIMSS_RevA_GetTXDMAChannel(mxc_spimss_reva_regs_t *spi);
+int MXC_SPIMSS_RevA_SetRXDMAChannel(mxc_spimss_reva_regs_t *spi, unsigned int channel);
+int MXC_SPIMSS_RevA_GetRXDMAChannel(mxc_spimss_reva_regs_t *spi);
 
 #endif // LIBRARIES_PERIPHDRIVERS_SOURCE_SPIMSS_SPIMSS_REVA_H_


### PR DESCRIPTION
## Description
There is no transaction API over DMA for SPIMSS driver in MSDK. In addition, we don't have example application which shows how to make SPIMSS master transaction by using DMA. 

Implemented Example:
SPIMSS_DMA example code is added for MAX32660 EVSYS

Implemented API Features:
SPIMSS DMA "Auto handlers". Auto handling is disabled by default.
APIs for using application defined DMA handlers and channels.

New API for SPIMSS Master Dma Transaction:
int MXC_SPIMSS_MasterTransDMA(mxc_spimss_regs_t *spi, mxc_spimss_req_t *req);

New APIs for Assigning DMA Channels:
int MXC_SPIMSS_SetTXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel);
int MXC_SPIMSS_SetRXDMAChannel(mxc_spimss_regs_t *spi, unsigned int channel);
int MXC_SPIMSS_GetTXDMAChannel(mxc_spimss_regs_t *spi);
int MXC_SPIMSS_GetRXDMAChannel(mxc_spimss_regs_t *spi);

