### PR TITLE
fix(Examples, Boards): Fix Max32670 RTC example, update MAX32655 board example list

### DIFF
--- a/Examples/MAX32670/RTC/README.md
+++ b/Examples/MAX32670/RTC/README.md
@@ -1,11 +1,12 @@
 ## Description
+## Description
 
 This example demonstrates the use of the Real Time Clock (RTC) and its alarm functionality.
 
 The RTC is enabled and the sub-second alarm set to trigger every 250 ms.
 (LED0) is toggled each time the sub-second alarm triggers.  The time-of-day alarm is set to 10 seconds.  When the time-of-day alarm triggers, the rate of the sub-second alarm is switched to 500 ms.
 
-(LED1) is toggled each time the time-of-day alarm triggers. The time-of-day alarm is then rearmed for another 10 sec.  Pressing SW2 will output the current value of the RTC to the console UART.
+(LED1) is toggled each time the time-of-day alarm triggers. The time-of-day alarm is then rearmed for another 10 sec.  Pressing SW3 will output the current value of the RTC to the console UART.
 
 
 ## Software
@@ -39,7 +40,7 @@ triggers, the rate of the sub-second alarm is switched to 500 ms.
 
 (LED1) is toggled each time the time-of-day alarm triggers.
 
-The time-of-day alarm is then rearmed for another 10 sec.  Pressing SW1
+The time-of-day alarm is then rearmed for another 10 sec.  Pressing SW3
 will output the current value of the RTC to the console UART.
 
 RTC started

--- a/Examples/MAX32670/RTC/main.c
+++ b/Examples/MAX32670/RTC/main.c
@@ -156,7 +156,7 @@ int main(void)
     printf("triggers, the rate of the sub-second alarm is switched to %d ms.\n\n",
            SUBSECOND_MSEC_1);
     printf("(LED1) is toggled each time the time-of-day alarm triggers.\n\n");
-    printf("The time-of-day alarm is then rearmed for another %d sec.  Pressing SW1\n",
+    printf("The time-of-day alarm is then rearmed for another %d sec.  Pressing SW3\n",
            TIME_OF_DAY_SEC);
     printf("will output the current value of the RTC to the console UART.\n\n");
 

--- a/Libraries/Boards/MAX32655/EvKit_V1/examples.txt
+++ b/Libraries/Boards/MAX32655/EvKit_V1/examples.txt
@@ -42,6 +42,7 @@ GPIO
 Hello_World
 Hello_World-riscv
 I2C
+I2C_EEPROM
 I2C_MNGR
 I2C_SCAN
 I2C_Sensor


### PR DESCRIPTION
The incorrect switch name in the MAX32670 RTC example has been corrected.
The example list under the MAX32655-EvKit_V1 board has been updated so that the I2C_EEPROM example appears in the project creation wizard.