### PR TITLE
fix(Build): Fix broken `make flash.openocd` on Windows + MSYS2

### DIFF
--- a/Tools/Flash/flash.mk
+++ b/Tools/Flash/flash.mk
@@ -47,15 +47,10 @@ OPENOCDEXE      ?= openocd.exe
 
 # Determine if we can use cygpath to convert the path name
 CYGPATH_AVAILABLE := 0
-ifneq ($(findstring MSYS, $(UNAME)), )
-CYGPATH_AVAILABLE := 1
-endif
-
-ifneq ($(findstring MINGW, $(UNAME)), )
-CYGPATH_AVAILABLE := 1
-endif
-
-ifneq ($(findstring CYGWIN, $(UNAME)), )
+ifneq ($(findstring msys, $(_OS)), )
+# NOTE:  "_OS" auto-detection comes from gcc.mk
+# As a result, this file should be included AFTER gcc.mk
+# This is done via the target's "MAX32xxx.mk" file.
 CYGPATH_AVAILABLE := 1
 endif
 


### PR DESCRIPTION
### Description

The MSDK includes [Makefile targets for flashing](https://analog-devices-msdk.github.io/msdk/USERGUIDE/#flashing-on-the-command-line) via a `flash.mk` file.  This target depends on a rule for creating a .hex file.  The .hex file is added as an explicit dependency of the flashing targets so that it's built before attempting the flash.  On Windows + MSYS2 the file path was mal-formed.  `cygpath` is required to correct the path, but the code that detected the availability of `cygpath` was not working correctly.

This PR fixes the OS auto-detection in `flash.mk`, which fixes `make flash.openocd` on Windows.

Fixes #872 

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.

