### PR TITLE
fix(PeriphDrivers): Required SDK Changes for ME55 SKB and SPI_Usecase Examples. 

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32572/mxc_pins.h
+++ b/Libraries/PeriphDrivers/Include/MAX32572/mxc_pins.h
@@ -38,16 +38,14 @@
 
 #ifndef LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32572_MXC_PINS_H_
 #define LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32572_MXC_PINS_H_
-
+ typedef enum { MAP_A, MAP_B } sys_map_t;
 #include "gpio.h"
 
 /***** Global Variables *****/
 // Predefined GPIO Configurations
+extern const mxc_gpio_cfg_t gpio_cfg_extclk;
 extern const mxc_gpio_cfg_t gpio_cfg_i2c0;
 extern const mxc_gpio_cfg_t gpio_cfg_i2c1;
-extern const mxc_gpio_cfg_t gpio_cfg_i2c2;
-extern const mxc_gpio_cfg_t gpio_cfg_i2c2b;
-extern const mxc_gpio_cfg_t gpio_cfg_i2c2c;
 
 extern const mxc_gpio_cfg_t gpio_cfg_uart0;
 extern const mxc_gpio_cfg_t gpio_cfg_uart0_flow;
@@ -62,13 +60,6 @@ extern const mxc_gpio_cfg_t gpio_cfg_uart3;
 extern const mxc_gpio_cfg_t gpio_cfg_uart3_flow;
 extern const mxc_gpio_cfg_t gpio_cfg_uart3_flow_disable;
 
-extern const mxc_gpio_cfg_t gpio_cfg_spi0;
-// NOTE: SPI1 definied here with SS1 only, SS0 is on port0 by itself.
-extern const mxc_gpio_cfg_t gpio_cfg_spi1;
-// NOTE: SPI2 defined here with SS0 only, and NOT SS1 and SS2
-extern const mxc_gpio_cfg_t gpio_cfg_spi2;
-extern const mxc_gpio_cfg_t gpio_cfg_spi2b;
-
 // Timers are only defined once, depending on package, each timer could be mapped to other pins
 extern const mxc_gpio_cfg_t gpio_cfg_tmr0;
 extern const mxc_gpio_cfg_t gpio_cfg_tmr1;
@@ -77,7 +68,9 @@ extern const mxc_gpio_cfg_t gpio_cfg_tmr3;
 extern const mxc_gpio_cfg_t gpio_cfg_tmr4;
 extern const mxc_gpio_cfg_t gpio_cfg_tmr5;
 
-// Pulse trains are only defined once, depending on package, each PT could be mapped to other pins
+extern const mxc_gpio_cfg_t gpio_cfg_rtcsqw;
+extern const mxc_gpio_cfg_t gpio_cfg_rtcsqwb;
+
 extern const mxc_gpio_cfg_t gpio_cfg_pt0;
 extern const mxc_gpio_cfg_t gpio_cfg_pt1;
 extern const mxc_gpio_cfg_t gpio_cfg_pt2;
@@ -87,44 +80,45 @@ extern const mxc_gpio_cfg_t gpio_cfg_pt5;
 extern const mxc_gpio_cfg_t gpio_cfg_pt6;
 extern const mxc_gpio_cfg_t gpio_cfg_pt7;
 
-extern const mxc_gpio_cfg_t gpio_cfg_owm;
-extern const mxc_gpio_cfg_t gpio_cfg_owmb;
+extern const mxc_gpio_cfg_t gpio_cfg_rv_jtag;
 
-// Port 0 Pins 6-14, Port 1 Pins 1-5 and 16-19, Port 2 Pins 10-19
-// Other configurations are available, depending on package, to allow the use of EMAC or SDHC
-// Note that both P1a and P1b must be configured for proper operation
-extern const mxc_gpio_cfg_t gpio_cfg_P0_clcd;
-extern const mxc_gpio_cfg_t gpio_cfg_P1a_clcd;
-extern const mxc_gpio_cfg_t gpio_cfg_P1b_clcd;
-extern const mxc_gpio_cfg_t gpio_cfg_P2_clcd;
-
-extern const mxc_gpio_cfg_t gpio_cfg_rtcsqw;
-extern const mxc_gpio_cfg_t gpio_cfg_rtcsqwb;
-
-extern const mxc_gpio_cfg_t gpio_cfg_sdhc;
-extern const mxc_gpio_cfg_t gpio_cfg_sdhcb;
-
-extern const mxc_gpio_cfg_t gpio_cfg_sc0;
-extern const mxc_gpio_cfg_t gpio_cfg_sc1;
-
-// Note that both P0 and P1 must be configured for proper operation
 extern const mxc_gpio_cfg_t gpio_cfg_spixf;
-extern const mxc_gpio_cfg_t gpio_cfg_spixr_P0;
-extern const mxc_gpio_cfg_t gpio_cfg_spixr_P1;
 
