### PR TITLE
feat(PeriphDrivers): Add System Clock Div APIs for MAX32670 and MAX32660

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32660/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/mxc_sys.h
@@ -101,6 +101,17 @@ typedef enum {
     MXC_SYS_CLOCK_HIRC = MXC_V_GCR_CLK_CTRL_CLKSEL_HIRC, /**< High Frequency Internal Oscillator */
 } mxc_sys_system_clock_t;
 
+typedef enum {
+    MXC_SYS_CLOCK_DIV_1 = MXC_S_GCR_CLK_CTRL_PSC_DIV1,
+    MXC_SYS_CLOCK_DIV_2 = MXC_S_GCR_CLK_CTRL_PSC_DIV2,
+    MXC_SYS_CLOCK_DIV_4 = MXC_S_GCR_CLK_CTRL_PSC_DIV4,
+    MXC_SYS_CLOCK_DIV_8 = MXC_S_GCR_CLK_CTRL_PSC_DIV8,
+    MXC_SYS_CLOCK_DIV_16 = MXC_S_GCR_CLK_CTRL_PSC_DIV16,
+    MXC_SYS_CLOCK_DIV_32 = MXC_S_GCR_CLK_CTRL_PSC_DIV32,
+    MXC_SYS_CLOCK_DIV_64 = MXC_S_GCR_CLK_CTRL_PSC_DIV64,
+    MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLK_CTRL_PSC_DIV128
+} mxc_sys_system_clock_div_t;
+
 #define MXC_SYS_USN_LEN 8
 
 /***** Function Prototypes *****/
@@ -266,6 +277,18 @@ int MXC_SYS_ClockSourceDisable(mxc_sys_system_clock_t clock);
  * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock);
+
+/**
+ * @brief Set the system clock divider.
+ * @param div       Enumeration for desired clock divider.
+ */
+void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div);
+
+/**
+ * @brief Get the system clock divider.
+ * @returns         System clock divider.
+ */
+mxc_sys_system_clock_div_t MXC_SYS_GetClockDiv(void);
 
 /**
  * @brief Wait for a clock to enable with timeout

--- a/Libraries/PeriphDrivers/Include/MAX32670/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/mxc_sys.h
@@ -125,6 +125,17 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Use the external system clock input */
 } mxc_sys_system_clock_t;
 
+typedef enum {
+    MXC_SYS_CLOCK_DIV_1 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV1,
+    MXC_SYS_CLOCK_DIV_2 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV2,
+    MXC_SYS_CLOCK_DIV_4 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV4,
+    MXC_SYS_CLOCK_DIV_8 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV8,
+    MXC_SYS_CLOCK_DIV_16 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV16,
+    MXC_SYS_CLOCK_DIV_32 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV32,
+    MXC_SYS_CLOCK_DIV_64 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV64,
+    MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
+} mxc_sys_system_clock_div_t;
+
 #define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
 #define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
 #define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
@@ -292,6 +303,18 @@ int MXC_SYS_ClockSourceDisable(mxc_sys_system_clock_t clock);
  * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock);
+
+/**
+ * @brief Set the system clock divider.
+ * @param div       Enumeration for desired clock divider.
+ */
+void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div);
+
+/**
+ * @brief Get the system clock divider.
+ * @returns         System clock divider.
+ */
+mxc_sys_system_clock_div_t MXC_SYS_GetClockDiv(void);
 
 /**
  * @brief Wait for a clock to enable with timeout

--- a/Libraries/PeriphDrivers/Include/MAX32675/mxc_sys.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/mxc_sys.h
@@ -149,6 +149,17 @@ typedef enum {
         MXC_V_GCR_CLKCTRL_SYSCLK_SEL_EXTCLK /**< Select the External RTC Crystal Oscillator */
 } mxc_sys_system_clock_t;
 
