### PR TITLE
chore(PeriphDrivers): Define I2C Speeds for MAX32662

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32662/i2c.h
+++ b/Libraries/PeriphDrivers/Include/MAX32662/i2c.h
@@ -44,6 +44,12 @@ extern "C" {
  * @{
  */
 
+/***** Definitions *****/
+#define MXC_I2C_STD_MODE 100000
+#define MXC_I2C_FAST_SPEED 400000
+#define MXC_I2C_FASTPLUS_SPEED 1000000
+#define MXC_I2C_HIGH_SPEED 3400000
+
 typedef struct _i2c_req_t mxc_i2c_req_t;
 /**
  * @brief   The callback used by the MXC_I2C_ReadByteInteractive() function.


### PR DESCRIPTION
### Description

Most of MAX32 MCUs supports 4 different I2C speeds and these speeds defined in 'i2c.h' file of MCU. But these definitions missed for MAX32662.
The purpose of this commit is adding these definitions for MAX32662 to provide common interface for I2C speed.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.