### PR TITLE
feat(Build): Add Compiler Flag for Checking Target Micro

### DIFF
--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc.mk
@@ -266,6 +266,13 @@ ifneq "$(TARGET)" ""
 CFLAGS+=-DTARGET=$(TARGET)
 endif
 
+ifneq "$(TARGET_UC)" ""
+# Define a flag that the pre-processor can actually work with
+# (i.e. #ifdef MAX78000 ...)
+# TARGET_UC typically comes from the project core Makefile
+CFLAGS += -D$(TARGET_UC)
+endif
+
 ifneq "$(TARGET_REV)" ""
 CFLAGS+=-DTARGET_REV=$(TARGET_REV)
 endif

--- a/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
+++ b/Libraries/CMSIS/Device/Maxim/GCC/gcc_riscv.mk
@@ -264,6 +264,13 @@ ifneq "$(TARGET)" ""
 CFLAGS+=-DTARGET=$(TARGET)
 endif
 
+ifneq "$(TARGET_UC)" ""
+# Define a flag that the pre-processor can actually work with
+# (i.e. #ifdef MAX78000 ...)
+# TARGET_UC typically comes from the project core Makefile
+CFLAGS += -D$(TARGET_UC)
+endif
+
 ifneq "$(TARGET_REV)" ""
 CFLAGS+=-DTARGET_REV=$(TARGET_REV)
 endif


### PR DESCRIPTION
### Description

Previous builds defined `TARGET=MAXxxxxx`, but the pre-processor can't do string comparisons.  This PR defines `MAXxxxxx` to enable checks like

```C
#ifdef MAX32665
...
#endif
```

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.