+typedef enum {
+    MXC_SYS_CLOCK_DIV_1 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV1,
+    MXC_SYS_CLOCK_DIV_2 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV2,
+    MXC_SYS_CLOCK_DIV_4 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV4,
+    MXC_SYS_CLOCK_DIV_8 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV8,
+    MXC_SYS_CLOCK_DIV_16 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV16,
+    MXC_SYS_CLOCK_DIV_32 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV32,
+    MXC_SYS_CLOCK_DIV_64 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV64,
+    MXC_SYS_CLOCK_DIV_128 = MXC_S_GCR_CLKCTRL_SYSCLK_DIV_DIV128
+} mxc_sys_system_clock_div_t;
+
 #define MXC_SYS_USN_CHECKSUM_LEN 16 // Length of the USN + padding for checksum compute
 #define MXC_SYS_USN_CSUM_FIELD_LEN 2 // Size of the checksum field in the USN
 #define MXC_SYS_USN_LEN 13 // Size of the USN including the checksum
@@ -316,6 +327,18 @@ int MXC_SYS_ClockSourceDisable(mxc_sys_system_clock_t clock);
  * @returns         E_NO_ERROR if everything is successful.
  */
 int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock);
+
+/**
+ * @brief Set the system clock divider.
+ * @param div       Enumeration for desired clock divider.
+ */
+void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div);
+
+/**
+ * @brief Get the system clock divider.
+ * @returns         System clock divider.
+ */
+mxc_sys_system_clock_div_t MXC_SYS_GetClockDiv(void);
 
 /**
  * @brief Wait for a clock to enable with timeout

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me11.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me11.c
@@ -301,6 +301,25 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 }
 
 /* ************************************************************************** */
+void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div)
+{
+    /* Return if this setting is already current */
+    if (div == MXC_SYS_GetClockDiv()) {
+        return;
+    }
+
+    MXC_SETFIELD(MXC_GCR->clk_ctrl, MXC_F_GCR_CLK_CTRL_PSC, div);
+
+    SystemCoreClockUpdate();
+}
+
+/* ************************************************************************** */
+mxc_sys_system_clock_div_t MXC_SYS_GetClockDiv(void)
+{
+    return (MXC_GCR->clk_ctrl & MXC_F_GCR_CLK_CTRL_PSC);
+}
+
+/* ************************************************************************** */
 void MXC_SYS_Reset_Periph(mxc_sys_reset_t reset)
 {
     /* The mxc_sys_reset_t enum uses enum values that are the offset by 32 for the rstr1 register. */

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
@@ -437,6 +437,25 @@ int MXC_SYS_Clock_Select(mxc_sys_system_clock_t clock)
 }
 
 /* ************************************************************************** */
+void MXC_SYS_SetClockDiv(mxc_sys_system_clock_div_t div)
+{
+    /* Return if this setting is already current */
+    if (div == MXC_SYS_GetClockDiv()) {
+        return;
+    }
+
+    MXC_SETFIELD(MXC_GCR->clkctrl, MXC_F_GCR_CLKCTRL_SYSCLK_DIV, div);
+
+    SystemCoreClockUpdate();
+}
+
+/* ************************************************************************** */
+mxc_sys_system_clock_div_t MXC_SYS_GetClockDiv(void)
+{
+    return (MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_SYSCLK_DIV);
+}
+
+/* ************************************************************************** */
 void MXC_SYS_Reset_Periph(mxc_sys_reset_t reset)
 {
     // RTC reset bit is different for RevA and RevB


### PR DESCRIPTION
### Description

MAX32670 and MAX32660 has prescaler register that can be used to div system clock to specific value, this commit add related function to provide this feature

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/4107ee0d-86f3-4fdc-a34d-ba52621d0cb8)

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.



https://www.analog.com/media/en/technical-documentation/user-guides/max32660-user-guide.pdf
https://www.analog.com/media/en/technical-documentation/user-guides/max32670max32671-user-guide.pdf
