### PR TITLE
chore(PeriphDrivers): Define `MXC_GPIO_PAD` Enum Consistently Across All Parts

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/gpio.h
@@ -121,6 +121,8 @@ typedef enum {
     MXC_GPIO_PAD_NONE, ///< No pull-up or pull-down
     MXC_GPIO_PAD_PULL_UP, ///< Set pad to weak pull-up
     MXC_GPIO_PAD_PULL_DOWN, ///< Set pad to weak pull-down
+    MXC_GPIO_PAD_WEAK_PULL_UP = MXC_GPIO_PAD_PULL_UP, ///< Set pad to weak pull-up
+    MXC_GPIO_PAD_WEAK_PULL_DOWN = MXC_GPIO_PAD_PULL_DOWN, ///< Set pad to weak pull-down
 } mxc_gpio_pad_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/gpio.h
@@ -142,6 +142,8 @@ typedef enum {
     MXC_GPIO_PAD_NONE, ///< No pull-up or pull-down
     MXC_GPIO_PAD_PULL_UP, ///< Set pad to weak pull-up
     MXC_GPIO_PAD_PULL_DOWN, ///< Set pad to weak pull-down
+    MXC_GPIO_PAD_WEAK_PULL_UP = MXC_GPIO_PAD_PULL_UP, ///< Set pad to weak pull-up
+    MXC_GPIO_PAD_WEAK_PULL_DOWN = MXC_GPIO_PAD_PULL_DOWN, ///< Set pad to weak pull-down
 } mxc_gpio_pad_t;
 
 /**

--- a/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/gpio.h
@@ -142,6 +142,8 @@ typedef enum {
     MXC_GPIO_PAD_NONE, ///< No pull-up or pull-down
     MXC_GPIO_PAD_PULL_UP, ///< Set pad to weak pull-up
     MXC_GPIO_PAD_PULL_DOWN, ///< Set pad to weak pull-down
+    MXC_GPIO_PAD_WEAK_PULL_UP = MXC_GPIO_PAD_PULL_UP, ///< Set pad to weak pull-up
+    MXC_GPIO_PAD_WEAK_PULL_DOWN = MXC_GPIO_PAD_PULL_DOWN, ///< Set pad to weak pull-down
 } mxc_gpio_pad_t;
 
 /**


### PR DESCRIPTION
### Description

Most of MAX32 MCUs has pull-up/down and weak pull-up/down feature But some of MCUs only has pull-up/down, this differentiation create delta between gpio interface function and so that it make it hard to develop high level common interface functions.

The purpose of this commit is to align padding definition to provide common interface for gpio.h file

Without this addition it requires add extra macro/definition... to develop common fw which drive MAX32 MCUs, Like below

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/46590392/6b9b85c4-aa05-4854-80f3-da7714dffc93)


### Checklist Before Requesting Review

- [X] PR Title follows correct guidelines.
- [X] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.
