### PR TITLE
chore(Boards,PeriphDrivers): Add Olimex selection, treat UART3 as other UARTs, and fix BCB build errors for MAX32572

### DIFF
--- a/Libraries/Boards/MAX32572/BCB/board.mk
+++ b/Libraries/Boards/MAX32572/BCB/board.mk
@@ -27,14 +27,11 @@ endif
 SRCS += board.c
 SRCS += stdio.c
 SRCS += led.c
-SRCS += is25.c
+SRCS += w25.c
 SRCS += pb.c
-SRCS += tsc2007.c
-SRCS += tft_ssd2119.c
 
 PROJ_CFLAGS+=-DSPIXF_RAM
-PROJ_CFLAGS+=-DEXT_FLASH_IS25
-PROJ_CFLAGS+=-DTS_TSC2007
+PROJ_CFLAGS+=-DEXT_FLASH_W25
 
 MISC_DRIVERS_DIR ?= $(MAXIM_PATH)/Libraries/MiscDrivers
 
@@ -44,8 +41,6 @@ VPATH += $(MISC_DRIVERS_DIR)
 VPATH += $(MISC_DRIVERS_DIR)/LED
 VPATH += $(MISC_DRIVERS_DIR)/PushButton
 VPATH += $(MISC_DRIVERS_DIR)/ExtMemory
-VPATH += $(MISC_DRIVERS_DIR)/Display
-VPATH += $(MISC_DRIVERS_DIR)/Touchscreen
 
 # Where to find BSP header files
 IPATH += $(BOARD_DIR)/Include
@@ -53,5 +48,3 @@ IPATH += $(MISC_DRIVERS_DIR)
 IPATH += $(MISC_DRIVERS_DIR)/LED
 IPATH += $(MISC_DRIVERS_DIR)/PushButton
 IPATH += $(MISC_DRIVERS_DIR)/ExtMemory
-IPATH += $(MISC_DRIVERS_DIR)/Display
-IPATH += $(MISC_DRIVERS_DIR)/Touchscreen

--- a/Libraries/Boards/MAX32572/BCB/board.mk
+++ b/Libraries/Boards/MAX32572/BCB/board.mk
@@ -27,9 +27,16 @@ endif
 SRCS += board.c
 SRCS += stdio.c
 SRCS += led.c
+SRCS += is25.c
 SRCS += pb.c
+SRCS += tsc2007.c
+SRCS += tft_ssd2119.c
 
-MISC_DRIVERS_DIR ?= $(LIBS_DIR)/MiscDrivers
+PROJ_CFLAGS+=-DSPIXF_RAM
+PROJ_CFLAGS+=-DEXT_FLASH_IS25
+PROJ_CFLAGS+=-DTS_TSC2007
+
+MISC_DRIVERS_DIR ?= $(MAXIM_PATH)/Libraries/MiscDrivers
 
 # Where to find BSP source files
 VPATH += $(BOARD_DIR)/Source
@@ -37,6 +44,8 @@ VPATH += $(MISC_DRIVERS_DIR)
 VPATH += $(MISC_DRIVERS_DIR)/LED
 VPATH += $(MISC_DRIVERS_DIR)/PushButton
 VPATH += $(MISC_DRIVERS_DIR)/ExtMemory
+VPATH += $(MISC_DRIVERS_DIR)/Display
+VPATH += $(MISC_DRIVERS_DIR)/Touchscreen
 
 # Where to find BSP header files
 IPATH += $(BOARD_DIR)/Include
@@ -44,3 +53,5 @@ IPATH += $(MISC_DRIVERS_DIR)
 IPATH += $(MISC_DRIVERS_DIR)/LED
 IPATH += $(MISC_DRIVERS_DIR)/PushButton
 IPATH += $(MISC_DRIVERS_DIR)/ExtMemory
+IPATH += $(MISC_DRIVERS_DIR)/Display
+IPATH += $(MISC_DRIVERS_DIR)/Touchscreen

--- a/Libraries/Boards/MAX32572/EvKit_V1/adapters.txt
+++ b/Libraries/Boards/MAX32572/EvKit_V1/adapters.txt
@@ -1,2 +1,6 @@
 CMSIS-DAP, interface/cmsis-dap.cfg
 MAX32625_PICO, interface/cmsis-dap.cfg
