### PR TITLE
fix(Boards): Remove TFT Lib include from board with no TFT

### DIFF
--- a/Libraries/Boards/MAX32690/WLP_V1/Source/board.c
+++ b/Libraries/Boards/MAX32690/WLP_V1/Source/board.c
@@ -31,7 +31,6 @@
 #include "mxc_sys.h"
 #include "pb.h"
 #include "spixf.h"
-#include "tft_st7735.h"
 #include "uart.h"
 
 /***** Global Variables *****/


### PR DESCRIPTION
### Description

Removed TFT include from WLP_V1 for the MAX32690, a board with no TFT.