### PR TITLE
fix(MiscDrivers): MSDK-1240: Clear out of bounds warnings seen with GCC v13.2

### DIFF
--- a/Libraries/MiscDrivers/Display/tft_ssd2119.c
+++ b/Libraries/MiscDrivers/Display/tft_ssd2119.c
@@ -118,8 +118,8 @@ typedef struct {
 
 #pragma pack()
 
-extern Header_images_t _bin_start_; // binary start address, defined in linker file
-extern unsigned int _bin_end_; // binary end address, defined in linker file
+extern unsigned char _bin_start_[]; // binary start address, defined in linker file
+extern unsigned char _bin_end_; // binary end address, defined in linker file
 static unsigned char *images_start_addr = NULL;
 static Header_images_t images_header;
 
@@ -927,10 +927,10 @@ int MXC_TFT_Init(void)
     memset(&images_header, 0, sizeof(Header_images_t));
 
     // Is there any image data to work with?
-    if ((unsigned int *)&_bin_start_ != (unsigned int *)&_bin_end_) {
-        images_start_addr = (unsigned char *)&_bin_start_;
+    if (_bin_start_ != &_bin_end_) {
+        images_start_addr = _bin_start_;
         // set header
-        images_header = *((Header_images_t *)&_bin_start_);
+        memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
     }
 
     /*

--- a/Libraries/MiscDrivers/Display/tft_ssd2119.c
+++ b/Libraries/MiscDrivers/Display/tft_ssd2119.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "mxc_device.h"
 #include "mxc_delay.h"
@@ -117,7 +118,7 @@ typedef struct {
 
 #pragma pack()
 
-extern unsigned int _bin_start_; // binary start address, defined in linker file
+extern Header_images_t _bin_start_; // binary start address, defined in linker file
 extern unsigned int _bin_end_; // binary end address, defined in linker file
 static unsigned char *images_start_addr = NULL;
 static Header_images_t images_header;
@@ -926,10 +927,10 @@ int MXC_TFT_Init(void)
     memset(&images_header, 0, sizeof(Header_images_t));
 
     // Is there any image data to work with?
-    if (_bin_start_ != _bin_end_) {
+    if ((unsigned int *)&_bin_start_ != (unsigned int *)&_bin_end_) {
         images_start_addr = (unsigned char *)&_bin_start_;
         // set header
-        memcpy(&images_header, images_start_addr, sizeof(Header_images_t));
+        images_header = *((Header_images_t *)&_bin_start_);
     }
 
     /*
@@ -1276,9 +1277,12 @@ void MXC_TFT_SetFont(int font_id)
 
 void MXC_TFT_Printf(const char *format, ...)
 {
-    char str[100];
+    char str[100] = { 0 };
+    va_list args;
 
-    snprintf(str, sizeof(str), format, *((&format) + 1), *((&format) + 2), *((&format) + 3));
+    va_start(args, format);
+    vsnprintf(str, sizeof(str), format, args);
+    va_end(args);
 
     printCursor(str); //printf_message
 }

--- a/Libraries/MiscDrivers/Display/tft_st7735.c
+++ b/Libraries/MiscDrivers/Display/tft_st7735.c
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdarg.h>
 
 #include "board.h"
 #include "gpio.h"
@@ -688,11 +689,14 @@ void MXC_TFT_SetFont(int font_id)
 
 void MXC_TFT_Printf(const char *format, ...)
 {
-    char str[100];
     char value;
     int i;
+    char str[100] = { 0 };
+    va_list args;
 
-    snprintf(str, sizeof(str), format, *((&format) + 1), *((&format) + 2), *((&format) + 3));
+    va_start(args, format);
+    vsnprintf(str, sizeof(str), format, args);
+    va_end(args);
 
     for (i = 0; i < sizeof(str); i++) {
         value = str[i];


### PR DESCRIPTION
### Description

GCC 13.2 warning clearance for tft_ssd2119.c

In the latest compiler version, the array bounds warnings appear. This was an internal issue and I tried building MAX78000 kws20_demo example and saw warnings myself. 

The changes are in:
1. MXC_TFT_Init function: Optional and tested for both GCC Versions (10.3 and 13.2) on MAX78000 kws20_demo.
2. MXC_TFT_Printf function: This one works incorrect when using GCC v13.2 - so should be merged. Tested with MAX32662 Demo Example.
