### PR TITLE
fix(PeriphDrivers): Update MAX32662 GPIO PAD configuration

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/gpio.h
@@ -139,10 +139,10 @@ typedef enum {
  */
 typedef enum {
     MXC_GPIO_PAD_NONE, /**< No pull-up or pull-down */
-    MXC_GPIO_PAD_PULL_UP, /**< Set pad to strong pull-up */
-    MXC_GPIO_PAD_PULL_DOWN, /**< Set pad to strong pull-down */
-    MXC_GPIO_PAD_WEAK_PULL_UP, /**< Set pad to weak pull-up */
-    MXC_GPIO_PAD_WEAK_PULL_DOWN, /**< Set pad to weak pull-down */
+    MXC_GPIO_PAD_PULL_UP, /**< Set pad to weak pull-up */
+    MXC_GPIO_PAD_PULL_DOWN, /**< Set pad to weak pull-down */
+    MXC_GPIO_PAD_WEAK_PULL_UP = MXC_GPIO_PAD_PULL_UP, /**< Set pad to weak pull-up */
+    MXC_GPIO_PAD_WEAK_PULL_DOWN = MXC_GPIO_PAD_PULL_DOWN, /**< Set pad to weak pull-down */
 } mxc_gpio_pad_t;
 
 /**

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
@@ -81,31 +81,16 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     switch (cfg->pad) {
     case MXC_GPIO_PAD_NONE:
         gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
-        break;
-
-    case MXC_GPIO_PAD_WEAK_PULL_UP:
-        gpio->padctrl0 |= cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
-        gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_UP:
         gpio->padctrl0 |= cfg->mask;
-        gpio->padctrl1 &= ~cfg->mask;
         gpio->ps |= cfg->mask;
-        break;
-
-    case MXC_GPIO_PAD_WEAK_PULL_DOWN:
-        gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 |= cfg->mask;
-        gpio->ps &= ~cfg->mask;
         break;
 
     case MXC_GPIO_PAD_PULL_DOWN:
-        gpio->padctrl0 &= ~cfg->mask;
-        gpio->padctrl1 |= cfg->mask;
-        gpio->ps |= cfg->mask;
+        gpio->padctrl0 |= cfg->mask;
+        gpio->ps &= ~cfg->mask;
         break;
 
     default:


### PR DESCRIPTION
## Pull Request Template

### Description

ME12 only supports high-impedance, weak pullup and weak pulldown options.

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/94184469/64b08d1f-7688-4bc2-ab46-b7f6f1856a99)

This commit removes other options and corrects related register values of PAD configuration.

### Checklist Before Requesting Review

- [x] PR Title follows correct guidelines.
- [x] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.