-// Note that both P2a and P2b must be configured for proper operation
-extern const mxc_gpio_cfg_t gpio_cfg_emac_P2a;
-extern const mxc_gpio_cfg_t gpio_cfg_emac_P2b;
+// SPI v2 Pin Definitions
+extern const mxc_gpio_cfg_t gpio_cfg_spi0_standard;
+extern const mxc_gpio_cfg_t gpio_cfg_spi0_3wire;
+extern const mxc_gpio_cfg_t gpio_cfg_spi0_dual;
+extern const mxc_gpio_cfg_t gpio_cfg_spi0_quad;
+extern const mxc_gpio_cfg_t gpio_cfg_spi1_standard;
+extern const mxc_gpio_cfg_t gpio_cfg_spi1_3wire;
+extern const mxc_gpio_cfg_t gpio_cfg_spi1_dual;
+extern const mxc_gpio_cfg_t gpio_cfg_spi1_quad;
+// SPI2 does not exist in the MAX32572 (to match instance addressing with MAX32570B)
+extern const mxc_gpio_cfg_t gpio_cfg_spi3_standard;
+extern const mxc_gpio_cfg_t gpio_cfg_spi3_3wire;
+extern const mxc_gpio_cfg_t gpio_cfg_spi3_dual;
+extern const mxc_gpio_cfg_t gpio_cfg_spi3_quad;
 
-// Note that all of the following must be configured for proper operation
+// SPI v2 Target Selects Pin Definitions
+extern const mxc_gpio_cfg_t gpio_cfg_spi0_ts0;
+extern const mxc_gpio_cfg_t gpio_cfg_spi1_ts0;
+extern const mxc_gpio_cfg_t gpio_cfg_spi1_ts1;
+extern const mxc_gpio_cfg_t gpio_cfg_spi1_ts2;
+extern const mxc_gpio_cfg_t gpio_cfg_spi1_ts3;
+// SPI2 does not exist in the MAX32572 (to match instance addressing with MAX32570B)
+extern const mxc_gpio_cfg_t gpio_cfg_spi3_ts0;
+extern const mxc_gpio_cfg_t gpio_cfg_spi3_ts1;
+extern const mxc_gpio_cfg_t gpio_cfg_spi3_ts2;
+extern const mxc_gpio_cfg_t gpio_cfg_spi3_ts3;
+
+extern const mxc_gpio_cfg_t gpio_cfg_adc_ain0;
+extern const mxc_gpio_cfg_t gpio_cfg_adc_ain1;
+extern const mxc_gpio_cfg_t gpio_cfg_adc_ain2;
+extern const mxc_gpio_cfg_t gpio_cfg_adc_ain3;
+extern const mxc_gpio_cfg_t gpio_cfg_adc_ain4;
+extern const mxc_gpio_cfg_t gpio_cfg_adc_ain5;
+extern const mxc_gpio_cfg_t gpio_cfg_adc_ain6;
+extern const mxc_gpio_cfg_t gpio_cfg_adc_ain7;
+
 extern const mxc_gpio_cfg_t gpio_cfg_kbd_P2;
-
-// Note that both P0 and P1 must be configured for proper operation
-extern const mxc_gpio_cfg_t gpio_cfg_pcif_P0;
-extern const mxc_gpio_cfg_t gpio_cfg_pcif_P1;
-extern const mxc_gpio_cfg_t gpio_cfg_pcif_hsync;
-extern const mxc_gpio_cfg_t gpio_cfg_pcif_vsync;
-extern const mxc_gpio_cfg_t gpio_cfg_pcif_pclk;
-extern const mxc_gpio_cfg_t gpio_cfg_pcif_pwrdwn;
-
 #endif // LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32572_MXC_PINS_H_

--- a/Libraries/PeriphDrivers/Source/SKBD/skbd_reva.c
+++ b/Libraries/PeriphDrivers/Source/SKBD/skbd_reva.c
@@ -119,11 +119,10 @@ int MXC_SKBD_RevA_Init(mxc_skbd_reva_regs_t *skbd, mxc_skbd_config_t config)
         }
 
         /* Configure the SKBD  */
-        temp =
-            ((config.reg_erase << MXC_F_SKBD_REVA_CTRL1_CLEAR_POS) | MXC_F_SKBD_REVA_CTRL1_AUTOEN);
-        temp |= (config.debounce << MXC_F_SKBD_REVA_CTRL1_DBTM_POS) & MXC_F_SKBD_REVA_CTRL1_DBTM;
-        temp |= (outputs << MXC_F_SKBD_REVA_CTRL1_OUTNB_POS) & MXC_F_SKBD_REVA_CTRL1_OUTNB;
-        skbd->ctrl1 |= temp;
+        skbd->ctrl1 = MXC_F_SKBD_REVA_CTRL1_AUTOEN // ->ctrl1[0]
+        		| MXC_F_SKBD_REVA_CTRL1_CLEAR // ->ctrl1[1]
+        		| MXC_F_SKBD_REVA_CTRL1_OUTNB //ctrl1[11:8]
+        		| config.debounce << MXC_F_SKBD_REVA_CTRL1_DBTM_POS; //ctrl1[15:13]
 
         while (!(skbd->sr & MXC_F_SKBD_REVA_SR_BUSY)) {}
 