+OLIMEX-ARM-USB-OCD-H, interface/ftdi/olimex-arm-usb-ocd-h.cfg
+OLIMEX-ARM-USB-OCD-H SWD, interface/ftdi/olimex-arm-usb-ocd-h.cfg -f interface/ftdi/olimex-arm-jtag-swd.cfg
+OLIMEX-ARM-USB-TINY-H, interface/ftdi/olimex-arm-usb-tiny-h.cfg
+OLIMEX-ARM-USB-TINY-H SWD, interface/ftdi/olimex-arm-usb-tiny-h.cfg -f interface/ftdi/olimex-arm-jtag-swd.cfg

--- a/Libraries/PeriphDrivers/Source/UART/uart_me55.c
+++ b/Libraries/PeriphDrivers/Source/UART/uart_me55.c
@@ -131,59 +131,12 @@ int MXC_UART_ReadyForSleep(mxc_uart_regs_t *uart)
 int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clock_t clock)
 {
     int freq;
-    int mod = 0;
-    int clkdiv = 0;
 
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    // check if the uart is LPUART
-    if (uart == MXC_UART3) {
-        // OSR default value
-        uart->osr = 5;
-
-        switch (clock) {
-        case MXC_UART_APB_CLK:
-            clkdiv = ((IBRO_FREQ) / baud);
-            mod = ((IBRO_FREQ) % baud);
-            break;
-
-        case MXC_UART_EXT_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK;
-            break;
-
-        case MXC_UART_ERTCO_CLK:
-            uart->ctrl |= MXC_S_UART_CTRL_BCLKSRC_CLK2;
-            uart->ctrl |= MXC_F_UART_CTRL_FDM;
-            if (baud == 9600) {
-                clkdiv = 7;
-                mod = 0;
-            } else {
-                clkdiv = ((ERTCO_FREQ * 2) / baud);
-                mod = ((ERTCO_FREQ * 2) % baud);
-            }
-
-            if (baud > 2400) {
-                uart->osr = 0;
-            } else {
-                uart->osr = 1;
-            }
-            break;
-
-        default:
-            return E_BAD_PARAM;
-        }
-
-        if (!clkdiv || mod > (baud / 2)) {
-            clkdiv++;
-        }
-        uart->clkdiv = clkdiv;
-
-        freq = MXC_UART_GetFrequency(uart);
-    } else {
-        freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
-    }
+    freq = MXC_UART_RevB_SetFrequency((mxc_uart_revb_regs_t *)uart, baud, clock);
 
     if (freq > 0) {
         // Enable baud clock and wait for it to become ready.
@@ -196,30 +149,11 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
 
 int MXC_UART_GetFrequency(mxc_uart_regs_t *uart)
 {
-    int periphClock = 0;
-
     if (MXC_UART_GET_IDX(uart) < 0) {
         return E_BAD_PARAM;
     }
 
-    // check if UARt is LP UART
-    if (uart == MXC_UART3) {
-        if ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) == MXC_S_UART_CTRL_BCLKSRC_EXTERNAL_CLOCK) {
-            return E_NOT_SUPPORTED;
-        } else if ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) ==
-                   MXC_S_UART_CTRL_BCLKSRC_PERIPHERAL_CLOCK) {
-            periphClock = IBRO_FREQ;
-        } else if ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) == MXC_S_UART_CTRL_BCLKSRC_CLK2) {
-            periphClock = ERTCO_FREQ * 2;
-        } else if ((uart->ctrl & MXC_F_UART_CTRL_BCLKSRC) == MXC_S_UART_CTRL_BCLKSRC_CLK3) {
-            periphClock = INRO_FREQ * 2;
-        } else {
-            return E_BAD_PARAM;
-        }
-        return (periphClock / uart->clkdiv);
-    } else {
-        return MXC_UART_RevB_GetFrequency((mxc_uart_revb_regs_t *)uart);
-    }
+    return MXC_UART_RevB_GetFrequency((mxc_uart_revb_regs_t *)uart);
 }
 
 int MXC_UART_SetDataSize(mxc_uart_regs_t *uart, int dataSize)


### PR DESCRIPTION
### Description

Some fixes that were discovered for ME55 since release.

1. UART3 was treated as a special LP UART case for `MXC_UART_SetFrequency(...)` and `MXC_UART_GetFrequency(...)`, when all UARTs are the same type for ME55.
2. BCB had some build errors since last syncup.
3. Add Olimex selection to ME55 EVKIT adapters.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.