### PR TITLE
fix(PeriphDrivers): Update RTC SEC and SSEC register size

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Include/max32660.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Include/max32660.svd
@@ -4774,6 +4774,14 @@ transaction.</description>
      <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
      <addressOffset>0x00</addressOffset>
      <resetMask>0x00000000</resetMask>
+     <fields>
+      <field>
+       <name>SEC</name>
+       <description>Seconds Counter.</description>
+       <bitOffset>0</bitOffset>
+       <bitWidth>32</bitWidth>
+      </field>
+     </fields>
     </register>
     <register>
      <name>SSEC</name>

--- a/Libraries/CMSIS/Device/Maxim/MAX32660/Include/rtc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32660/Include/rtc_regs.h
@@ -102,6 +102,17 @@ typedef struct {
 
 /**
  * @ingroup  rtc_registers
+ * @defgroup RTC_SEC RTC_SEC
+ * @brief    RTC Second Counter. This register contains the 32-bit second counter.
+ * @{
+ */
+#define MXC_F_RTC_SEC_SEC_POS                          0 /**< SEC_SEC Position */
+#define MXC_F_RTC_SEC_SEC                              ((uint32_t)(0xFFFFFFFFUL << MXC_F_RTC_SEC_SEC_POS)) /**< SEC_SEC Mask */
+
+/**@} end of group RTC_SEC_Register */
+
+/**
+ * @ingroup  rtc_registers
  * @defgroup RTC_SSEC RTC_SSEC
  * @brief    RTC Sub-second Counter. This counter increments at 256Hz. RTC_SEC is incremented
  *           when this register rolls over from 0xFF to 0x00.

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Include/max32670.svd
@@ -6426,7 +6426,7 @@
        <name>SEC</name>
        <description>Seconds Counter.</description>
        <bitOffset>0</bitOffset>
-       <bitWidth>8</bitWidth>
+       <bitWidth>32</bitWidth>
       </field>
      </fields>
     </register>
@@ -6440,7 +6440,7 @@
        <name>SSEC</name>
        <description>Sub-Seconds Counter (12-bit).</description>
        <bitOffset>0</bitOffset>
-       <bitWidth>8</bitWidth>
+       <bitWidth>12</bitWidth>
       </field>
      </fields>
     </register>

--- a/Libraries/CMSIS/Device/Maxim/MAX32670/Include/rtc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32670/Include/rtc_regs.h
@@ -107,7 +107,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_RTC_SEC_SEC_POS                          0 /**< SEC_SEC Position */
-#define MXC_F_RTC_SEC_SEC                              ((uint32_t)(0xFFUL << MXC_F_RTC_SEC_SEC_POS)) /**< SEC_SEC Mask */
+#define MXC_F_RTC_SEC_SEC                              ((uint32_t)(0xFFFFFFFFUL << MXC_F_RTC_SEC_SEC_POS)) /**< SEC_SEC Mask */
 
 /**@} end of group RTC_SEC_Register */
 
@@ -119,7 +119,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_RTC_SSEC_SSEC_POS                        0 /**< SSEC_SSEC Position */
-#define MXC_F_RTC_SSEC_SSEC                            ((uint32_t)(0xFFUL << MXC_F_RTC_SSEC_SSEC_POS)) /**< SSEC_SSEC Mask */
+#define MXC_F_RTC_SSEC_SSEC                            ((uint32_t)(0xFFFUL << MXC_F_RTC_SSEC_SSEC_POS)) /**< SSEC_SSEC Mask */
 
 /**@} end of group RTC_SSEC_Register */
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.svd
@@ -9494,7 +9494,7 @@
        <name>SEC</name>
        <description>Seconds Counter.</description>
        <bitOffset>0</bitOffset>
-       <bitWidth>8</bitWidth>
+       <bitWidth>32</bitWidth>
       </field>
      </fields>
     </register>
@@ -9508,7 +9508,7 @@
        <name>SSEC</name>
        <description>Sub-Seconds Counter (12-bit).</description>
        <bitOffset>0</bitOffset>
-       <bitWidth>8</bitWidth>
+       <bitWidth>12</bitWidth>
       </field>
      </fields>
     </register>

--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Include/rtc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Include/rtc_regs.h
@@ -107,7 +107,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_RTC_SEC_SEC_POS                          0 /**< SEC_SEC Position */
-#define MXC_F_RTC_SEC_SEC                              ((uint32_t)(0xFFUL << MXC_F_RTC_SEC_SEC_POS)) /**< SEC_SEC Mask */
+#define MXC_F_RTC_SEC_SEC                              ((uint32_t)(0xFFFFFFFFUL << MXC_F_RTC_SEC_SEC_POS)) /**< SEC_SEC Mask */
 
 /**@} end of group RTC_SEC_Register */
 
@@ -119,7 +119,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_RTC_SSEC_SSEC_POS                        0 /**< SSEC_SSEC Position */
-#define MXC_F_RTC_SSEC_SSEC                            ((uint32_t)(0xFFUL << MXC_F_RTC_SSEC_SSEC_POS)) /**< SSEC_SSEC Mask */
+#define MXC_F_RTC_SSEC_SSEC                            ((uint32_t)(0xFFFUL << MXC_F_RTC_SSEC_SSEC_POS)) /**< SSEC_SSEC Mask */
 
 /**@} end of group RTC_SSEC_Register */
 

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.svd
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/max32675.svd
@@ -6432,7 +6432,7 @@
        <name>SEC</name>
        <description>Seconds Counter.</description>
        <bitOffset>0</bitOffset>
-       <bitWidth>8</bitWidth>
+       <bitWidth>32</bitWidth>
       </field>
      </fields>
     </register>
@@ -6446,7 +6446,7 @@
        <name>SSEC</name>
        <description>Sub-Seconds Counter (12-bit).</description>
        <bitOffset>0</bitOffset>
-       <bitWidth>8</bitWidth>
+       <bitWidth>12</bitWidth>
       </field>
      </fields>
     </register>

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Include/rtc_regs.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Include/rtc_regs.h
@@ -107,7 +107,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_RTC_SEC_SEC_POS                          0 /**< SEC_SEC Position */
-#define MXC_F_RTC_SEC_SEC                              ((uint32_t)(0xFFUL << MXC_F_RTC_SEC_SEC_POS)) /**< SEC_SEC Mask */
+#define MXC_F_RTC_SEC_SEC                              ((uint32_t)(0xFFFFFFFFUL << MXC_F_RTC_SEC_SEC_POS)) /**< SEC_SEC Mask */
 
 /**@} end of group RTC_SEC_Register */
 
@@ -119,7 +119,7 @@ typedef struct {
  * @{
  */
 #define MXC_F_RTC_SSEC_SSEC_POS                        0 /**< SSEC_SSEC Position */
-#define MXC_F_RTC_SSEC_SSEC                            ((uint32_t)(0xFFUL << MXC_F_RTC_SSEC_SSEC_POS)) /**< SSEC_SSEC Mask */
+#define MXC_F_RTC_SSEC_SSEC                            ((uint32_t)(0xFFFUL << MXC_F_RTC_SSEC_SSEC_POS)) /**< SSEC_SSEC Mask */
 
 /**@} end of group RTC_SSEC_Register */
 

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_reva_me11.svd
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_reva_me11.svd
@@ -20,6 +20,14 @@
         <description>RTC Second Counter. This register contains the 32-bit second counter.</description>
         <addressOffset>0x00</addressOffset>
         <resetMask>0x00000000</resetMask>
+        <fields>
+          <field>
+            <name>SEC</name>
+            <description>Seconds Counter.</description>
+            <bitOffset>0</bitOffset>
+            <bitWidth>32</bitWidth>
+          </field>
+        </fields>
       </register>
       <register>
         <name>SSEC</name>

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_reva_me15.svd
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_reva_me15.svd
@@ -25,7 +25,7 @@
             <name>SEC</name>
             <description>Seconds Counter.</description>
             <bitOffset>0</bitOffset>
-            <bitWidth>8</bitWidth>
+            <bitWidth>32</bitWidth>
           </field>
         </fields>
       </register>
@@ -39,7 +39,7 @@
             <name>SSEC</name>
             <description>Sub-Seconds Counter (12-bit).</description>
             <bitOffset>0</bitOffset>
-            <bitWidth>8</bitWidth>
+            <bitWidth>12</bitWidth>
           </field>
         </fields>
       </register>

--- a/Libraries/PeriphDrivers/Source/RTC/rtc_reva_me21.svd
+++ b/Libraries/PeriphDrivers/Source/RTC/rtc_reva_me21.svd
@@ -25,7 +25,7 @@
             <name>SEC</name>
             <description>Seconds Counter.</description>
             <bitOffset>0</bitOffset>
-            <bitWidth>8</bitWidth>
+            <bitWidth>32</bitWidth>
           </field>
         </fields>
       </register>
@@ -39,7 +39,7 @@
             <name>SSEC</name>
             <description>Sub-Seconds Counter (12-bit).</description>
             <bitOffset>0</bitOffset>
-            <bitWidth>8</bitWidth>
+            <bitWidth>12</bitWidth>
           </field>
         </fields>
       </register>


### PR DESCRIPTION
### Description

RTC SEC and SSEC register size is 32bit and 12bits This value is set to 8bits for MAX32670, MAX32660, MAX32672.
This commit set register size to the correct values.

### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

Links:
https://www.analog.com/media/en/technical-documentation/user-guides/max32670max32671-user-guide.pdf
https://www.analog.com/media/en/technical-documentation/user-guides/max32672-user-guide.pdf
https://www.analog.com/media/en/technical-documentation/user-guides/max32660-user-guide.pdf

Register size as per of UGs
![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/efd568c5-859c-48ae-8d22-1ea304eae0be)
