### PR TITLE
fix(CMSIS,PeriphDrivers): Fix logic error in SYS Clock Enable/Disable functions and INRO frequency for MAX32662

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/MAX32662/Include/system_max32662.h
+++ b/Libraries/CMSIS/Device/Maxim/MAX32662/Include/system_max32662.h
@@ -57,7 +57,7 @@ extern "C" {
          Update if use of this oscillator requires precise timing.*/
 /* NOTE: INRO was previously named NANORING */
 #ifndef INRO_FREQ
-#define INRO_FREQ 8000
+#define INRO_FREQ 80000
 #endif
 
 #ifndef IPO_FREQ

--- a/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
+++ b/Libraries/PeriphDrivers/Source/SYS/sys_me12.c
@@ -150,12 +150,12 @@ int MXC_SYS_IsClockEnabled(mxc_sys_periph_clock_t clock)
 /* ************************************************************************** */
 void MXC_SYS_ClockDisable(mxc_sys_periph_clock_t clock)
 {
-    if (clock > 31) {
-        clock -= 32;
-        MXC_GCR->pclkdis1 |= (0x1 << clock);
-    } else if (clock > 63) {
+    if (clock > 63) {
         clock -= 64;
         MXC_MCR->pclkdis |= (0x1 << clock);
+    } else if (clock > 31) {
+        clock -= 32;
+        MXC_GCR->pclkdis1 |= (0x1 << clock);
     } else {
         MXC_GCR->pclkdis0 |= (0x1 << clock);
     }
@@ -164,12 +164,12 @@ void MXC_SYS_ClockDisable(mxc_sys_periph_clock_t clock)
 /* ************************************************************************** */
 void MXC_SYS_ClockEnable(mxc_sys_periph_clock_t clock)
 {
-    if (clock > 31) {
-        clock -= 32;
-        MXC_GCR->pclkdis1 &= ~(0x1 << clock);
-    } else if (clock > 63) {
+    if (clock > 63) {
         clock -= 64;
         MXC_MCR->pclkdis &= ~(0x1 << clock);
+    } else if (clock > 31) {
+        clock -= 32;
+        MXC_GCR->pclkdis1 &= ~(0x1 << clock);
     } else {
         MXC_GCR->pclkdis0 &= ~(0x1 << clock);
     }


### PR DESCRIPTION
1) INRO/NANORING clock is 80kHz according to the UG. But, it was defined as 8kHz in system_max32662.h. See page 36 -> https://www.analog.com/media/en/technical-documentation/user-guides/max32662-ug-7640.pdf 
![image](https://github.com/Analog-Devices-MSDK/msdk/assets/134288264/21bef1b9-57f1-4978-b961-746281cdc340)

2) Logic error exists related to if controls in MXC_SYS_ClockDisable and MXC_SYS_ClockEnable functions. See sys_me12.c


