### PR TITLE
fix(CMSIS): Fix MAX32690 SRAM Size Calculation

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32690/Source/GCC/max32690_memory.mk
+++ b/Libraries/CMSIS/Device/Maxim/MAX32690/Source/GCC/max32690_memory.mk
@@ -2,7 +2,7 @@
 PROJ_AFLAGS += -DFLASH_ORIGIN=0x10000000
 PROJ_AFLAGS += -DFLASH_SIZE=0x340000
 PROJ_AFLAGS += -DSRAM_ORIGIN=0x20000000
-PROJ_AFLAGS += -DSRAM_SIZE=0x120000
+PROJ_AFLAGS += -DSRAM_SIZE=0x100000
 
 # Each core has a mailbox in the RISCV core SRAM memory space.
 # Total memory allocated for boxes will be 2*MAILBOX_SIZE


### PR DESCRIPTION
## Pull Request Template

### Description

Total SRAM size shall be 1MB.
In linker file SRAM size calculated by below formula ARM_SRAM_SIZE = _SRAM_SIZE - _RISCV_SRAM_SIZE;
ARM SRAM size shall be less than total incase of riscv core enabled.

This condition causes issue while working on DAPLink fw for MAX32690.

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [X] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.


![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/26f77879-31ea-4d31-a06d-b4279931e30f)

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/86574a47-0773-4c00-a6db-03707b7258db)

