### PR TITLE
fix(Tools): Remove MAX32572 guard for generating SCP packets in SBT build rules

### DIFF
--- a/Tools/SBT/SBT-rules.mk
+++ b/Tools/SBT/SBT-rules.mk
@@ -14,9 +14,7 @@ sla: all
 	@echo " "
 	arm-none-eabi-objcopy  $(BUILD_DIR)/$(PROJECT).elf --update-section .sig=$(BUILD_DIR)/$(PROJECT).sig
 	@echo " "
-	@if [ "$(TARGET_SEC)" != "MAX32572" ]; then \
-		$(BUILD_SESSION) -c $(TARGET_SEC) key_file=$(TEST_KEY) ${SCP_PACKETS} $(BUILD_DIR)/$(PROJECT).sbin ;\
-	fi
+	$(BUILD_SESSION) -c $(TARGET_SEC) key_file=$(TEST_KEY) ${SCP_PACKETS} $(BUILD_DIR)/$(PROJECT).sbin
 
 # The SCPA target.
 # "make scpa" is a special rule for SCPA applet programs, which are


### PR DESCRIPTION
### Description

Forgot to remove the MAX32572 guard in the SBT rules when the linkers were fixed last week.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.