### PR TITLE
fix(CMSIS): MSDK-1249: Add OVR Correction to SystemCoreClock Calculation for MAX32662 MAX32672 MAX32675

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
@@ -25,6 +25,7 @@
 #include "max32672.h"
 #include "gcr_regs.h"
 #include "mxc_sys.h"
+#include "pwrseq_regs.h"
 
 extern void (*const __isr_vector[])(void);
 
@@ -78,6 +79,21 @@ __weak void SystemCoreClockUpdate(void)
     }
     // Get the clock divider
     if (clk_src == MXC_S_GCR_CLKCTRL_SYSCLK_SEL_IPO) {
+        uint32_t ovr = (MXC_PWRSEQ->lpcn & MXC_F_PWRSEQ_LPCN_OVR);
+        switch (ovr) {
+        case MXC_S_PWRSEQ_LPCN_OVR_0_9V:
+            base_freq = base_freq >> 3;
+            break;
+        case MXC_S_PWRSEQ_LPCN_OVR_1_0V:
+            base_freq = base_freq >> 1;
+            break;
+        case MXC_S_PWRSEQ_LPCN_OVR_1_1V:
+        default:
+            /* Nothing to do here.
+                OVR = 1.1V means the clock runs full speed. */
+            break;
+        }
+
         base_freq = base_freq >> ((MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_IPO_DIV) >>
                                   MXC_F_GCR_CLKCTRL_IPO_DIV_POS);
     }

--- a/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
+++ b/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
@@ -25,6 +25,7 @@
 #include "max32675.h"
 #include "gcr_regs.h"
 #include "mxc_sys.h"
+#include "pwrseq_regs.h"
 
 extern void (*const __vector_table[])(void);
 
@@ -80,6 +81,21 @@ __weak void SystemCoreClockUpdate(void)
     }
     // Get the clock divider
     if (clk_src == MXC_S_GCR_CLKCTRL_SYSCLK_SEL_IPO) {
+        uint32_t ovr = (MXC_PWRSEQ->lpcn & MXC_F_PWRSEQ_LPCN_OVR);
+        switch (ovr) {
+        case MXC_S_PWRSEQ_LPCN_OVR_0_9V:
+            base_freq = base_freq >> 3;
+            break;
+        case MXC_S_PWRSEQ_LPCN_OVR_1_0V:
+            base_freq = base_freq >> 1;
+            break;
+        case MXC_S_PWRSEQ_LPCN_OVR_1_1V:
+        default:
+            /* Nothing to do here.
+                OVR = 1.1V means the clock runs full speed. */
+            break;
+        }
+
         base_freq = base_freq >> ((MXC_GCR->clkctrl & MXC_F_GCR_CLKCTRL_IPO_DIV) >>
                                   MXC_F_GCR_CLKCTRL_IPO_DIV_POS);
     }


### PR DESCRIPTION
### Description

MAX32662, MAX32672 and MAX32675 has the OVR bit to operate CPU voltage with different modes and this affects also the IPO clock. We need to consider this when calculating the system core clock.

PS. This has already done for MAX32660 in [here](https://github.com/Analog-Devices-MSDK/msdk/blob/b71d6f576b70670144f35bf898ddd7ef4e92c53a/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c#L65)

