### PR TITLE
chore(PeriphDrivers): Fix typo

### DIFF
--- a/Libraries/PeriphDrivers/Source/LP/lp_me11.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me11.c
@@ -192,7 +192,7 @@ void MXC_LP_EnterBackupMode(void)
     while (1) {}
 }
 
-void MXC_LP_EnterShutdownMode(void)
+void MXC_LP_EnterShutDownMode(void)
 {
     MXC_GCR->pm &= ~MXC_F_GCR_PM_MODE;
     MXC_GCR->pm |= MXC_S_GCR_PM_MODE_SHUTDOWN;

--- a/Libraries/PeriphDrivers/Source/LP/lp_me14.c
+++ b/Libraries/PeriphDrivers/Source/LP/lp_me14.c
@@ -365,7 +365,7 @@ void MXC_LP_EnterBackgroundMode(void)
     __WFI();
 }
 
-void MXC_LP_EnterShutdownMode(void)
+void MXC_LP_EnterShutDownMode(void)
 {
     MXC_GCR->pm &= ~MXC_F_GCR_PM_MODE;
     MXC_GCR->pm |= MXC_S_GCR_PM_MODE_SHUTDOWN;


### PR DESCRIPTION




### Description

MXC_LP_EnterShutDownMode function name does not match with .h and .c files. To it match with other part number too, ShutDown prefered instead of Shutdown which match with rest of the usage in the file like MXC_LP_SRCCShutdown ...

See: 
https://github.com/Analog-Devices-MSDK/msdk/blob/main/Libraries/PeriphDrivers/Include/MAX32660/lp.h#L197
https://github.com/Analog-Devices-MSDK/msdk/blob/main/Libraries/PeriphDrivers/Include/MAX32665/lp.h#L390

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.


