### PR TITLE
fix(workflow): Fix Skipped Build Tests

### DIFF
--- a/.github/workflows/Build_Examples.yml
+++ b/.github/workflows/Build_Examples.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on:
       - ubuntu-latest
 
+    env:
+      SOURCE_BRANCH: ${{github.ref_name}}
+      TARGET_BRANCH: ${{github.event.pull_request.base.ref}}
+
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
@@ -34,13 +38,20 @@ jobs:
           repository: '${{ github.event.pull_request.head.repo.full_name }}'
 
       - name: Check watch files
-        id: check_watch 
+        id: check_watch        
         run: |
+          echo SOURCE_BRANCH = $SOURCE_BRANCH
+          echo TARGET_BRANCH = $TARGET_BRANCH
           # Determine if we need to run the test
           RUN_TEST=0
 
           # Always run test if a workflow_dispatch
           if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
+            RUN_TEST=1
+          fi
+
+          if [[ $SOURCE_BRANCH == "main" ]]; then
+            echo "Pushed to main, running test"
             RUN_TEST=1
           fi
 
@@ -57,8 +68,16 @@ jobs:
             makefile \
             Makefile"
 
-          # Get the diff from main
-          CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/origin/main)
+          if [[ -n $TARGET_BRANCH ]]; then
+            # We are in a PR.  Need to check changes against the target branch.
+            echo "Comparing PR against target branch: $TARGET_BRANCH"
+            echo "Adding remote '$GITHUB_SERVER_URL/$GITHUB_REPOSITORY' as 'upstream'"
+            git remote add upstream $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+            echo "Fetching $TARGET_BRANCH"
+            git fetch upstream $TARGET_BRANCH
+            echo "diffing files"
+            CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/upstream/$TARGET_BRANCH)
+          fi
 
           echo "Watching these locations and files"
           echo $WATCH_FILES
@@ -226,13 +245,20 @@ jobs:
           fi
 
       - name: Check watch files
-        id: check_watch 
+        id: check_watch        
         run: |
+          echo SOURCE_BRANCH = $SOURCE_BRANCH
+          echo TARGET_BRANCH = $TARGET_BRANCH
           # Determine if we need to run the test
           RUN_TEST=0
 
           # Always run test if a workflow_dispatch
           if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
+            RUN_TEST=1
+          fi
+
+          if [[ $SOURCE_BRANCH == "main" ]]; then
+            echo "Pushed to main, running test"
             RUN_TEST=1
           fi
 
@@ -249,8 +275,16 @@ jobs:
             makefile \
             Makefile"
 
-          # Get the diff from main
-          CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/origin/main)
+          if [[ -n $TARGET_BRANCH ]]; then
+            # We are in a PR.  Need to check changes against the target branch.
+            echo "Comparing PR against target branch: $TARGET_BRANCH"
+            echo "Adding remote '$GITHUB_SERVER_URL/$GITHUB_REPOSITORY' as 'upstream'"
+            git remote add upstream $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+            echo "Fetching $TARGET_BRANCH"
+            git fetch upstream $TARGET_BRANCH
+            echo "diffing files"
+            CHANGE_FILES=$(git diff --ignore-submodules --name-only remotes/upstream/$TARGET_BRANCH)
+          fi
 
           echo "Watching these locations and files"
           echo $WATCH_FILES


### PR DESCRIPTION
### Description

This PR fixes missed build tests for the following conditions:
- When a commit is pushed to main
- When a PR is opened from a fork, and the source branch is also named 'main'

If implemented correctly, the "Build Examples" test should fully run for this PR. 