--- a/Libraries/PeriphDrivers/Source/SPI/spi_reva2.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_reva2.c
@@ -1,7 +1,5 @@
 /******************************************************************************
- *
- * Copyright (C) 2022-2023 Maxim Integrated Products, Inc., All Rights Reserved.
- * (now owned by Analog Devices, Inc.)
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -30,22 +28,6 @@
  * trademarks, maskwork rights, or any other form of intellectual
  * property whatsoever. Maxim Integrated Products, Inc. retains all
  * ownership rights.
- *
- ******************************************************************************
- *
- * Copyright 2023 Analog Devices, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  *
  ******************************************************************************/
 
@@ -1417,11 +1399,12 @@ int MXC_SPI_RevA2_ControllerTransaction(mxc_spi_reva_regs_t *spi, uint8_t *tx_bu
     MXC_SPI_RevA2_transactionSetup(spi, tx_buffer, tx_length_frames, rx_buffer, rx_length_frames,
                                    false);
 
-    // Start the SPI transaction.
-    spi->ctrl0 |= MXC_F_SPI_REVA_CTRL0_START;
-
     // Handle Target Select Pin (Only applicable in HW_AUTO TS control scheme).
     MXC_SPI_RevA2_handleTSControl(spi, deassert, hw_ts_index);
+
+
+    // Start the SPI transaction.
+    spi->ctrl0 |= MXC_F_SPI_REVA_CTRL0_START;
 
     // Complete transaction once it started.
     while (STATES[spi_num].transaction_done == false) {

--- a/Libraries/PeriphDrivers/Source/SYS/pins_me55.c
+++ b/Libraries/PeriphDrivers/Source/SYS/pins_me55.c
@@ -44,190 +44,159 @@
 /***** Global Variables *****/
 
 // clang-format off
-const mxc_gpio_cfg_t gpio_cfg_i2c0 = { MXC_GPIO0, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1),
-                                       MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE,
-                                       MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_i2c1 = { MXC_GPIO1, (MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19),
-                                       MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE,
-                                       MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_i2c2 = { MXC_GPIO0, (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7),
-                                       MXC_GPIO_FUNC_ALT4, MXC_GPIO_PAD_NONE,
-                                       MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_i2c2b = { MXC_GPIO1, (MXC_GPIO_PIN_20 | MXC_GPIO_PIN_21),
-                                        MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE,
-                                        MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_i2c2c = { MXC_GPIO1, (MXC_GPIO_PIN_30 | MXC_GPIO_PIN_31),
-                                        MXC_GPIO_FUNC_ALT3, MXC_GPIO_PAD_NONE,
-                                        MXC_GPIO_VSSEL_VDDIO };
+const mxc_gpio_cfg_t gpio_cfg_i2c0 = { MXC_GPIO0, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1), MXC_GPIO_FUNC_ALT1,
+                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_i2c1 = { MXC_GPIO1, (MXC_GPIO_PIN_28 | MXC_GPIO_PIN_29), MXC_GPIO_FUNC_ALT1,
+                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
-const mxc_gpio_cfg_t gpio_cfg_uart0 = { MXC_GPIO1, (MXC_GPIO_PIN_11 | MXC_GPIO_PIN_12),
-                                        MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                        MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart0_flow = { MXC_GPIO1, (MXC_GPIO_PIN_9 | MXC_GPIO_PIN_10),
-                                             MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                             MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_9 | MXC_GPIO_PIN_10),
-                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                                     MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart1 = { MXC_GPIO1, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_16),
-                                        MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                        MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart1_flow = { MXC_GPIO1, (MXC_GPIO_PIN_13 | MXC_GPIO_PIN_15),
-                                             MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                             MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_13 | MXC_GPIO_PIN_15),
-                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                                     MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart2 = { MXC_GPIO1, (MXC_GPIO_PIN_9 | MXC_GPIO_PIN_10),
-                                        MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                        MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart2_flow = { MXC_GPIO1, (MXC_GPIO_PIN_7 | MXC_GPIO_PIN_8),
-                                             MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                             MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_7 | MXC_GPIO_PIN_8),
-                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                                     MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart3 = { MXC_GPIO1, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1),
-                                        MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                        MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart3_flow = { MXC_GPIO1, (MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3),
-                                             MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                             MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_uart3_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3),
-                                                     MXC_GPIO_FUNC_IN, MXC_GPIO_PAD_WEAK_PULL_UP,
-                                                     MXC_GPIO_VSSEL_VDDIO };
+const mxc_gpio_cfg_t gpio_cfg_uart0 = { MXC_GPIO1, (MXC_GPIO_PIN_8 | MXC_GPIO_PIN_9), MXC_GPIO_FUNC_ALT1,
+                                        MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart0_flow = { MXC_GPIO1, (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7), MXC_GPIO_FUNC_ALT1,
+                                             MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart0_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_6 | MXC_GPIO_PIN_7), MXC_GPIO_FUNC_IN,
+                                                     MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart1 = { MXC_GPIO1, (MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13), MXC_GPIO_FUNC_ALT1,
+                                        MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart1_flow = { MXC_GPIO1, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11), MXC_GPIO_FUNC_ALT1,
+                                             MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart1_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11), MXC_GPIO_FUNC_IN,
+                                                     MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart2 = { MXC_GPIO1, (MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17), MXC_GPIO_FUNC_ALT2,
+                                        MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart2_flow = { MXC_GPIO1, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_ALT2,
+                                             MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart2_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15), MXC_GPIO_FUNC_IN,
+                                                     MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart3 = { MXC_GPIO1, (MXC_GPIO_PIN_20 | MXC_GPIO_PIN_21), MXC_GPIO_FUNC_ALT2,
+                                        MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart3_flow = { MXC_GPIO1, (MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19), MXC_GPIO_FUNC_ALT2,
+                                             MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_uart3_flow_disable = { MXC_GPIO1, (MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19), MXC_GPIO_FUNC_IN,
+                                                     MXC_GPIO_PAD_WEAK_PULL_UP, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
-const mxc_gpio_cfg_t gpio_cfg_spi0 = {
-    MXC_GPIO0, (MXC_GPIO_PIN_2 | MXC_GPIO_PIN_3 | MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5),
-    MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO
-};
-// NOTE: SPI1 definied here with SS1 only, SS0 is on port0 by itself.
-const mxc_gpio_cfg_t gpio_cfg_spi1 = {
-    MXC_GPIO1, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_3 | MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5),
-    MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO
-};
-// NOTE: SPI2 defined here with SS0 only, and NOT SS1 and SS2
-const mxc_gpio_cfg_t gpio_cfg_spi2 = {
-    MXC_GPIO1, (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15 | MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17),
-    MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO
-};
-const mxc_gpio_cfg_t gpio_cfg_spi2b = {
-    MXC_GPIO1, (MXC_GPIO_PIN_22 | MXC_GPIO_PIN_23 | MXC_GPIO_PIN_24 | MXC_GPIO_PIN_25),
-    MXC_GPIO_FUNC_ALT3, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO
-};
+// SPI v2 Pin Definitions
+const mxc_gpio_cfg_t gpio_cfg_spi0_standard = { MXC_GPIO0, (MXC_GPIO_PIN_3 | MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5), MXC_GPIO_FUNC_ALT1,
+                                                MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi0_3wire = { MXC_GPIO0, (MXC_GPIO_PIN_3 | MXC_GPIO_PIN_5), MXC_GPIO_FUNC_ALT1,
+                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi0_dual = { MXC_GPIO0, (MXC_GPIO_PIN_3 | MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5), MXC_GPIO_FUNC_ALT1,
+                                            MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+// SPI0 QUAD mode not supported.
+
+//const mxc_gpio_cfg_t gpio_cfg_spi0_quad = { MXC_GPIO0, (MXC_GPIO_PIN_3 | MXC_GPIO_PIN_6 | MXC_GPIO_PIN_ | MXC_GPIO_PIN_8 | MXC_GPIO_PIN_9),
+//                                            MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
+const mxc_gpio_cfg_t gpio_cfg_spi1_standard = { MXC_GPIO1, (MXC_GPIO_PIN_3 | MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5), MXC_GPIO_FUNC_ALT1,
+                                                MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi1_3wire = { MXC_GPIO1, (MXC_GPIO_PIN_3 | MXC_GPIO_PIN_5), MXC_GPIO_FUNC_ALT1,
+                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi1_dual = { MXC_GPIO1, (MXC_GPIO_PIN_3 | MXC_GPIO_PIN_4 | MXC_GPIO_PIN_5),
+                                            MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+// SPI1 QUAD mode not supported.
+//const mxc_gpio_cfg_t gpio_cfg_spi1_quad = { MXC_GPIO1, (MXC_GPIO_PIN_21 | MXC_GPIO_PIN_22 | MXC_GPIO_PIN_23 | MXC_GPIO_PIN_24 | MXC_GPIO_PIN_25),
+//                                            MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
+// SPI2 does not exist in the MAX32572 (to match instance addressing with MAX32570B)
+
+const mxc_gpio_cfg_t gpio_cfg_spi3_standard = { MXC_GPIO0, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11 | MXC_GPIO_PIN_14), MXC_GPIO_FUNC_ALT1,
+                                                MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi3_3wire = { MXC_GPIO0, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_14), MXC_GPIO_FUNC_ALT1,
+                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi3_dual = { MXC_GPIO0, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11 | MXC_GPIO_PIN_14),
+                                            MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi3_quad = { MXC_GPIO0, (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11 | MXC_GPIO_PIN_12 | MXC_GPIO_PIN_13 | MXC_GPIO_PIN_14),
+                                            MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+
+// SPI v2 Target Selects Pin Definitions
+const mxc_gpio_cfg_t gpio_cfg_spi0_ts0 = { MXC_GPIO0, MXC_GPIO_PIN_2, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi1_ts0 = { MXC_GPIO0, MXC_GPIO_PIN_31, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi1_ts1 = { MXC_GPIO1, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi1_ts2 = { MXC_GPIO1, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi1_ts3 = { MXC_GPIO1, MXC_GPIO_PIN_2, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+// SPI2 does not exist in the MAX32572 (to match instance addressing with MAX32570B)
+const mxc_gpio_cfg_t gpio_cfg_spi3_ts0 = { MXC_GPIO0, MXC_GPIO_PIN_6, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi3_ts1 = { MXC_GPIO0, MXC_GPIO_PIN_7, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi3_ts2 = { MXC_GPIO0, MXC_GPIO_PIN_8, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_spi3_ts3 = { MXC_GPIO0, MXC_GPIO_PIN_9, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 // Timers are only defined once, depending on package, each timer could be mapped to other pins
-const mxc_gpio_cfg_t gpio_cfg_tmr0 = { MXC_GPIO1, MXC_GPIO_PIN_14, MXC_GPIO_FUNC_ALT3,
+const mxc_gpio_cfg_t gpio_cfg_tmr0 = { MXC_GPIO0, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_tmr1 = { MXC_GPIO1, MXC_GPIO_PIN_15, MXC_GPIO_FUNC_ALT3,
+const mxc_gpio_cfg_t gpio_cfg_tmr1 = { MXC_GPIO0, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_tmr2 = { MXC_GPIO1, MXC_GPIO_PIN_24, MXC_GPIO_FUNC_ALT2,
+const mxc_gpio_cfg_t gpio_cfg_tmr2 = { MXC_GPIO0, MXC_GPIO_PIN_2, MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_tmr3 = { MXC_GPIO1, MXC_GPIO_PIN_25, MXC_GPIO_FUNC_ALT2,
+const mxc_gpio_cfg_t gpio_cfg_tmr3 = { MXC_GPIO0, MXC_GPIO_PIN_3, MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_tmr4 = { MXC_GPIO1, MXC_GPIO_PIN_12, MXC_GPIO_FUNC_ALT3,
+const mxc_gpio_cfg_t gpio_cfg_tmr4 = { MXC_GPIO0, MXC_GPIO_PIN_4, MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_tmr5 = { MXC_GPIO1, MXC_GPIO_PIN_13, MXC_GPIO_FUNC_ALT3,
+const mxc_gpio_cfg_t gpio_cfg_tmr5 = { MXC_GPIO0, MXC_GPIO_PIN_5, MXC_GPIO_FUNC_ALT2,
                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 // Pulse trains are only defined once, depending on package, each PT could be mapped to other pins
-const mxc_gpio_cfg_t gpio_cfg_pt0 = { MXC_GPIO1, MXC_GPIO_PIN_28, MXC_GPIO_FUNC_ALT2,
+const mxc_gpio_cfg_t gpio_cfg_pt0 = { MXC_GPIO0, MXC_GPIO_PIN_21, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_pt1 = { MXC_GPIO1, MXC_GPIO_PIN_11, MXC_GPIO_FUNC_ALT4,
+const mxc_gpio_cfg_t gpio_cfg_pt1 = { MXC_GPIO0, MXC_GPIO_PIN_22, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_pt2 = { MXC_GPIO0, MXC_GPIO_PIN_11, MXC_GPIO_FUNC_ALT4,
+const mxc_gpio_cfg_t gpio_cfg_pt2 = { MXC_GPIO0, MXC_GPIO_PIN_23, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_pt3 = { MXC_GPIO0, MXC_GPIO_PIN_12, MXC_GPIO_FUNC_ALT4,
+const mxc_gpio_cfg_t gpio_cfg_pt3 = { MXC_GPIO0, MXC_GPIO_PIN_24, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_pt4 = { MXC_GPIO0, MXC_GPIO_PIN_13, MXC_GPIO_FUNC_ALT4,
+const mxc_gpio_cfg_t gpio_cfg_pt4 = { MXC_GPIO0, MXC_GPIO_PIN_25, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_pt5 = { MXC_GPIO0, MXC_GPIO_PIN_14, MXC_GPIO_FUNC_ALT4,
+const mxc_gpio_cfg_t gpio_cfg_pt5 = { MXC_GPIO0, MXC_GPIO_PIN_26, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_pt6 = { MXC_GPIO1, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT3,
+const mxc_gpio_cfg_t gpio_cfg_pt6 = { MXC_GPIO0, MXC_GPIO_PIN_31, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_pt7 = { MXC_GPIO0, MXC_GPIO_PIN_31, MXC_GPIO_FUNC_ALT3,
+const mxc_gpio_cfg_t gpio_cfg_pt7 = { MXC_GPIO1, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT2,
                                       MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
-const mxc_gpio_cfg_t gpio_cfg_owm = { MXC_GPIO0, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1),
-                                      MXC_GPIO_FUNC_ALT4, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_owmb = { MXC_GPIO1, (MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19),
-                                       MXC_GPIO_FUNC_ALT4, MXC_GPIO_PAD_NONE,
-                                       MXC_GPIO_VSSEL_VDDIO };
+const mxc_gpio_cfg_t gpio_cfg_adc_ain0 = { MXC_GPIO1, MXC_GPIO_PIN_0, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_adc_ain1 = { MXC_GPIO1, MXC_GPIO_PIN_1, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_adc_ain2 = { MXC_GPIO1, MXC_GPIO_PIN_2, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_adc_ain3 = { MXC_GPIO1, MXC_GPIO_PIN_3, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_adc_ain4 = { MXC_GPIO1, MXC_GPIO_PIN_4, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_adc_ain5 = { MXC_GPIO1, MXC_GPIO_PIN_5, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_adc_ain6 = { MXC_GPIO1, MXC_GPIO_PIN_6, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_adc_ain7 = { MXC_GPIO1, MXC_GPIO_PIN_7, MXC_GPIO_FUNC_ALT1,
+                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0 };
 
-// Port 0 Pins 6-14, Port 1 Pins 1-5 and 16-19, Port 2 Pins 10-19
-// Other configurations are available, depending on package, to allow the use of EMAC or SDHC
-// Note that both P1a and P1b must be configured for proper operation
-const mxc_gpio_cfg_t gpio_cfg_P0_clcd = { MXC_GPIO0, 0x00007FC0, MXC_GPIO_FUNC_ALT3,
-                                          MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_P1a_clcd = { MXC_GPIO1, 0x000F003E, MXC_GPIO_FUNC_ALT3,
-                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_P1b_clcd = { MXC_GPIO1, 0x00300000, MXC_GPIO_FUNC_ALT4,
-                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_P2_clcd = { MXC_GPIO1, 0x000FFC00, MXC_GPIO_FUNC_ALT3,
-                                          MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-
-const mxc_gpio_cfg_t gpio_cfg_rtcsqw = { MXC_GPIO0, MXC_GPIO_PIN_8, MXC_GPIO_FUNC_ALT4,
+const mxc_gpio_cfg_t gpio_cfg_rtcsqw = { MXC_GPIO0, MXC_GPIO_PIN_8, MXC_GPIO_FUNC_ALT2,
                                          MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 const mxc_gpio_cfg_t gpio_cfg_rtcsqwb = { MXC_GPIO1, MXC_GPIO_PIN_11, MXC_GPIO_FUNC_ALT2,
                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
-const mxc_gpio_cfg_t gpio_cfg_sdhc = { MXC_GPIO1,
-                                       (MXC_GPIO_PIN_10 | MXC_GPIO_PIN_11 | MXC_GPIO_PIN_12 |
-                                        MXC_GPIO_PIN_13 | MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15 |
-                                        MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17),
-                                       MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE,
-                                       MXC_GPIO_VSSEL_VDDIOH };
-const mxc_gpio_cfg_t gpio_cfg_sdhcb = { MXC_GPIO1,
-                                        (MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15 | MXC_GPIO_PIN_22 |
-                                         MXC_GPIO_PIN_23 | MXC_GPIO_PIN_24 | MXC_GPIO_PIN_25 |
-                                         MXC_GPIO_PIN_26 | MXC_GPIO_PIN_27),
-                                        MXC_GPIO_FUNC_ALT4, MXC_GPIO_PAD_NONE,
-                                        MXC_GPIO_VSSEL_VDDIOH };
-
-const mxc_gpio_cfg_t gpio_cfg_sc0 = { MXC_GPIO0,
-                                      (MXC_GPIO_PIN_15 | MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17 |
-                                       MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19 | MXC_GPIO_PIN_20),
-                                      MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_sc1 = { MXC_GPIO0,
-                                      (MXC_GPIO_PIN_22 | MXC_GPIO_PIN_23 | MXC_GPIO_PIN_24 |
-                                       MXC_GPIO_PIN_25 | MXC_GPIO_PIN_26 | MXC_GPIO_PIN_27),
-                                      MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_sc0 = { MXC_GPIO0, (MXC_GPIO_PIN_15 | MXC_GPIO_PIN_16 | MXC_GPIO_PIN_17 |
+                                      MXC_GPIO_PIN_18 | MXC_GPIO_PIN_19 | MXC_GPIO_PIN_20), MXC_GPIO_FUNC_ALT1,
+                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+const mxc_gpio_cfg_t gpio_cfg_sc1 = { MXC_GPIO0, (MXC_GPIO_PIN_21 | MXC_GPIO_PIN_22 | MXC_GPIO_PIN_23 |
+                                      MXC_GPIO_PIN_24 | MXC_GPIO_PIN_25 | MXC_GPIO_PIN_26), MXC_GPIO_FUNC_ALT1,
+                                      MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
 // Note that both P0 and P1 must be configured for proper operation
-const mxc_gpio_cfg_t gpio_cfg_spixf = { MXC_GPIO1,
-                                        (MXC_GPIO_PIN_22 | MXC_GPIO_PIN_23 | MXC_GPIO_PIN_24 |
-                                         MXC_GPIO_PIN_25 | MXC_GPIO_PIN_26 | MXC_GPIO_PIN_27),
-                                        MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_NONE,
-                                        MXC_GPIO_VSSEL_VDDIO };
-const mxc_gpio_cfg_t gpio_cfg_spixr_P0 = {
-    MXC_GPIO1, (MXC_GPIO_PIN_28 | MXC_GPIO_PIN_29 | MXC_GPIO_PIN_30 | MXC_GPIO_PIN_31),
-    MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_PULL_UP
-};
-const mxc_gpio_cfg_t gpio_cfg_spixr_P1 = { MXC_GPIO1, (MXC_GPIO_PIN_0 | MXC_GPIO_PIN_1),
-                                           MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_PULL_UP };
+const mxc_gpio_cfg_t gpio_cfg_spixf = { MXC_GPIO1, (MXC_GPIO_PIN_22 | MXC_GPIO_PIN_23 | MXC_GPIO_PIN_24 |
+                                        MXC_GPIO_PIN_25 | MXC_GPIO_PIN_26 | MXC_GPIO_PIN_27), MXC_GPIO_FUNC_ALT1,
+                                        MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
+// SKBD Pin Definitions
+const mxc_gpio_cfg_t gpio_cfg_kbd_P2 = { MXC_GPIO1, ( MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15 | MXC_GPIO_PIN_16 |
+										MXC_GPIO_PIN_17 | MXC_GPIO_PIN_18| MXC_GPIO_PIN_19 | MXC_GPIO_PIN_20 |
+										MXC_GPIO_PIN_21), MXC_GPIO_FUNC_ALT1, MXC_GPIO_PAD_PULL_UP, MXC_GPIO_VSSEL_VDDIO,
+										MXC_GPIO_DRVSTR_0 };
 
-// Note that both P2a and P2b must be configured for proper operation
-const mxc_gpio_cfg_t gpio_cfg_emac_P2a = { MXC_GPIO1, 0x000003FC, MXC_GPIO_FUNC_ALT4,
-                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
-const mxc_gpio_cfg_t gpio_cfg_emac_P2b = { MXC_GPIO1, 0xFFE00000, MXC_GPIO_FUNC_ALT1,
-                                           MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_0 };
 
-// Note that all of the following must be configured for proper operation
-const mxc_gpio_cfg_t gpio_cfg_kbd_P2 = { MXC_GPIO1, 0x000003FC, MXC_GPIO_FUNC_ALT1,
-                                         MXC_GPIO_PAD_PULL_UP };
-
-// Note that both P0 and P1 must be configured for proper operation
-const mxc_gpio_cfg_t gpio_cfg_pcif_P0 = { MXC_GPIO0, 0x00007FC0, MXC_GPIO_FUNC_ALT2,
-                                          MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0};
-const mxc_gpio_cfg_t gpio_cfg_pcif_P1 = { MXC_GPIO1,
-                                          (MXC_GPIO_PIN_1 | MXC_GPIO_PIN_14 | MXC_GPIO_PIN_15),
-                                          MXC_GPIO_FUNC_ALT2, MXC_GPIO_PAD_NONE,
-                                          MXC_GPIO_VSSEL_VDDIOH };
-const mxc_gpio_cfg_t gpio_cfg_pcif_hsync = { MXC_GPIO1, MXC_GPIO_PIN_2, MXC_GPIO_FUNC_ALT2,
-                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0};
-const mxc_gpio_cfg_t gpio_cfg_pcif_vsync = { MXC_GPIO1, MXC_GPIO_PIN_18, MXC_GPIO_FUNC_ALT4,
-                                             MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0};
-const mxc_gpio_cfg_t gpio_cfg_pcif_pclk = { MXC_GPIO1, MXC_GPIO_PIN_19, MXC_GPIO_FUNC_ALT4,
-                                            MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0};
-const mxc_gpio_cfg_t gpio_cfg_pcif_pwrdwn = { MXC_GPIO1, MXC_GPIO_PIN_21, MXC_GPIO_FUNC_OUT,
-                                              MXC_GPIO_PAD_NONE, MXC_GPIO_VSSEL_VDDIOH, MXC_GPIO_DRVSTR_0};

--- a/Libraries/PeriphDrivers/max32572_files.mk
+++ b/Libraries/PeriphDrivers/max32572_files.mk
@@ -1,7 +1,5 @@
-###############################################################################
- #
- # Copyright (C) 2022-2023 Maxim Integrated Products, Inc., All Rights Reserved.
- # (now owned by Analog Devices, Inc.)
+################################################################################
+ # Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a
  # copy of this software and associated documentation files (the "Software"),
@@ -31,23 +29,7 @@
  # property whatsoever. Maxim Integrated Products, Inc. retains all
  # ownership rights.
  #
- ##############################################################################
- #
- # Copyright 2023 Analog Devices, Inc.
- #
- # Licensed under the Apache License, Version 2.0 (the "License");
- # you may not use this file except in compliance with the License.
- # You may obtain a copy of the License at
- #
- #     http://www.apache.org/licenses/LICENSE-2.0
- #
- # Unless required by applicable law or agreed to in writing, software
- # distributed under the License is distributed on an "AS IS" BASIS,
- # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- # See the License for the specific language governing permissions and
- # limitations under the License.
- #
- ##############################################################################
+ ###############################################################################
 
 # This is the name of the build output file
 
@@ -61,7 +43,6 @@ ifeq "$(COMPILER)" ""
 $(error COMPILER must be specified)
 endif
 
-
 # This is the path to the CMSIS root directory
 ifeq "$(CMSIS_ROOT)" ""
 CMSIS_ROOT=../CMSIS
@@ -70,39 +51,32 @@ ifeq "$(LIBS_DIR)" ""
 LIBS_DIR = $(CMSIS_ROOT)/..
 endif
 
-
 PERIPH_DIR := $(LIBS_DIR)/PeriphDrivers
 SOURCE_DIR := $(PERIPH_DIR)/Source
 INCLUDE_DIR := $(PERIPH_DIR)/Include
 
 PERIPH_DRIVER_INCLUDE_DIR  += $(INCLUDE_DIR)/$(TARGET_UC)/
+
 # Source files
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/mxc_assert.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/mxc_delay.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/mxc_lock.c
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/nvic_table.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/pins_me55.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/sys_me55.c
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SYS/nvic_table.c
 
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/ADC
-#PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/ADC/adc_common.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/ADC/adc_me55.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/ADC/adc_reva.c
+
+PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/CTB
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CTB/ctb_common.c
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CTB/ctb_me55.c
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CTB/ctb_reva.c
 
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/DMA
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/DMA/dma_me55.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/DMA/dma_reva.c
-
-PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/PT
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/PT/pt_me55.c
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/PT/pt_reva.c
-
-PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/LP
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/LP/lp_me55.c
-
-PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/OTP
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/OTP/otp_me55.c
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/OTP/otp_reva.c
 
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/GPIO
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/GPIO/gpio_common.c
@@ -117,6 +91,17 @@ PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/I2C
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/I2C/i2c_me55.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/I2C/i2c_reva.c
 
+PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/LP
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/LP/lp_me55.c
+
+PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/OTP
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/OTP/otp_me55.c
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/OTP/otp_reva.c
+
+PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/PT
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/PT/pt_me55.c
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/PT/pt_reva.c
+
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/RTC
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/RTC/rtc_me55.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/RTC/rtc_reva.c
@@ -130,17 +115,12 @@ PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SMON/smon_me55.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SMON/smon_reva.c
 
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/SPI
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SPI/spi_me55.c
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SPI/spi_reva1.c
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SPI/spi_me55_v2.c
+PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SPI/spi_reva2.c
 
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/SPIXF
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SPIXF/spixf_me55.c
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/SPIXF/spixf_reva.c
-
-PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/CTB
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CTB/ctb_common.c
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CTB/ctb_me55.c
-PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/CTB/ctb_reva.c
 
 PERIPH_DRIVER_INCLUDE_DIR += $(SOURCE_DIR)/TMR
 PERIPH_DRIVER_C_FILES += $(SOURCE_DIR)/TMR/tmr_common.c


### PR DESCRIPTION
## Required SDK Changes for SKB and SPI_Usecase Examples. 

### Changes Made
Some changes have been made to the source code in order to make Secure Keypad and SPI work.

### Purpose
Changes were made at the request for the preparation of ME55 samples.

### Additional Context
The initialization made with the information of the SKB ctrl1 register in the User Guide prepared for ME55 does not give successful results. Although it works successfully in the standard initialization, it is a question mark.
