### PR TITLE
fix(PeriphDrivers): Add GPIO Chip Select Configuration for MAX32665 SPI driver

### DIFF
--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -94,7 +94,6 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
         while (MXC_GCR->rstr0 & MXC_F_GCR_RSTR0_SPI1) {}
         MXC_GCR->perckcn0 &= ~(MXC_F_GCR_PERCKCN0_SPI1D);
         MXC_GPIO_Config(&gpio_cfg_spi1);
-        
         // Configure Chip Select GPIOs
         if (numSlaves == 1) {
             MXC_GPIO_Config(&gpio_cfg_spi1_ss0);

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me14.c
@@ -57,7 +57,34 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
         MXC_GCR->perckcn1 &= ~(MXC_F_GCR_PERCKCN1_SPI0D);
         if (map == MAP_A) {
             MXC_GPIO_Config(&gpio_cfg_spi0a);
+
+            // Configure Chip Select GPIOs
+            if (numSlaves == 1) {
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss0a);
+            }
+            if (numSlaves == 2) {
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss0a);
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss1);
+            }
+            if (numSlaves == 3) {
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss0a);
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss1);
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss2);
+            }
         } else if (map == MAP_B) {
+            // Configure Chip Select GPIOs
+            if (numSlaves == 1) {
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss0b);
+            }
+            if (numSlaves == 2) {
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss0b);
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss1);
+            }
+            if (numSlaves == 3) {
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss0b);
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss1);
+                MXC_GPIO_Config(&gpio_cfg_spi0_ss2);
+            }
             MXC_GPIO_Config(&gpio_cfg_spi0b);
         } else {
             return E_BAD_PARAM;
@@ -67,11 +94,39 @@ int MXC_SPI_Init(mxc_spi_regs_t *spi, int masterMode, int quadModeUsed, int numS
         while (MXC_GCR->rstr0 & MXC_F_GCR_RSTR0_SPI1) {}
         MXC_GCR->perckcn0 &= ~(MXC_F_GCR_PERCKCN0_SPI1D);
         MXC_GPIO_Config(&gpio_cfg_spi1);
+        
+        // Configure Chip Select GPIOs
+        if (numSlaves == 1) {
+            MXC_GPIO_Config(&gpio_cfg_spi1_ss0);
+        }
+        if (numSlaves == 2) {
+            MXC_GPIO_Config(&gpio_cfg_spi1_ss0);
+            MXC_GPIO_Config(&gpio_cfg_spi1_ss1);
+        }
+        if (numSlaves == 3) {
+            MXC_GPIO_Config(&gpio_cfg_spi1_ss0);
+            MXC_GPIO_Config(&gpio_cfg_spi1_ss1);
+            MXC_GPIO_Config(&gpio_cfg_spi1_ss2);
+        }
     } else if (spi == MXC_SPI2) {
         MXC_GCR->rstr0 |= MXC_F_GCR_RSTR0_SPI2;
         while (MXC_GCR->rstr0 & MXC_F_GCR_RSTR0_SPI2) {}
         MXC_GCR->perckcn0 &= ~(MXC_F_GCR_PERCKCN0_SPI2D);
         MXC_GPIO_Config(&gpio_cfg_spi2);
+
+        // Configure Chip Select GPIOs
+        if (numSlaves == 1) {
+            MXC_GPIO_Config(&gpio_cfg_spi2_ss0);
+        }
+        if (numSlaves == 2) {
+            MXC_GPIO_Config(&gpio_cfg_spi2_ss0);
+            MXC_GPIO_Config(&gpio_cfg_spi2_ss1);
+        }
+        if (numSlaves == 3) {
+            MXC_GPIO_Config(&gpio_cfg_spi2_ss0);
+            MXC_GPIO_Config(&gpio_cfg_spi2_ss1);
+            MXC_GPIO_Config(&gpio_cfg_spi2_ss2);
+        }
     } else {
         return E_NO_DEVICE;
     }


### PR DESCRIPTION

### Description

fixes #396  . Add Chip Select configuration to MXC_SPI_Init using pre-existing me14_pins gpio cfg structs. SPI Example tested showing successful transactions and proper SPI Chip Select Behavior. 

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/82959533/d933fa14-05fe-4eb5-b85e-1f54a08dc44a)
![2024-01-15-121307](https://github.com/Analog-Devices-MSDK/msdk/assets/82959533/9b612bdd-b76d-4639-a089-55b519e5fab1)
Second image shows green LED1 on EVK, which indicates a successful run of the SPI example. 

#### Types
**fix** 

#### Scopes
**PeriphDrivers**
