### PR TITLE
fix(PeriphDrivers): MSDK-1245: Re-order VSSEL selection to avoid possible damages on pads

### DIFF
--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai85.c
@@ -110,6 +110,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     if (cfg->port == MXC_GPIO3) {
         switch (cfg->func) {
         case MXC_GPIO_FUNC_IN:
@@ -192,12 +198,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         default:
             return E_BAD_PARAM;
         }
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_ai87.c
@@ -110,6 +110,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     if (cfg->port == MXC_GPIO3) {
         switch (cfg->func) {
         case MXC_GPIO_FUNC_IN:
@@ -192,12 +198,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         default:
             return E_BAD_PARAM;
         }
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_es17.c
@@ -75,6 +75,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
 
@@ -115,12 +121,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     default:
         return E_BAD_PARAM;
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me10.c
@@ -102,6 +102,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int err;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    // Configure the vssel
+    err = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (err != E_NO_ERROR) {
+        return err;
+    }
+
     // Set the GPIO type
     if ((err = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask)) !=
         E_NO_ERROR) {
@@ -137,12 +143,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         break;
     default:
         return E_BAD_PARAM;
-    }
-
-    // Configure the vssel
-    err = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (err != E_NO_ERROR) {
-        return err;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me11.c
@@ -63,6 +63,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     // Set the GPIO type
     switch (cfg->func) {
     case MXC_GPIO_FUNC_IN:
@@ -119,12 +125,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     default:
         return E_BAD_PARAM;
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me12.c
@@ -70,6 +70,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     port = MXC_GPIO_GET_IDX(cfg->port);
     MXC_GPIO_Init(1 << port);
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
 
@@ -110,12 +116,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     default:
         return E_BAD_PARAM;
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me13.c
@@ -99,6 +99,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
 
@@ -139,12 +145,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     default:
         return E_BAD_PARAM;
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me14.c
@@ -79,6 +79,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
 
@@ -121,8 +127,7 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         return E_BAD_PARAM;
     }
 
-    // Configure the vssel
-    return MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    return E_NO_ERROR;
 }
 
 /* ************************************************************************** */

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me17.c
@@ -110,6 +110,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     MXC_GPIO_Init(1 << port);
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     if (cfg->port == MXC_GPIO3) {
         switch (cfg->func) {
         case MXC_GPIO_FUNC_IN:
@@ -192,12 +198,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         default:
             return E_BAD_PARAM;
         }
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me18.c
@@ -139,6 +139,14 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     // Initialize callback function pointers
     MXC_GPIO_Init(1 << port);
 
+    // Configure the vssel
+    if (port < 4) {
+        error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+        if (error != E_NO_ERROR) {
+            return error;
+        }
+    }
+
     // Configure alternate function
     if (port < 4) {
         error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
@@ -234,14 +242,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
         default:
             return E_BAD_PARAM;
-        }
-    }
-
-    // Configure the vssel
-    if (port < 4) {
-        error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-        if (error != E_NO_ERROR) {
-            return error;
         }
     }
 

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me20.c
@@ -143,6 +143,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
         MXC_GPIO_Init(1 << port);
     }
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
 
@@ -183,12 +189,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     default:
         return E_BAD_PARAM;
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength

--- a/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
+++ b/Libraries/PeriphDrivers/Source/GPIO/gpio_me55.c
@@ -77,6 +77,12 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
     int error;
     mxc_gpio_regs_t *gpio = cfg->port;
 
+    // Configure the vssel
+    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
+    if (error != E_NO_ERROR) {
+        return error;
+    }
+
     // Configure alternate function
     error = MXC_GPIO_RevA_SetAF((mxc_gpio_reva_regs_t *)gpio, cfg->func, cfg->mask);
 
@@ -117,12 +123,6 @@ int MXC_GPIO_Config(const mxc_gpio_cfg_t *cfg)
 
     default:
         return E_BAD_PARAM;
-    }
-
-    // Configure the vssel
-    error = MXC_GPIO_SetVSSEL(gpio, cfg->vssel, cfg->mask);
-    if (error != E_NO_ERROR) {
-        return error;
     }
 
     // Configure the drive strength


### PR DESCRIPTION
### Description

Voltage Rail selection should be made before padding configuration. A hesitation came from Clayton:

> For the MXC_GPIO_Config function, the last thing done is to select the voltage rail (gpio_me18.c). This creates a situation where damage to the part can occur. The GPIO on parts with multiple rails defaults to VDDIO (1.8V) with pullup/pulldown disabled. If a customer has 3.0V on a GPIO pin (say I2C pullups), and the code turns on the pullup before selecting the VDDIOH rail, the 3.0V back powers VDDIO, potentially causing damage to the pads.