### PR TITLE
fix(PeriphDrivers, Examples): MSDK-1232: Update I2S driver for confused usage of wsize and bits_word register fields - PR after discussions

### DIFF
--- a/Examples/MAX32655/I2S/main.c
+++ b/Examples/MAX32655/I2S/main.c
@@ -74,7 +74,7 @@ int main()
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
 
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX32655/I2S_Playback/main.c
+++ b/Examples/MAX32655/I2S_Playback/main.c
@@ -83,7 +83,7 @@ int i2s_init(void)
 {
     int err = E_NO_ERROR;
 
-    i2s_req.wordSize = MXC_I2S_DATASIZE_HALFWORD; // Configure I2S interface parameters
+    i2s_req.wordSize = MXC_I2S_WSIZE_HALFWORD; // Configure I2S interface parameters
     i2s_req.sampleSize = MXC_I2S_SAMPLESIZE_SIXTEEN;
     i2s_req.justify = MXC_I2S_LSB_JUSTIFY;
     i2s_req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX32662/I2S/main.c
+++ b/Examples/MAX32662/I2S/main.c
@@ -74,7 +74,7 @@ int main()
 
     req.channelMode = MXC_I2S_INTERNAL_SCK_WS_0; // Set I2S configurations
     req.stereoMode = MXC_I2S_STEREO;
-    req.wordSize = MXC_I2S_DATASIZE_HALFWORD;
+    req.wordSize = MXC_I2S_WSIZE_HALFWORD;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.bitOrder = MXC_I2S_MSB_FIRST;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX32670/I2S/main.c
+++ b/Examples/MAX32670/I2S/main.c
@@ -81,7 +81,7 @@ int main()
     printf("(JP4) in case no data is moving in and out of SDO/SDI.\n");
     printf("\n\n\n\n");
 
-    req.wordSize = MXC_I2S_DATASIZE_HALFWORD;
+    req.wordSize = MXC_I2S_WSIZE_HALFWORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_SIXTEEN;
     req.justify = MXC_I2S_LSB_JUSTIFY;
     req.channelMode = MXC_I2S_INTERNAL_SCK_WS_0;

--- a/Examples/MAX32672/I2S/main.c
+++ b/Examples/MAX32672/I2S/main.c
@@ -92,7 +92,7 @@ int main()
     Console_Shutdown();
 
     // Initialize I2S
-    req.wordSize = MXC_I2S_DATASIZE_HALFWORD;
+    req.wordSize = MXC_I2S_WSIZE_HALFWORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_SIXTEEN;
     req.justify = MXC_I2S_LSB_JUSTIFY;
     req.channelMode = MXC_I2S_INTERNAL_SCK_WS_0;

--- a/Examples/MAX32675/I2S/main.c
+++ b/Examples/MAX32675/I2S/main.c
@@ -81,7 +81,7 @@ int main()
     printf("(JP6) in case no data is moving in and out of SDO/SDI.\n");
     printf("\n\n\n\n");
 
-    req.wordSize = MXC_I2S_DATASIZE_HALFWORD;
+    req.wordSize = MXC_I2S_WSIZE_HALFWORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_SIXTEEN;
     req.justify = MXC_I2S_LSB_JUSTIFY;
     req.channelMode = MXC_I2S_INTERNAL_SCK_WS_0;

--- a/Examples/MAX32680/I2S/main.c
+++ b/Examples/MAX32680/I2S/main.c
@@ -80,7 +80,7 @@ int main()
     printf("I2S Signals may be viewed on pins P1.2-P1.5.\n");
     printf("\n\n\n\n");
 
-    req.wordSize = MXC_I2S_DATASIZE_HALFWORD;
+    req.wordSize = MXC_I2S_WSIZE_HALFWORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_SIXTEEN;
     req.justify = MXC_I2S_LSB_JUSTIFY;
     req.channelMode = MXC_I2S_INTERNAL_SCK_WS_0;

--- a/Examples/MAX32690/I2S/main.c
+++ b/Examples/MAX32690/I2S/main.c
@@ -80,7 +80,7 @@ int main()
     printf("\nI2S Transmission Example\n");
     printf("I2S Signals may be viewed on pins P2.26-P2.29.\n");
 
-    req.wordSize = MXC_I2S_DATASIZE_HALFWORD;
+    req.wordSize = MXC_I2S_WSIZE_HALFWORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_SIXTEEN;
     req.justify = MXC_I2S_LSB_JUSTIFY;
     req.channelMode = MXC_I2S_INTERNAL_SCK_WS_0;

--- a/Examples/MAX78000/CNN/kws20_demo-riscv/main_riscv.c
+++ b/Examples/MAX78000/CNN/kws20_demo-riscv/main_riscv.c
@@ -475,7 +475,7 @@ void I2SInit()
     /* Initialize I2S RX buffer */
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX78000/CNN/kws20_demo/main.c
+++ b/Examples/MAX78000/CNN/kws20_demo/main.c
@@ -909,7 +909,7 @@ void I2SInit()
     /* Initialize I2S RX buffer */
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX78000/CNN/snake_game_demo/main.c
+++ b/Examples/MAX78000/CNN/snake_game_demo/main.c
@@ -601,7 +601,7 @@ void I2SInit()
     /* Initialize I2S RX buffer */
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX78000/I2S/main.c
+++ b/Examples/MAX78000/I2S/main.c
@@ -98,7 +98,7 @@ int main()
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
 
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX78000/I2S_DMA/main.c
+++ b/Examples/MAX78000/I2S_DMA/main.c
@@ -106,7 +106,7 @@ int main()
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
 
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX78000/I2S_DMA_Target/main.c
+++ b/Examples/MAX78000/I2S_DMA_Target/main.c
@@ -168,7 +168,7 @@ void i2s_init(void)
 #define I2S_CRUFT_PTR (void *)UINT32_MAX
 #define I2S_CRUFT_LEN UINT32_MAX
 
-    req.wordSize = MXC_I2S_DATASIZE_HALFWORD;
+    req.wordSize = MXC_I2S_WSIZE_HALFWORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_SIXTEEN;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX78002/CNN/kws20_demo/main.c
+++ b/Examples/MAX78002/CNN/kws20_demo/main.c
@@ -785,7 +785,7 @@ void I2SInit()
     /* Initialize I2S RX buffer */
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX78002/I2S/main.c
+++ b/Examples/MAX78002/I2S/main.c
@@ -76,7 +76,7 @@ int main()
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
 
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Examples/MAX78002/I2S_DMA/main.c
+++ b/Examples/MAX78002/I2S_DMA/main.c
@@ -88,7 +88,7 @@ int main()
     memset(i2s_rx_buffer, 0, sizeof(i2s_rx_buffer));
 
     /* Configure I2S interface parameters */
-    req.wordSize = MXC_I2S_DATASIZE_WORD;
+    req.wordSize = MXC_I2S_WSIZE_WORD;
     req.sampleSize = MXC_I2S_SAMPLESIZE_THIRTYTWO;
     req.justify = MXC_I2S_MSB_JUSTIFY;
     req.wsPolarity = MXC_I2S_POL_NORMAL;

--- a/Libraries/PeriphDrivers/Include/MAX32655/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/i2s.h
@@ -63,11 +63,18 @@ typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 /** @brief I2S polarity configuration */
 typedef enum { MXC_I2S_CLKSRC_ERFO, MXC_I2S_CLKSRC_EXT } mxc_i2s_clksrc_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Include/MAX32655/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32655/i2s.h
@@ -86,6 +86,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -94,7 +102,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -134,6 +167,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   This function enables and selects the source clock for I2S master mode. By default

--- a/Libraries/PeriphDrivers/Include/MAX32662/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/i2s.h
@@ -83,6 +83,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -91,7 +99,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -131,6 +164,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   Enable TX channel

--- a/Libraries/PeriphDrivers/Include/MAX32662/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/i2s.h
@@ -60,11 +60,18 @@ typedef enum { MXC_I2S_MSB_FIRST, MXC_I2S_LSB_FIRST } mxc_i2s_bitorder_t;
 /** @brief I2S transaction justify order */
 typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Include/MAX32670/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/i2s.h
@@ -83,6 +83,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -91,7 +99,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -131,6 +164,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   Enable TX channel

--- a/Libraries/PeriphDrivers/Include/MAX32670/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32670/i2s.h
@@ -60,11 +60,18 @@ typedef enum { MXC_I2S_MSB_FIRST, MXC_I2S_LSB_FIRST } mxc_i2s_bitorder_t;
 /** @brief I2S transaction justify order */
 typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Include/MAX32672/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/i2s.h
@@ -83,6 +83,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -91,7 +99,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -131,6 +164,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   Enable TX channel

--- a/Libraries/PeriphDrivers/Include/MAX32672/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32672/i2s.h
@@ -60,11 +60,18 @@ typedef enum { MXC_I2S_MSB_FIRST, MXC_I2S_LSB_FIRST } mxc_i2s_bitorder_t;
 /** @brief I2S transaction justify order */
 typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Include/MAX32675/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/i2s.h
@@ -83,6 +83,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -91,7 +99,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -131,6 +164,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   Enable TX channel

--- a/Libraries/PeriphDrivers/Include/MAX32675/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32675/i2s.h
@@ -60,11 +60,18 @@ typedef enum { MXC_I2S_MSB_FIRST, MXC_I2S_LSB_FIRST } mxc_i2s_bitorder_t;
 /** @brief I2S transaction justify order */
 typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Include/MAX32680/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/i2s.h
@@ -83,6 +83,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -91,7 +99,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -131,6 +164,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   Enable TX channel

--- a/Libraries/PeriphDrivers/Include/MAX32680/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32680/i2s.h
@@ -60,11 +60,18 @@ typedef enum { MXC_I2S_MSB_FIRST, MXC_I2S_LSB_FIRST } mxc_i2s_bitorder_t;
 /** @brief I2S transaction justify order */
 typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Include/MAX32690/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/i2s.h
@@ -83,6 +83,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -91,7 +99,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -131,6 +164,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   Enable TX channel

--- a/Libraries/PeriphDrivers/Include/MAX32690/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX32690/i2s.h
@@ -60,11 +60,18 @@ typedef enum { MXC_I2S_MSB_FIRST, MXC_I2S_LSB_FIRST } mxc_i2s_bitorder_t;
 /** @brief I2S transaction justify order */
 typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Include/MAX78000/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/i2s.h
@@ -83,6 +83,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -91,7 +99,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -131,6 +164,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   Enable TX channel

--- a/Libraries/PeriphDrivers/Include/MAX78000/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX78000/i2s.h
@@ -60,11 +60,18 @@ typedef enum { MXC_I2S_MSB_FIRST, MXC_I2S_LSB_FIRST } mxc_i2s_bitorder_t;
 /** @brief I2S transaction justify order */
 typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Include/MAX78002/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/i2s.h
@@ -83,6 +83,14 @@ typedef enum {
     MXC_I2S_SAMPLESIZE_THIRTYTWO,
 } mxc_i2s_samplesize_t;
 
+/** @brief  I2S transaction adjust position.
+ * 
+ * This field is used to determine which bits are used if the sample size is less than the bits per word.*/
+typedef enum {
+    MXC_I2S_ADJUST_LEFT,
+    MXC_I2S_ADJUST_RIGHT,
+} mxc_i2s_adjust_t;
+
 /** @brief  I2S channel mode */
 typedef enum {
     MXC_I2S_INTERNAL_SCK_WS_0,
@@ -91,7 +99,32 @@ typedef enum {
     MXC_I2S_EXTERNAL_SCK_EXTERNAL_WS,
 } mxc_i2s_ch_mode_t;
 
-/** @brief I2S Configuration Struct */
+/** @brief I2S Extended Configuration Struct 
+ * 
+ * Provides manual access to I2S channel configuration. */
+typedef struct {
+    mxc_i2s_wsize_t wordSize;
+    mxc_i2s_justify_t justify;
+    mxc_i2s_bitorder_t bitOrder;
+    mxc_i2s_adjust_t adjust;
+    uint8_t bitsWord; ///< Zero based field. Set it to <desired_value - 1>. MAX=0x1F.
+    uint8_t sampleSize; ///< Between zero and bitsWord. Consider setting 'adjust' field with this.
+} mxc_i2s_ext_config_t;
+
+/** @brief I2S Configuration Struct 
+ * 
+ * Only available for following 'most common' configurations. For other configurations, please see \ref mxc_i2s_ext_config_t.
+ *  _______________________________________________________________________
+ * |    Audio     |            sampleSize         |        wordSize        |
+ * | Sample Width |   \ref mxc_i2s_samplesize_t   |  \ref mxc_i2s_wsize_t  |
+ * |-----------------------------------------------------------------------|
+ * |       8 bits |      MXC_I2S_SAMPLESIZE_EIGHT |     MXC_I2S_WSIZE_BYTE |
+ * |      16 bits |    MXC_I2S_SAMPLESIZE_SIXTEEN | MXC_I2S_WSIZE_HALFWORD |
+ * |      20 bits |     MXC_I2S_SAMPLESIZE_TWENTY |     MXC_I2S_WSIZE_WORD |
+ * |      24 bits | MXC_I2S_SAMPLESIZE_TWENTYFOUR |     MXC_I2S_WSIZE_WORD |
+ * |      32 bits |  MXC_I2S_SAMPLESIZE_THIRTYTWO |     MXC_I2S_WSIZE_WORD |
+ * |______________|_______________________________|________________________|
+*/
 typedef struct {
     mxc_i2s_ch_mode_t channelMode;
     mxc_i2s_stereo_t stereoMode;
@@ -131,6 +164,14 @@ int MXC_I2S_Shutdown(void);
  * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
  */
 int MXC_I2S_ConfigData(mxc_i2s_req_t *req);
+
+/**
+ * @brief   Manually set all I2S data configurations. Overwrites all values included in cfg.
+ * 
+ * @param   cfg           see \ref mxc_i2s_ext_config_t I2S Extended Data Configuration struct.
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.   
+ */
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg);
 
 /**
  * @brief   Enable TX channel

--- a/Libraries/PeriphDrivers/Include/MAX78002/i2s.h
+++ b/Libraries/PeriphDrivers/Include/MAX78002/i2s.h
@@ -60,11 +60,18 @@ typedef enum { MXC_I2S_MSB_FIRST, MXC_I2S_LSB_FIRST } mxc_i2s_bitorder_t;
 /** @brief I2S transaction justify order */
 typedef enum { MXC_I2S_MSB_JUSTIFY, MXC_I2S_LSB_JUSTIFY } mxc_i2s_justify_t;
 
-/** @brief  I2S transaction word size */
+/** @brief I2S transaction word size.
+ *
+ * Set this field to the desired width for data writes and reads from the FIFO. */
 typedef enum {
-    MXC_I2S_DATASIZE_BYTE,
-    MXC_I2S_DATASIZE_HALFWORD,
-    MXC_I2S_DATASIZE_WORD
+    MXC_I2S_WSIZE_BYTE, ///< Set 8-bit FIFO transactions
+    MXC_I2S_WSIZE_HALFWORD, ///< Set 16-bit FIFO transactions
+    MXC_I2S_WSIZE_WORD, ///< Set 32-bit FIFO transactions
+
+    MXC_I2S_DATASIZE_BYTE = MXC_I2S_WSIZE_BYTE, ///< Legacy name.  Use MXC_I2S_WSIZE_BYTE instead.
+    MXC_I2S_DATASIZE_HALFWORD =
+        MXC_I2S_WSIZE_HALFWORD, ///< Legacy name.  Use MXC_I2S_WSIZE_HALFWORD instead.
+    MXC_I2S_DATASIZE_WORD = MXC_I2S_WSIZE_WORD, ///< Legacy name.  Use MXC_I2S_WSIZE_WORD instead.
 } mxc_i2s_wsize_t;
 
 /** @brief  I2S transaction sample size */

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_ai85.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_ai85.c
@@ -62,6 +62,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData((mxc_i2s_reva_regs_t *)MXC_I2S, req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 void MXC_I2S_TXEnable(void)
 {
     MXC_I2S_RevA_TXEnable((mxc_i2s_reva_regs_t *)MXC_I2S);

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_ai87.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_ai87.c
@@ -62,6 +62,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData((mxc_i2s_reva_regs_t *)MXC_I2S, req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 void MXC_I2S_TXEnable(void)
 {
     MXC_I2S_RevA_TXEnable((mxc_i2s_reva_regs_t *)MXC_I2S);

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_me12.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_me12.c
@@ -64,6 +64,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData((mxc_i2s_reva_regs_t *)MXC_I2S, req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 void MXC_I2S_TXEnable()
 {
     MXC_I2S_RevA_TXEnable((mxc_i2s_reva_regs_t *)MXC_I2S);

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_me15.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_me15.c
@@ -58,6 +58,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData((mxc_i2s_reva_regs_t *)MXC_I2S, req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 void MXC_I2S_TXEnable(void)
 {
     MXC_I2S_RevA_TXEnable((mxc_i2s_reva_regs_t *)MXC_I2S);

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_me16.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_me16.c
@@ -58,6 +58,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData(req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 void MXC_I2S_TXEnable(void)
 {
     MXC_I2S_RevA_TXEnable();

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_me17.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_me17.c
@@ -68,6 +68,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData((mxc_i2s_reva_regs_t *)MXC_I2S, req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 int MXC_I2S_SelectClockSource(mxc_i2s_clksrc_t clk_src, uint32_t freq_ext)
 {
     // Check for bad parameters

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_me18.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_me18.c
@@ -68,6 +68,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData((mxc_i2s_reva_regs_t *)MXC_I2S, req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 void MXC_I2S_TXEnable()
 {
     MXC_I2S_RevA_TXEnable((mxc_i2s_reva_regs_t *)MXC_I2S);

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_me20.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_me20.c
@@ -65,6 +65,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData((mxc_i2s_reva_regs_t *)MXC_I2S, req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 void MXC_I2S_TXEnable()
 {
     MXC_I2S_RevA_TXEnable((mxc_i2s_reva_regs_t *)MXC_I2S);

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_me21.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_me21.c
@@ -58,6 +58,11 @@ int MXC_I2S_ConfigData(mxc_i2s_req_t *req)
     return MXC_I2S_RevA_ConfigData((mxc_i2s_reva_regs_t *)MXC_I2S, req);
 }
 
+int MXC_I2S_ConfigExtendedData(mxc_i2s_ext_config_t *cfg)
+{
+    return MXC_I2S_RevA_ConfigExtendedData((mxc_i2s_reva_regs_t *)MXC_I2S, cfg);
+}
+
 void MXC_I2S_TXEnable(void)
 {
     MXC_I2S_RevA_TXEnable((mxc_i2s_reva_regs_t *)MXC_I2S);

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_reva.c
@@ -56,6 +56,20 @@ static mxc_i2s_req_t txn_req;
 static mxc_i2s_reva_txn_t txn_state;
 static uint32_t txn_lock = 0;
 
+static void configure_data_sizes(mxc_i2s_reva_regs_t *i2s, uint8_t bits_word, uint8_t smp_sz,
+                                 uint8_t wsize)
+{
+    i2s->ctrl1ch0 |= (bits_word << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
+
+    //Set sample length if defined:
+    //The SMP_SIZE is equal to bitsWord when sampleSize == 0 or sampleSize > bitsWord
+    i2s->ctrl1ch0 |= (smp_sz << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS);
+
+    //Set datasize to load in FIFO
+    MXC_SETFIELD(i2s->ctrl0ch0, MXC_F_I2S_REVA_CTRL0CH0_WSIZE,
+                 wsize << MXC_F_I2S_REVA_CTRL0CH0_WSIZE_POS);
+}
+
 /* ****** Functions ****** */
 int MXC_I2S_RevA_Init(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
 {
@@ -136,23 +150,8 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
 
     switch (req->sampleSize) {
     case MXC_I2S_SAMPLESIZE_EIGHT:
-        if (req->wordSize == MXC_I2S_DATASIZE_WORD) {
-            //Set word length
-            i2s->ctrl1ch0 |= (DATALENGTH_THIRTYTWO << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
-        } else if (req->wordSize == MXC_I2S_DATASIZE_HALFWORD) {
-            //Set word length
-            i2s->ctrl1ch0 |= (DATALENGTH_SIXTEEN << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
-        } else {
-            //Set word length
-            i2s->ctrl1ch0 |= (DATALENGTH_EIGHT << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
-        }
 
-        //Set sample length
-        i2s->ctrl1ch0 |= (DATALENGTH_EIGHT << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS);
-
-        //Set datasize to load in FIFO
-        MXC_SETFIELD(i2s->ctrl0ch0, MXC_F_I2S_REVA_CTRL0CH0_WSIZE,
-                     (MXC_I2S_DATASIZE_BYTE) << MXC_F_I2S_REVA_CTRL0CH0_WSIZE_POS);
+        configure_data_sizes(i2c, DATALENGTH_EIGHT, 0, MXC_I2S_WSIZE_BYTE);
 
         dataMask = 0x000000ff;
 
@@ -165,20 +164,8 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
         break;
 
     case MXC_I2S_SAMPLESIZE_SIXTEEN:
-        if (req->wordSize == MXC_I2S_DATASIZE_WORD) {
-            //Set word length
-            i2s->ctrl1ch0 |= (DATALENGTH_THIRTYTWO << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
-        } else {
-            //Set word length
-            i2s->ctrl1ch0 |= (DATALENGTH_SIXTEEN << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
-        }
 
-        //Set sample length
-        i2s->ctrl1ch0 |= (DATALENGTH_SIXTEEN << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS);
-
-        //Set datasize
-        MXC_SETFIELD(i2s->ctrl0ch0, MXC_F_I2S_REVA_CTRL0CH0_WSIZE,
-                     (MXC_I2S_DATASIZE_HALFWORD) << MXC_F_I2S_REVA_CTRL0CH0_WSIZE_POS);
+        configure_data_sizes(i2c, DATALENGTH_SIXTEEN, 0, MXC_I2S_WSIZE_HALFWORD);
 
         dataMask = 0x0000ffff;
 
@@ -191,15 +178,8 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
         break;
 
     case MXC_I2S_SAMPLESIZE_TWENTY:
-        //Set word length
-        i2s->ctrl1ch0 |= (DATALENGTH_THIRTYTWO << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
 
-        //Set sample length
-        i2s->ctrl1ch0 |= (DATALENGTH_TWENTY << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS);
-
-        //Set datasize
-        MXC_SETFIELD(i2s->ctrl0ch0, MXC_F_I2S_REVA_CTRL0CH0_WSIZE,
-                     (MXC_I2S_DATASIZE_WORD) << MXC_F_I2S_REVA_CTRL0CH0_WSIZE_POS);
+        configure_data_sizes(i2c, DATALENGTH_TWENTY, 0, MXC_I2S_WSIZE_WORD);
 
         dataMask = 0x00fffff;
 
@@ -212,15 +192,8 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
         break;
 
     case MXC_I2S_SAMPLESIZE_TWENTYFOUR:
-        //Set word length
-        i2s->ctrl1ch0 |= (DATALENGTH_THIRTYTWO << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
 
-        //Set sample length
-        i2s->ctrl1ch0 |= (DATALENGTH_TWENTYFOUR << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS);
-
-        //Set datasize
-        MXC_SETFIELD(i2s->ctrl0ch0, MXC_F_I2S_REVA_CTRL0CH0_WSIZE,
-                     (MXC_I2S_DATASIZE_WORD) << MXC_F_I2S_REVA_CTRL0CH0_WSIZE_POS);
+        configure_data_sizes(i2c, DATALENGTH_TWENTYFOUR, 0, MXC_I2S_WSIZE_WORD);
 
         dataMask = 0x00ffffff;
 
@@ -233,15 +206,8 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
         break;
 
     case MXC_I2S_SAMPLESIZE_THIRTYTWO:
-        //Set word length
-        i2s->ctrl1ch0 |= (DATALENGTH_THIRTYTWO << MXC_F_I2S_REVA_CTRL1CH0_BITS_WORD_POS);
 
-        //Set sample length
-        i2s->ctrl1ch0 |= (DATALENGTH_THIRTYTWO << MXC_F_I2S_REVA_CTRL1CH0_SMP_SIZE_POS);
-
-        //Set datasize
-        MXC_SETFIELD(i2s->ctrl0ch0, MXC_F_I2S_REVA_CTRL0CH0_WSIZE,
-                     (MXC_I2S_DATASIZE_WORD) << MXC_F_I2S_REVA_CTRL0CH0_WSIZE_POS);
+        configure_data_sizes(i2c, DATALENGTH_THIRTYTWO, 0, MXC_I2S_WSIZE_WORD);
 
         dataMask = 0xffffffff;
 
@@ -337,13 +303,13 @@ int MXC_I2S_RevA_GetSampleRate(mxc_i2s_reva_regs_t *i2s, uint32_t src_clk)
               MXC_F_I2S_REVA_CTRL1CH0_CLKDIV_POS; // Get clock divider value
 
     switch (word_sz) { // Get word size
-    case MXC_I2S_DATASIZE_BYTE:
+    case MXC_I2S_WSIZE_BYTE:
         word_sz = 8;
         break;
-    case MXC_I2S_DATASIZE_HALFWORD:
+    case MXC_I2S_WSIZE_HALFWORD:
         word_sz = 16;
         break;
-    case MXC_I2S_DATASIZE_WORD:
+    case MXC_I2S_WSIZE_WORD:
     default:
         word_sz = 32;
         break;
@@ -358,29 +324,30 @@ int MXC_I2S_RevA_GetSampleRate(mxc_i2s_reva_regs_t *i2s, uint32_t src_clk)
 int MXC_I2S_RevA_CalculateClockDiv(mxc_i2s_reva_regs_t *i2s, uint32_t smpl_rate,
                                    mxc_i2s_wsize_t smpl_sz, uint32_t src_clk)
 {
-    uint32_t bclk;
+    uint32_t bclk = 0;
+    uint32_t word_size = 0;
 
     switch (smpl_sz) { // Get word size
-    case MXC_I2S_DATASIZE_BYTE:
-        bclk = 8;
+    case MXC_I2S_WSIZE_BYTE:
+        word_size = 8;
         break;
-    case MXC_I2S_DATASIZE_HALFWORD:
-        bclk = 16;
+    case MXC_I2S_WSIZE_HALFWORD:
+        word_size = 16;
         break;
-    case MXC_I2S_DATASIZE_WORD:
-        bclk = 32;
+    case MXC_I2S_WSIZE_WORD:
+        word_size = 32;
         break;
     default:
         return E_BAD_PARAM;
     }
 
-    bclk *= smpl_rate * 4; // bclk_frequency = sample_rate * word_size * 2
+    bclk = smpl_rate * word_size * 2; // bclk_frequency = sample_rate * word_size * 2
 
     if (bclk > src_clk) {
         return E_INVALID;
     }
 
-    return (src_clk / bclk) - 1; // clk_divider = src_clk_frequency / (bclk_frequency * 2) - 1
+    return (src_clk / (bclk * 2)) - 1; // clk_divider = src_clk_frequency / (bclk_frequency * 2) - 1
 }
 
 void MXC_I2S_RevA_Flush(mxc_i2s_reva_regs_t *i2s)
@@ -394,17 +361,17 @@ static uint32_t write_tx_fifo(void *tx, mxc_i2s_wsize_t wordSize, int smpl_cnt)
 {
     uint32_t write_val = 0;
 
-    if (wordSize == MXC_I2S_DATASIZE_BYTE) {
+    if (wordSize == MXC_I2S_WSIZE_BYTE) {
         uint8_t *tx8 = (uint8_t *)tx;
         for (int i = 0; i < 4; i++) {
             write_val |= (tx8[smpl_cnt++] << (i * 8));
         }
-    } else if (wordSize == MXC_I2S_DATASIZE_HALFWORD) {
+    } else if (wordSize == MXC_I2S_WSIZE_HALFWORD) {
         uint16_t *tx16 = (uint16_t *)tx;
         for (int i = 0; i < 2; i++) {
             write_val |= (tx16[smpl_cnt++] << (i * 16));
         }
-    } else if (wordSize == MXC_I2S_DATASIZE_WORD) {
+    } else if (wordSize == MXC_I2S_WSIZE_WORD) {
         uint32_t *tx32 = (uint32_t *)tx;
         write_val = tx32[smpl_cnt];
     }
@@ -421,7 +388,7 @@ int MXC_I2S_RevA_FillTXFIFO(mxc_i2s_reva_regs_t *i2s, void *txData, mxc_i2s_wsiz
 
     if (txData == NULL) { // Check for bad parameters
         return E_NULL_PTR;
-    } else if (wordSize < MXC_I2S_DATASIZE_BYTE || wordSize > MXC_I2S_DATASIZE_WORD) {
+    } else if (wordSize < MXC_I2S_WSIZE_BYTE || wordSize > MXC_I2S_WSIZE_WORD) {
         return E_BAD_PARAM;
     } else if (len == 0) {
         return E_NO_ERROR;
@@ -445,19 +412,19 @@ static void read_rx_fifo(mxc_i2s_reva_regs_t *i2s, void *rxData, mxc_i2s_wsize_t
 {
     uint32_t fifo_val = i2s->fifoch0;
 
-    if (wordSize == MXC_I2S_DATASIZE_BYTE) {
+    if (wordSize == MXC_I2S_WSIZE_BYTE) {
         uint8_t *rx8 = (uint8_t *)rxData;
         for (int i = 0; i < 4; i++) {
             rx8[cnt++] = fifo_val & 0xFF;
             fifo_val = fifo_val >> 8;
         }
-    } else if (wordSize == MXC_I2S_DATASIZE_HALFWORD) {
+    } else if (wordSize == MXC_I2S_WSIZE_HALFWORD) {
         uint16_t *rx16 = (uint16_t *)rxData;
         for (int i = 0; i < 2; i++) {
             rx16[cnt++] = fifo_val & 0xFFFF;
             fifo_val = fifo_val >> 16;
         }
-    } else if (wordSize == MXC_I2S_DATASIZE_WORD) {
+    } else if (wordSize == MXC_I2S_WSIZE_WORD) {
         uint32_t *rx32 = (uint32_t *)rxData;
         rx32[cnt] = fifo_val;
     }
@@ -472,7 +439,7 @@ int MXC_I2S_RevA_ReadRXFIFO(mxc_i2s_reva_regs_t *i2s, void *rxData, mxc_i2s_wsiz
 
     if (rxData == NULL) { // Check for bad parameters
         return E_NULL_PTR;
-    } else if (wordSize < MXC_I2S_DATASIZE_BYTE || wordSize > MXC_I2S_DATASIZE_WORD) {
+    } else if (wordSize < MXC_I2S_WSIZE_BYTE || wordSize > MXC_I2S_WSIZE_WORD) {
         return E_BAD_PARAM;
     } else if (len == 0) {
         return E_NO_ERROR;
@@ -657,19 +624,19 @@ int MXC_I2S_RevA_TXDMAConfig(mxc_i2s_reva_regs_t *i2s, void *src_addr, int len)
     config.ch = channel;
 
     switch (request->wordSize) {
-    case MXC_I2S_DATASIZE_WORD:
+    case MXC_I2S_WSIZE_WORD:
         config.srcwd = MXC_DMA_WIDTH_WORD;
         config.dstwd = MXC_DMA_WIDTH_WORD;
         advConfig.burst_size = 4;
         break;
 
-    case MXC_I2S_DATASIZE_HALFWORD:
+    case MXC_I2S_WSIZE_HALFWORD:
         config.srcwd = MXC_DMA_WIDTH_HALFWORD;
         config.dstwd = MXC_DMA_WIDTH_WORD;
         advConfig.burst_size = 2;
         break;
 
-    case MXC_I2S_DATASIZE_BYTE:
+    case MXC_I2S_WSIZE_BYTE:
         config.srcwd = MXC_DMA_WIDTH_BYTE;
         config.dstwd = MXC_DMA_WIDTH_WORD;
         advConfig.burst_size = 1;
@@ -734,19 +701,19 @@ int MXC_I2S_RevA_RXDMAConfig(mxc_i2s_reva_regs_t *i2s, void *dest_addr, int len)
     config.ch = channel;
 
     switch (request->wordSize) {
-    case MXC_I2S_DATASIZE_WORD:
+    case MXC_I2S_WSIZE_WORD:
         config.srcwd = MXC_DMA_WIDTH_WORD;
         config.dstwd = MXC_DMA_WIDTH_WORD;
         advConfig.burst_size = 4;
         break;
 
-    case MXC_I2S_DATASIZE_HALFWORD:
+    case MXC_I2S_WSIZE_HALFWORD:
         config.srcwd = MXC_DMA_WIDTH_WORD;
         config.dstwd = MXC_DMA_WIDTH_HALFWORD;
         advConfig.burst_size = 2;
         break;
 
-    case MXC_I2S_DATASIZE_BYTE:
+    case MXC_I2S_WSIZE_BYTE:
         config.srcwd = MXC_DMA_WIDTH_WORD;
         config.dstwd = MXC_DMA_WIDTH_BYTE;
         advConfig.burst_size = 1;

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_reva.c
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_reva.c
@@ -151,7 +151,7 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
     switch (req->sampleSize) {
     case MXC_I2S_SAMPLESIZE_EIGHT:
 
-        configure_data_sizes(i2c, DATALENGTH_EIGHT, 0, MXC_I2S_WSIZE_BYTE);
+        configure_data_sizes(i2s, DATALENGTH_EIGHT, 0, MXC_I2S_WSIZE_BYTE);
 
         dataMask = 0x000000ff;
 
@@ -165,7 +165,7 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
 
     case MXC_I2S_SAMPLESIZE_SIXTEEN:
 
-        configure_data_sizes(i2c, DATALENGTH_SIXTEEN, 0, MXC_I2S_WSIZE_HALFWORD);
+        configure_data_sizes(i2s, DATALENGTH_SIXTEEN, 0, MXC_I2S_WSIZE_HALFWORD);
 
         dataMask = 0x0000ffff;
 
@@ -179,7 +179,7 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
 
     case MXC_I2S_SAMPLESIZE_TWENTY:
 
-        configure_data_sizes(i2c, DATALENGTH_TWENTY, 0, MXC_I2S_WSIZE_WORD);
+        configure_data_sizes(i2s, DATALENGTH_TWENTY, 0, MXC_I2S_WSIZE_WORD);
 
         dataMask = 0x00fffff;
 
@@ -193,7 +193,7 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
 
     case MXC_I2S_SAMPLESIZE_TWENTYFOUR:
 
-        configure_data_sizes(i2c, DATALENGTH_TWENTYFOUR, 0, MXC_I2S_WSIZE_WORD);
+        configure_data_sizes(i2s, DATALENGTH_TWENTYFOUR, 0, MXC_I2S_WSIZE_WORD);
 
         dataMask = 0x00ffffff;
 
@@ -207,7 +207,7 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
 
     case MXC_I2S_SAMPLESIZE_THIRTYTWO:
 
-        configure_data_sizes(i2c, DATALENGTH_THIRTYTWO, 0, MXC_I2S_WSIZE_WORD);
+        configure_data_sizes(i2s, DATALENGTH_THIRTYTWO, 0, MXC_I2S_WSIZE_WORD);
 
         dataMask = 0xffffffff;
 
@@ -225,6 +225,25 @@ int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req)
     }
 
     return E_NO_ERROR;
+}
+
+int MXC_I2S_RevA_ConfigExtendedData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_ext_config_t *cfg)
+{
+    int retval = E_NO_ERROR;
+
+    i2s->ctrl1ch0 &= ~MXC_F_I2S_REVA_CTRL1CH0_EN;
+
+    MXC_SETFIELD(i2s->ctrl0ch0, MXC_F_I2S_REVA_CTRL0CH0_ALIGN,
+                 (cfg->justify) << MXC_F_I2S_REVA_CTRL0CH0_ALIGN_POS);
+
+    configure_data_sizes(i2s, cfg->bitsWord, cfg->sampleSize, cfg->wordSize);
+
+    MXC_SETFIELD(i2s->ctrl1ch0, MXC_F_I2S_REVA_CTRL1CH0_ADJUST,
+                 (cfg->adjust) << MXC_F_I2S_REVA_CTRL1CH0_ADJUST_POS);
+
+    i2s->ctrl1ch0 |= MXC_F_I2S_REVA_CTRL1CH0_EN;
+
+    return retval;
 }
 
 void MXC_I2S_RevA_TXEnable(mxc_i2s_reva_regs_t *i2s)

--- a/Libraries/PeriphDrivers/Source/I2S/i2s_reva.h
+++ b/Libraries/PeriphDrivers/Source/I2S/i2s_reva.h
@@ -36,6 +36,8 @@ int MXC_I2S_RevA_Shutdown(mxc_i2s_reva_regs_t *i2s);
 
 int MXC_I2S_RevA_ConfigData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_req_t *req);
 
+int MXC_I2S_RevA_ConfigExtendedData(mxc_i2s_reva_regs_t *i2s, mxc_i2s_ext_config_t *cfg);
+
 void MXC_I2S_RevA_TXEnable(mxc_i2s_reva_regs_t *i2s);
 
 void MXC_I2S_RevA_TXDisable(mxc_i2s_reva_regs_t *i2s);


### PR DESCRIPTION
### Description

After discussions and careful considerations, I decided to create another PR for #MSDK-1232. This description is a clone of #847.

Fix I2S Peripheral Driver for mixed usage of sample_size and bits_word registers. As described in the related Jira tickets, there was a confused usage for the word size and bits_word.

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/75470772/e83537a0-d276-4056-adcd-19d1a314efc9)

![image](https://github.com/Analog-Devices-MSDK/msdk/assets/75470772/902c24dd-fb62-4c4d-80d2-692393fa8f14)


I updated all I2S examples to use new changes and made them buildable. I am going to open a new PR for examples after my changes are approved.