### PR TITLE
fix(Examples): Fix MAX78002 TFT_Demo Example for TFT=ADAFRUIT

### DIFF
--- a/Examples/MAX78002/TFT_Demo/main.c
+++ b/Examples/MAX78002/TFT_Demo/main.c
@@ -143,7 +143,7 @@ int main(void)
         printf("Touch screen initialization failed\n");
     MXC_TS_Start();
     TFT_Print("Touch the screen!", 0, 120, font_5, 17);
-    TFT_Print("And check serial terminal!", 0, 120, font_5, 27);
+    TFT_Print("And check serial terminal!", 0, 140, font_5, 27);
 #else
     /* Initialize TFT display */
     MXC_TFT_Init(NULL, NULL);

--- a/Examples/MAX78002/TFT_Demo/main.c
+++ b/Examples/MAX78002/TFT_Demo/main.c
@@ -134,9 +134,14 @@ int main(void)
 
     printf("TFT Demo Example\n");
 #ifdef TFT_ADAFRUIT
-    /* Initialize touch screen */
+    /* Initialize ADAFRUIT TFT display */
+    MXC_TFT_Init(MXC_SPI0, -1, NULL, NULL);
+    MXC_TFT_SetRotation(ROTATE_270);
+    TFT_test();
+    /* Initialize ADAFRUIT touch screen */
     if (MXC_TS_Init(MXC_SPI0, -1, NULL, NULL))
         printf("Touch screen initialization failed\n");
+    MXC_TS_Start();
 #else
     /* Initialize TFT display */
     MXC_TFT_Init(NULL, NULL);

--- a/Examples/MAX78002/TFT_Demo/main.c
+++ b/Examples/MAX78002/TFT_Demo/main.c
@@ -143,6 +143,7 @@ int main(void)
         printf("Touch screen initialization failed\n");
     MXC_TS_Start();
     TFT_Print("Touch the screen!", 0, 120, font_5, 17);
+    TFT_Print("And check serial terminal!", 0, 120, font_5, 27);
 #else
     /* Initialize TFT display */
     MXC_TFT_Init(NULL, NULL);

--- a/Examples/MAX78002/TFT_Demo/main.c
+++ b/Examples/MAX78002/TFT_Demo/main.c
@@ -142,6 +142,7 @@ int main(void)
     if (MXC_TS_Init(MXC_SPI0, -1, NULL, NULL))
         printf("Touch screen initialization failed\n");
     MXC_TS_Start();
+    TFT_Print("Touch the screen!", 0, 120, font_5, 17);
 #else
     /* Initialize TFT display */
     MXC_TFT_Init(NULL, NULL);


### PR DESCRIPTION
TFT_Demo Example for MAX78002 with Adafruit Featherwing TFT Display was not working properly.

-main.c is changed in order to initiate the TFT Display, then the Touchscreen.

After the change, the example works fine:
![IMG_8172](https://github.com/Analog-Devices-MSDK/msdk/assets/136325521/f331d064-6008-42ce-b374-7de00d4a5257)
![IMG_8173](https://github.com/Analog-Devices-MSDK/msdk/assets/136325521/ac7e0df7-77a5-42b6-b22f-ff82f35390e9)
![IMG_8174](https://github.com/Analog-Devices-MSDK/msdk/assets/136325521/e3313a0a-64ea-4edf-a3fe-ccb1227eecee)
